### PR TITLE
Update AttachmentMaskController referer handling

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -36,7 +36,7 @@ class AttachmentsController < ApplicationController
   rescue Timeout::Error
     redirect_to wait_for_attachment_mask_path(
       @attachment.to_signed_global_id,
-      referer: request.fullpath
+      referer: verifier.generate(request.fullpath)
     )
   end
 
@@ -223,5 +223,9 @@ class AttachmentsController < ApplicationController
 
   def with_prominence
     @info_request
+  end
+
+  def verifier
+    Rails.application.message_verifier('AttachmentsController')
   end
 end

--- a/app/views/attachment_masks/done.html.erb
+++ b/app/views/attachment_masks/done.html.erb
@@ -7,5 +7,5 @@
 </p>
 
 <p>
-  <%= link_to _('Download attachment'), @show_attachment_path, class: 'button' %>
+  <%= link_to _('Download attachment'), @referer, class: 'button' %>
 </p>

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -138,9 +138,21 @@ RSpec.describe AttachmentsController, type: :controller do
         it 'redirects to wait for attachment mask route' do
           allow_any_instance_of(FoiAttachment).to receive(:to_signed_global_id).
             and_return('ABC')
+
+          verifier = double('ActiveSupport::MessageVerifier')
+          allow(controller).to receive(:verifier).and_return(verifier)
+          allow(verifier).to receive(:generate).with(
+            get_attachment_path(
+              incoming_message_id: attachment.incoming_message_id,
+              id: info_request.id,
+              part: attachment.url_part_number,
+              file_name: attachment.filename
+            )
+          ).and_return('DEF')
+
           show
           expect(response).to redirect_to(
-            wait_for_attachment_mask_path('ABC', referer: request.fullpath)
+            wait_for_attachment_mask_path('ABC', referer: 'DEF')
           )
         end
       end


### PR DESCRIPTION
## Relevant issue(s)

Update AttachmentMaskController referer handling

## What does this do?

Addresses potential cross-site scripting issue identified by Brakeman.

This change uses `MessageVerifier` to encodes the referer when passing it from the `AttachmentController` to the `AttachmentMaskController`, this is needed because we don't know which route the attachment was requested from (public, share by link, project).

## Why was this needed?

We were relying on `redirect_to` raising an `UnsafeRedirectError` exception when the referer param was changes to an external link.

This works for the controller, but we also use the referer param on the `done` view. So once the attachment is available, if the param is manually changed the resulting page would have a download link which points to changed referer param.

We use temporary signed attachment IDs so the resulting URL would only be available for a short period of time so the attack vector is minimal.
