### PR TITLE
[#7977] Update `AttachmentController#show_as_html` to do attachment masking in the background

### DIFF
--- a/app/controllers/attachment_masks_controller.rb
+++ b/app/controllers/attachment_masks_controller.rb
@@ -9,6 +9,8 @@ class AttachmentMasksController < ApplicationController
 
   def wait
     if @attachment.masked?
+      redirect_to @referer and return if refered_from_show_as_html?
+
       redirect_to done_attachment_mask_path(
         id: @attachment.to_signed_global_id,
         referer: verifier.generate(@referer)
@@ -53,5 +55,9 @@ class AttachmentMasksController < ApplicationController
 
   def verifier
     Rails.application.message_verifier('AttachmentsController')
+  end
+
+  def refered_from_show_as_html?
+    @referer =~ %r(/request/\d+/response/\d+/attach/html/)
   end
 end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -16,7 +16,7 @@ class AttachmentsController < ApplicationController
   before_action :authenticate_attachment
   before_action :authenticate_attachment_as_html, only: :show_as_html
 
-  around_action :ensure_masked, only: :show
+  around_action :ensure_masked
   around_action :cache_attachments, only: :show_as_html
 
   def show

--- a/spec/controllers/attachment_masks_controller_spec.rb
+++ b/spec/controllers/attachment_masks_controller_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe AttachmentMasksController, type: :controller do
       end
     end
 
+    context 'when attachment is masked and refered from show as HTML action' do
+      it 'redirects to referer' do
+        allow(controller).to receive(:refered_from_show_as_html?).
+          and_return(true)
+        allow(attachment).to receive(:to_signed_global_id).and_return('ABC')
+        wait
+        expect(response).to redirect_to('/referer')
+      end
+    end
+
     context 'when attachment is unmasked' do
       let(:attachment) { FactoryBot.build(:body_text, :unmasked, id: 1) }
 

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -64,12 +64,17 @@ RSpec.describe 'when handling incoming mail' do
   it "generates a valid HTML verson of plain text attachments" do
     receive_incoming_mail('incoming-request-two-same-name.email',
                           email_to: info_request.incoming_email)
-    visit get_attachment_as_html_path(
+    attachment_path = get_attachment_as_html_path(
       incoming_message_id: info_request.incoming_messages.first.id,
       id: info_request.id,
       part: 2,
       file_name: 'hello world.txt.html',
       skip_cache: 1)
+
+    visit attachment_path
+    perform_enqueued_jobs
+
+    visit attachment_path
     expect(page.response_headers['Content-Type']).to eq("text/html; charset=utf-8")
     expect(page).to have_content "Second hello"
   end
@@ -77,12 +82,17 @@ RSpec.describe 'when handling incoming mail' do
   it "generates a valid HTML verson of PDF attachments" do
     receive_incoming_mail('incoming-request-pdf-attachment.email',
                           email_to: info_request.incoming_email)
-    visit get_attachment_as_html_path(
+    attachment_path = get_attachment_as_html_path(
       incoming_message_id: info_request.incoming_messages.first.id,
       id: info_request.id,
       part: 2,
       file_name: 'fs 50379341.pdf.html',
       skip_cache: 1)
+
+    visit attachment_path
+    perform_enqueued_jobs
+
+    visit attachment_path
     expect(page.response_headers['Content-Type']).to eq("text/html; charset=utf-8")
     expect(page).to have_content "Walberswick Parish Council"
   end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7977

## What does this do?

This updates `AttachmentController#show_as_html` to do attachment masking in the background.

## Why was this needed?

Our "view attachments in the browser" feature, or "view as HTML", is doing a lot of processing inline in the web processes and this sometimes causes memory issues on the server and results in oom-kill running.

## Implementation notes

Uses the same logic as the `#show` action to check an attachment is masked before proceeding with the action. This means it will time outs after 5 seconds and then redirect the `AttachmentMaskController` to wait for the job to complete before rendering a view saying the attachment is now viewable.