### PR TITLE
Add Github workflow to check for changelog entry

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,7 @@
 ## Screenshots
 
 ## Notes to reviewer
+
+<hr>
+
+Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,39 @@
+name: Changelog
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Check for [skip changelog]
+      run: |
+        PR_DESCRIPTION=$(gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --json body -q '.body')
+        if echo "$PR_DESCRIPTION" | grep -q "\[skip changelog\]"; then
+          echo "Skip changelog found in PR description. Passing the action."
+          exit 0
+        fi
+
+    - name: Check for changes in doc/CHANGES.md
+      run: |
+        git fetch origin ${{ github.event.pull_request.base.ref }}
+        FILES_CHANGED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} ${{ github.sha }})
+        if [[ "$FILES_CHANGED" == *"doc/CHANGES.md"* ]]; then
+          echo "doc/CHANGES.md has been modified. Passing the action."
+          exit 0
+        else
+          echo "doc/CHANGES.md has not been modified. Failing the action."
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/alaveteli_test
       RAILS_ENV: test
+      GH_TOKEN: ${{ github.token }}
 
     steps:
     - name: Checkout repository
@@ -51,6 +52,14 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
+
+    - name: Check for [skip ci]
+      run: |
+        PR_DESCRIPTION=$(gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --json body -q '.body')
+        if echo "$PR_DESCRIPTION" | grep -q "\[skip ci\]"; then
+          echo "Skip CI found in PR description. Passing the action."
+          exit 0
+        fi
 
     - name: Install packages
       env:


### PR DESCRIPTION
When creating PR we should update the changelog as this helps others see what is upcoming in the next release and makes release Alaveteli versions easier.

This workflow ensures an `docs/CHANGES.md` is modified or the pull request description contains `[sk ip chang elog]` <- spaces added for testing

Update the PR template to help remind devs to do this before the PR is created.

[skip ci]
