### PR TITLE
Improve clarity of both_links for FoiAttachment

### DIFF
--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -44,7 +44,7 @@ module Admin::LinkHelper
     info_request = foi_attachment.incoming_message.info_request
 
     link_to(icon, foi_attachment_path(foi_attachment), title: title) + ' ' +
-      link_to("#{info_request.title} #{foi_attachment.filename}",
+      link_to(foi_attachment.filename,
               edit_admin_foi_attachment_path(foi_attachment),
               title: admin_title)
   end


### PR DESCRIPTION
Prepending the info request title adds extra noise when viewing the list of an attachments for an incoming message. We lose a bit of context if rendering `both_links` for an attachment outside of its request/incoming message page, but I don't think we do that at present and it's worth the tradeoff. In a situation where we do want both, then we can add it in in that specific context.

BEFORE

![Screenshot 2023-11-14 at 11 50 08](https://github.com/mysociety/alaveteli/assets/282788/3f611738-054a-4843-86b0-57e8824eb12f)

AFTER

![Screenshot 2023-11-14 at 11 50 02](https://github.com/mysociety/alaveteli/assets/282788/550cd5c8-deb6-4bb9-8194-8c17f65258c5)


[skip changelog]
