### PR TITLE
Add a basic TrackThing both_links

### DIFF
--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -94,6 +94,14 @@ module Admin::LinkHelper
               title: admin_title)
   end
 
+  def track_thing_both_links(track_thing)
+    title = 'View track'
+    icon = eye
+    icon_link = search_general_path(track_thing.track_query)
+
+    link_to(icon, icon_link, title: title) + ' ' + "#{track_thing.id}:"
+  end
+
   def admin_title
     'View full details'
   end

--- a/app/views/admin_track/_some_tracks.html.erb
+++ b/app/views/admin_track/_some_tracks.html.erb
@@ -11,7 +11,9 @@
       <div class="accordion-group">
         <div class="accordion-heading">
           <a href="#track_<%=track_thing.id%>" data-toggle="collapse" data-parent="requests"><%= chevron_right %></a>
-          <%=track_thing.id%>:
+
+          <%= both_links(track_thing) %>
+
           <% if track_thing.public_body_id %>
             <%= link_to "<code>#{h track_thing.track_query}</code>".html_safe, public_body_path(track_thing.public_body) %>
           <% elsif track_thing.info_request_id %>

--- a/spec/helpers/admin/link_helper_spec.rb
+++ b/spec/helpers/admin/link_helper_spec.rb
@@ -96,5 +96,27 @@ RSpec.describe Admin::LinkHelper do
       it { is_expected.to include(record.url) }
       it { is_expected.to include(edit_admin_blog_post_path(record)) }
     end
+
+    context 'with a TrackThing' do
+      context 'tracking a search' do
+        let(:record) { FactoryBot.create(:search_track) }
+
+        it { is_expected.to include('icon-eye-open') }
+        it { is_expected.to include("#{record.id}:") }
+        it { is_expected.to include(search_general_path(record.track_query)) }
+      end
+
+      context 'tracking a trackable record' do
+        let(:record) { FactoryBot.create(:request_update_track) }
+        let(:url_title) { record.info_request.url_title }
+
+        it { is_expected.to include('icon-eye-open') }
+        it { is_expected.to include("#{record.id}:") }
+
+        it do
+          is_expected.to include(search_general_path("request:#{url_title}"))
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
We render Tracks in the admin interface but they don't have an "eye" next to them as per other records. This commit adds a basic implementation which just links to the search query of the track.

The current view code in `admin_track/_some_tracks` does some more complex handling, where the "title" of the track links directly to a trackable record if the track has one associated, or falls back to the plain text search query.

We could later move this behaviour to the eye, and then link to an admin page for the track via the search term (in line with other records) when we have an admin page.

The main intent of this commit is just to get the eye in place, such that we can improve the behaviour at a later date.

![Screenshot 2023-10-16 at 18 00 41](https://github.com/mysociety/alaveteli/assets/282788/a9ed91d5-30e4-4cdd-9774-304dc57e031b)

![Screenshot 2023-10-16 at 18 00 51](https://github.com/mysociety/alaveteli/assets/282788/f3ec3867-0257-4ff0-bf75-12c125c917ba)

👁️
