### PR TITLE
[#6402] Warning notes on request preview

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -259,6 +259,7 @@ Layout/LineLength:
     - "^\\s*context\\s+.*do$"
     - "^\\s*describe\\s+.*do$"
     - "^RSpec\\.describe(\\s+|\\().*do$"
+    - "^RSpec\\.shared_examples(\\s+|\\().*do.*$"
     - "^\\s*class\\s+[A-Z].*<.*"
   Exclude:
     - bin/setup

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -252,6 +252,8 @@ class RequestController < ApplicationController
       return
     end
 
+    @outgoing_message.update_taggable_terms
+
     # Show preview page, if it is a preview
     return render_new_preview if params[:preview].to_i == 1
 

--- a/app/models/concerns/taggable_terms.rb
+++ b/app/models/concerns/taggable_terms.rb
@@ -1,0 +1,38 @@
+module TaggableTerms
+  extend ActiveSupport::Concern
+
+  included do
+    cattr_accessor :taggable_terms, default: {}
+    before_save :update_taggable_terms, if: :taggable_term_attribute_changed?
+  end
+
+  def update_taggable_terms
+    taggable_terms.each do |attr, terms_tags|
+      terms_tags.each do |term, tag|
+        if attribute_matches_taggable_term?(attr, term)
+          add_tag_if_not_already_present(tag.to_s)
+        else
+          unless tag_applied_via_other_taggable_term?(tag, attr)
+            remove_tag(tag.to_s)
+          end
+        end
+      end
+    end
+  end
+
+  private
+
+  def taggable_term_attribute_changed?
+    changed.include?(taggable_terms.keys)
+  end
+
+  def attribute_matches_taggable_term?(attr, term)
+    read_attribute(attr) =~ Regexp.new(term)
+  end
+
+  def tag_applied_via_other_taggable_term?(tag, attr)
+    taggable_terms[attr].
+      select { |_, other_tag| other_tag == tag }.
+      any? { |term, _| attribute_matches_taggable_term?(attr, term) }
+  end
+end

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -29,7 +29,9 @@ class OutgoingMessage < ApplicationRecord
   include MessageProminence
   include Rails.application.routes.url_helpers
   include LinkToHelper
+  include Notable
   include Taggable
+  include TaggableTerms
 
   STATUS_TYPES = %w(ready sent failed).freeze
   MESSAGE_TYPES = %w(initial_request followup).freeze

--- a/app/views/request/preview.html.erb
+++ b/app/views/request/preview.html.erb
@@ -10,6 +10,8 @@
 
   <div class="message-preview">
     <div class="preview-advice">
+      <%= render_notes(@outgoing_message.all_notes) %>
+
       <div class="advice-panel">
         <ul>
           <li><%= _('Check you haven\'t included any <strong>personal information</strong>.') %></li>

--- a/spec/models/concerns/taggable_terms.rb
+++ b/spec/models/concerns/taggable_terms.rb
@@ -1,0 +1,33 @@
+RSpec.shared_examples 'concerns/taggable_terms' do |*factory_opts, attr_under_test|
+  let(:record) { FactoryBot.build(*factory_opts) }
+
+  let(:terms_tags) do
+    { /train/i => 'trains',
+      /bus/i => 'bus',
+      /locomotive/i => 'trains',
+      /bike/ => 'bicycles' }
+  end
+
+  before do
+    record.taggable_terms = { attr_under_test => terms_tags }
+  end
+
+  describe '#update_taggable_terms' do
+    subject { record.update_taggable_terms }
+    before { subject }
+
+    it 'applies a tag when a term matches' do
+      expect(record).to be_tagged('bus')
+    end
+
+    it 'does not apply a tag when there is no match for a term' do
+      expect(record).not_to be_tagged('bicycles')
+    end
+
+    it 'applies a tag when one term term matches but a later term with the same tag does not' do
+      # i.e. keep "trains" because it matched /train/, so don't remove it
+      # because it didn't match /locomotive/
+      expect(record).to be_tagged('trains')
+    end
+  end
+end

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -21,10 +21,14 @@
 require 'spec_helper'
 require 'models/concerns/message_prominence'
 require 'models/concerns/taggable'
+require 'models/concerns/taggable_terms'
 
 RSpec.describe OutgoingMessage do
   it_behaves_like 'concerns/message_prominence', :initial_request
   it_behaves_like 'concerns/taggable', :initial_request
+  it_behaves_like 'concerns/taggable_terms',
+                  :initial_request, { body: 'Some trains and a bus.' },
+                  :body
 
   describe '.is_searchable' do
     subject { described_class.is_searchable }


### PR DESCRIPTION
## Relevant issue(s)

A version of #6402

## What does this do?

Show tag-based notes on new request preview if the message content matches a configured term.

## Why was this needed?

Allow us to detect terms in messages and warn users before they go on to submit their request

## Implementation notes

Could use [on_change](https://github.com/ronna-s/on_change) to update the tags after any update to an attribute, rather than only doing so before saving.

## Screenshots

![Screenshot 2023-10-18 at 09 55 46](https://github.com/mysociety/alaveteli/assets/282788/e9cbfe2a-fb79-4b43-8e71-137e4d08a22a)

![Screenshot 2023-10-18 at 09 56 15](https://github.com/mysociety/alaveteli/assets/282788/b1f21062-33de-406f-8924-50ae2c303748)

## Notes to reviewer

`remove_tag(tag.to_s) unless tag_applied_via_other_taggable_term?(tag, attr)` seems like it could get quite computationally expensive. Might be a nicer way of doing this part.
