### PR TITLE
[#7971] Update attachment processing

### DIFF
--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -28,7 +28,7 @@ class FoiAttachmentMaskJob < ApplicationJob
       @attachment = attachment.load_attachment_from_incoming_message
     end
 
-    mask
+    mask if @attachment
   end
 
   private

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -113,7 +113,7 @@ class FoiAttachment < ApplicationRecord
     end
 
   rescue ActiveRecord::RecordNotFound
-    load_attachment_from_incoming_message.body
+    load_attachment_from_incoming_message!.body
   end
 
   # body as UTF-8 text, with scrubbing of invalid chars if needed
@@ -329,6 +329,14 @@ class FoiAttachment < ApplicationRecord
   end
 
   private
+
+  def load_attachment_from_incoming_message!
+    attachment = load_attachment_from_incoming_message
+    return attachment if attachment
+
+    raise MissingAttachment, "attachment couldn't be reloaded using " \
+      "url_part_number and display_filename attributes"
+  end
 
   def text_type?
     AlaveteliTextMasker::TextMask.include?(content_type)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -347,6 +347,11 @@ class IncomingMessage < ApplicationRecord
     parse_raw_email!
     main_part = get_main_body_text_part
     _convert_part_body_to_text(main_part)
+
+  rescue FoiAttachment::MissingAttachment
+    # occasionally the main body part gets rebuilt while being masked, we should
+    # be able to just retry to get the new main body part instance from the db.
+    retry
   end
 
   # Given a main text part, converts it to text

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -173,6 +173,15 @@ RSpec.describe FoiAttachment do
         )
         expect(foi_attachment.body).to eq('thisisthenewtext')
       end
+
+      it 'raises MissingAttachment exception if attachment still can not be found' do
+        allow(foi_attachment).to(
+          receive(:load_attachment_from_incoming_message).and_return(nil)
+        )
+        expect { foi_attachment.body }.to raise_error(
+          FoiAttachment::MissingAttachment
+        )
+      end
     end
 
   end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -1192,4 +1192,35 @@ RSpec.describe IncomingMessage, 'when getting the main body text' do
 
   end
 
+  context 'when main body attachment goes missing' do
+
+    let(:incoming_message) { FactoryBot.create(:incoming_message) }
+
+    before do
+      # ensure main body part can't be found and is unmasked so #unmasked_body
+      # is called
+      incoming_message.get_main_body_text_part.update(
+        filename: 'incorrect', hexdigest: 'incorrect', masked_at: nil
+      )
+
+      # stub method to find original attachment by its content
+      allow(MailHandler).to receive(
+        :attempt_to_find_original_attachment_attributes
+      ).and_return(nil)
+    end
+
+    it 'rebuilds missing attachments without erroring' do
+      expect { incoming_message.get_main_body_text_internal }.to change(
+        incoming_message, :get_main_body_text_part
+      )
+    end
+
+    it 'returns the rebuilt attachment body' do
+      expect(incoming_message.get_main_body_text_internal).to eq(
+        'hereisthetext'
+      )
+    end
+
+  end
+
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7971

## What does this do?

Update attachment processing

Handle when incoming messages are re-parsed which can cause attachments to be rebuilt when trying to render the main body part.

## Why was this needed?

Occasionally when main body attachment part will get rebuilt while the content is masked. When this happens we can see errors such as: <code>undefined method `unmasked_body' for nil:NilClass</code>.

## Implementation notes

This change ensures the masking job doesn't fail and the code will now raise an `MissingAttachment` exception instead.

Rescuing from this in `IncomingMessage#get_main_body_text_internal` allows us to retry straight away as in the second attempt the main part will be the new attachment instance and the part will be rendered.

<hr>

[skip changelog]