### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,7 @@
 ## Screenshots
 
 ## Notes to reviewer
+
+<hr>
+
+Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,51 @@
+name: Changelog
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Check for [skip changelog]
+      id: skip
+      run: |
+        PR_DESCRIPTION=$(gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --json body -q '.body')
+        if echo "$PR_DESCRIPTION" | grep -q "\[skip changelog\]"; then
+          echo "skip_changelog=true" >> $GITHUB_OUTPUT
+        else
+          echo "skip_changelog=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Check for changes in doc/CHANGES.md
+      id: changes
+      run: |
+        git fetch origin ${{ github.event.pull_request.base.ref }}
+        FILES_CHANGED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }} ${{ github.sha }})
+        if [[ "$FILES_CHANGED" == *"doc/CHANGES.md"* ]]; then
+          echo "changes_found=true" >> $GITHUB_OUTPUT
+        else
+          echo "changes_found=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Final Check
+      run: |
+        if [[ "${{ steps.skip.outputs.skip_changelog }}" == "true" || "${{ steps.changes.outputs.changes_found }}" == "true" ]]; then
+          echo "Either [skip changelog] was found or doc/CHANGES.md was modified. Passing the action."
+          exit 0
+        else
+          echo "Neither [skip changelog] was found nor was doc/CHANGES.md modified. Failing the action."
+          exit 1
+        fi

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Check for [skip changelog]
       id: skip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [master, develop]
   pull_request:
+    types:
+      - opened
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
   rspec:
     name: Ruby ${{ matrix.ruby }} / PostgreSQL ${{ matrix.postgres }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     needs: check
     if: needs.check.outputs.skip_rspec == 'false'
@@ -128,7 +128,7 @@ jobs:
       checks: write
     name: Coveralls
     needs: rspec
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,33 @@ permissions:
   contents: read
 
 jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    outputs:
+      skip_rspec: ${{ steps.skip.outputs.skip_rspec }}
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+    - name: Check for [skip rspec]
+      id: skip
+      run: |
+        PR_DESCRIPTION=$(gh pr view https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }} --json body -q '.body')
+        if echo "$PR_DESCRIPTION" | grep -q "\[skip rspec\]"; then
+          echo "Skip RSpec found in PR description. Passing the action."
+          echo "skip_rspec=true" >> $GITHUB_OUTPUT
+        else
+          echo "skip_rspec=false" >> $GITHUB_OUTPUT
+        fi
+
   rspec:
     name: Ruby ${{ matrix.ruby }} / PostgreSQL ${{ matrix.postgres }}
     runs-on: ubuntu-20.04
+
+    needs: check
+    if: needs.check.outputs.skip_rspec == 'false'
 
     permissions:
       checks: write # for coverallsapp/github-action to create new checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,11 +124,14 @@ jobs:
         parallel: true
 
   coveralls:
+    name: Coveralls
+    runs-on: ubuntu-latest
+
+    needs: rspec
+
     permissions:
       checks: write
-    name: Coveralls
-    needs: rspec
-    runs-on: ubuntu-latest
+
     steps:
       - name: Coveralls Finished
         uses: coverallsapp/github-action@master

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Install Ruby
       uses: ruby/setup-ruby@v1
@@ -17,7 +17,7 @@ jobs:
         ruby-version: 3.0
 
     - name: Run RuboCop linter
-      uses: reviewdog/action-rubocop@v1
+      uses: reviewdog/action-rubocop@v2
       with:
         github_token: ${{ secrets.github_token }}
         rubocop_flags: -DES

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,10 @@
 name: RuboCop
 
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
 
 permissions:
   contents: read


### PR DESCRIPTION
## What does this do?

1. Add workflow to check the changelog is updated
2. Allow changelog check to be skipped
3. Allow rspec to be skipped
4. Update the PR template to help remind devs to do this before the PR is created
5. Updates action versions (fixes depreciation and NodeJS warnings)
6. Update platform versions to `ubuntu@latest`
7. Minor YAML configuration reordering
8. Remove `pr.reopened` workflow event type from RuboCop and CI - we would probably want to rebase in this scenario.

## Why was this needed?

When creating PR we should update the changelog as this helps others see what is upcoming in the next release and makes release Alaveteli versions easier.

This workflow ensures an `docs/CHANGES.md` is modified or the pull request description contains `[skip changelog]`, I've also made sure you can edit the PR description to add this and the workflow reruns.

To skip RSpec we can now include `[skip rspec]` but unlike the above, editing the PR description won't stop/start RSpec because due to how long this workflow takes to run we don't want to stop/restart the RSpec if minor edits are made to the PR description.