### PR TITLE
Add MailerHelper#case_reference

### DIFF
--- a/app/helpers/mailer_helper.rb
+++ b/app/helpers/mailer_helper.rb
@@ -1,4 +1,23 @@
 module MailerHelper
+  # Generate a case reference number to differentiate subject lines and/or
+  # include in the body of emails.
+  #
+  # prefix - A String prefix to identify the general case type
+  #          (default: 'CASE').
+  #
+  # Examples:
+  #
+  #    case_reference
+  #    # => "CASE/20231020-DF1I"
+  #
+  #    case_reference('HELP')
+  #    # => "HELP/20231020-QK3C"
+  #
+  # Returns a String case reference ID.
+  def case_reference(prefix = 'CASE')
+    "#{prefix}/#{Time.now.strftime('%Y%m%d')}-#{SecureRandom.base36(4).upcase}"
+  end
+
   def contact_from_name_and_email
     "#{AlaveteliConfiguration.contact_name} <#{AlaveteliConfiguration.contact_email}>"
   end

--- a/spec/helpers/mailer_helper_spec.rb
+++ b/spec/helpers/mailer_helper_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe MailerHelper do
+  include MailerHelper
+
+  describe '#case_reference' do
+    context 'with the default prefix' do
+      subject { case_reference }
+      it { is_expected.to match(/CASE\/\d{8}-[A-Z0-9]{4}/) }
+    end
+
+    context 'with a custom prefix' do
+      subject { case_reference('HELP') }
+      it { is_expected.to match(/HELP\/\d{8}-[A-Z0-9]{4}/) }
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Generic implementation to help with https://github.com/mysociety/whatdotheyknow-theme/issues/1774

## What does this do?

A generic case reference ID generator for use in email Subject lines to prevent incorrect threading by mail clients, and/or to use in the Body for end user ease of reference.
