### PR TITLE
[#1782] Help us CTA from delivery error message

### DIFF
--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -185,10 +185,14 @@ module InfoRequestHelper
       public_body_link: public_body_link(info_request.public_body))
   end
 
-  def status_text_error_message(_info_request, _opts = {})
+  def status_text_error_message(info_request, _opts = {})
+    body = info_request.public_body
     _('There was a <strong>delivery error</strong> or similar, which ' \
-      'needs fixing by the {{site_name}} team.',
-      site_name: site_name)
+      'needs fixing by the {{site_name}} team. Can you help by ' \
+      '<a href="{{change_request_url}}">finding updated contact ' \
+      'details</a>?',
+      site_name: site_name,
+      change_request_url: new_change_request_body_path(body: body.url_name))
   end
 
   def status_text_requires_admin(_info_request, _opts = {})

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Signpost users to find new contact details for requests with delivery errors
+  (Gareth Rees)
 * Add admin view of unmasked version of main body part attachments (Gareth Rees)
 * Add internal ID number to authority CSV download (Alex Parsons, Graeme
   Porteous)

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -359,9 +359,17 @@ RSpec.describe InfoRequestHelper do
     context 'error_message' do
 
       it 'returns a description' do
-        allow(info_request).to receive(:calculate_status).and_return("error_message")
+        allow(info_request).
+          to receive(:public_body).and_return(double(url_name: 'foo'))
+
+        allow(info_request).
+          to receive(:calculate_status).and_return('error_message')
+
         expected = 'There was a <strong>delivery error</strong> or similar, ' \
-                   'which needs fixing by the Alaveteli team.'
+                   'which needs fixing by the Alaveteli team. Can you help ' \
+                   'by <a href="/change_request/new/foo">finding updated ' \
+                   'contact details</a>?'
+
         expect(status_text(info_request)).to eq(expected)
       end
 


### PR DESCRIPTION
Finding contact details can take a fair amount of work. Users are often happy to help, but the only signpost we have for this is when submitting the classification. They might not have time to source a new address there and then – and the form itself could be improved – but a reminder for them and other users viewing the requests might help distribute some of this work to the community.

Fixes https://github.com/mysociety/alaveteli/issues/1782.

**Public Request:**

![Screenshot 2023-11-08 at 20 41 37](https://github.com/mysociety/alaveteli/assets/282788/21fff458-362e-4966-a81e-282eb5c235c5)

**Private Request:**

![Screenshot 2023-11-09 at 09 53 55](https://github.com/mysociety/alaveteli/assets/282788/54e2be61-972d-4fde-85c0-21cad5378902)

