### PR TITLE
[#1106] Admin view of unmasked incoming message

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -145,6 +145,15 @@ body.admin {
     display: inline;
   }
 
+  blockquote .well p {
+    font-size: 14px;
+    margin-bottom: 1em !important;
+
+    &:last-child {
+      margin-bottom: 0 !important;
+    }
+  }
+
   div#user_locale_switcher {
     div.btn-group:before,
     div.btn-group:after {

--- a/app/views/admin/foi_attachments/edit.html.erb
+++ b/app/views/admin/foi_attachments/edit.html.erb
@@ -44,3 +44,14 @@
     <%= submit_tag 'Save', class: 'btn btn-success' %>
   </div>
 <% end %>
+
+<% if @foi_attachment.main_body_part? %>
+  <hr />
+  <h2>Unmasked message body (quotes unfolded):</h2>
+
+  <blockquote>
+    <div class="well well-small">
+      <%= simple_format(@foi_attachment.unmasked_body) %>
+    </div>
+  </blockquote>
+<% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add admin view of unmasked version of main body part attachments (Gareth Rees)
 * Add internal ID number to authority CSV download (Alex Parsons, Graeme
   Porteous)
 


### PR DESCRIPTION
Admins often want to view the contents of an incoming message without any masking or censor rules applied.

In some cases you can inspect the raw email, but it's often base64 encoded, which means needing to download the email and open it in a mail client. Even when the email is not base64 encoded, it's often difficult to mentally parse the information out when there are lots of headers, attachment sections and HTML body content.

This commit adds an unmasked view of main body part attachments. This is equivalent to the main body contents of an incoming message that we show in public.

This does require "downloading" the attachment from Active Storage, but at present we use local file storage for attachments, so that's fine. Even if we moved them to S3 it wouldn't be a disaster to fetch them each time, as this isn't a frequently viewed page.

Needed to use an `!important` CSS rule to improve the visual rendering as for some reason bootstrap sets `margin-bottom: 0;` on `p` tags within a `blockquote` element (See
bootstrap-sass-2.3.2.2/vendor/assets/stylesheets/bootstrap/_type.scss).

Fixes https://github.com/mysociety/alaveteli/issues/1106.

![Screenshot 2023-11-07 at 15 52 55](https://github.com/mysociety/alaveteli/assets/282788/ddb9a75c-5dc9-433f-a0f5-511d31ade4ff)

