### PR TITLE
Add admin links to and from batch request show action

### DIFF
--- a/app/views/admin/info_request_batches/_admin_columns.html.erb
+++ b/app/views/admin/info_request_batches/_admin_columns.html.erb
@@ -1,5 +1,9 @@
 <table class="table table-striped table-condensed">
   <tbody>
+    <tr>
+      <th>Batch page:</th>
+      <td><%= link_to info_request_batch_url(info_request_batch), info_request_batch_path(info_request_batch) %></td>
+    </tr>
     <% info_request_batch.for_admin_column do |name, value| %>
       <tr>
         <td>

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -8,12 +8,23 @@
   <h1><%= @title %></h1>
 
   <% if @info_request_batch.sent? %>
-    <%= n_('Sent to one authority by {{info_request_user}} on {{date}}.',
-           'Sent to {{authority_count}} authorities by {{info_request_user}} on {{date}}.',
-           @info_request_batch.info_requests.size,
-           authority_count: @info_request_batch.info_requests.size,
-           info_request_user: user_link(@info_request_batch.user),
-           date: simple_date(@info_request_batch.sent_at)) %>
+    <% if @user && @user.admin_page_links? %>
+      <%= n_('Sent batch ({{batch_admin_link}}) to one authority by {{info_request_user}} ({{user_admin_link}}) on {{date}}.',
+             'Sent batch ({{batch_admin_link}}) to {{authority_count}} authorities by {{info_request_user}} ({{user_admin_link}}) on {{date}}.',
+             @info_request_batch.info_requests.size,
+             batch_admin_link: link_to(_('admin'), admin_info_request_batch_path(@info_request_batch)),
+             authority_count: @info_request_batch.info_requests.size,
+             info_request_user: user_link(@info_request_batch.user),
+             user_admin_link: link_to(_('admin'), admin_user_path(@info_request_batch.user)),
+             date: simple_date(@info_request_batch.sent_at)) %>
+    <% else %>
+      <%= n_('Sent to one authority by {{info_request_user}} on {{date}}.',
+             'Sent to {{authority_count}} authorities by {{info_request_user}} on {{date}}.',
+             @info_request_batch.info_requests.size,
+             authority_count: @info_request_batch.info_requests.size,
+             info_request_user: user_link(@info_request_batch.user),
+             date: simple_date(@info_request_batch.sent_at)) %>
+    <% end %>
   <% else %>
     <%= _('Created by {{info_request_user}} on {{date}}.',
           info_request_user: user_link(@info_request_batch.user),

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add admin links to and from batch request show action (Graeme Porteous)
 * Signpost key user administration contributions for requests on request list
   pages (Gareth Rees)
 * Signpost users to find new contact details for requests with delivery errors


### PR DESCRIPTION
## What does this do?

Add admin links to and from batch request show action

## Why was this needed?

For easier admin of batches.

## Screenshots

![image](https://github.com/mysociety/alaveteli/assets/5426/d32427ac-2a38-4b2d-a05f-e805f49e82dd)
![image](https://github.com/mysociety/alaveteli/assets/5426/862dba80-768d-4838-9816-884d4e4a7942)
