### PR TITLE
[#8009] Update model invalidate cache callbacks

### DIFF
--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -88,7 +88,7 @@ class InfoRequestEvent < ApplicationRecord
     self.event_type = "hide"
   end
   after_create :update_request, if: :response?
-  after_create :invalidate_cached_pages
+  after_update :invalidate_cached_pages, unless: :no_xapian_reindex
 
   after_commit -> { info_request.create_or_update_request_summary },
                   on: [:create]

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -88,7 +88,7 @@ class InfoRequestEvent < ApplicationRecord
     self.event_type = "hide"
   end
   after_create :update_request, if: :response?
-  after_update :invalidate_cached_pages, unless: :no_xapian_reindex
+  after_create :invalidate_cached_pages, unless: :no_xapian_reindex
 
   after_commit -> { info_request.create_or_update_request_summary },
                   on: [:create]

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -116,7 +116,8 @@ class PublicBody < ApplicationRecord
 
   after_save :update_missing_email_tag
 
-  after_update :reindex_requested_from, :invalidate_cached_pages
+  after_update :reindex_requested_from, :invalidate_cached_pages,
+               unless: :no_xapian_reindex
 
   # Every public body except for the internal admin one is visible
   scope :visible, -> { where("public_bodies.id <> #{ PublicBody.internal_admin_body.id }") }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -181,9 +181,10 @@ class User < ApplicationRecord
   validate :email_and_name_are_valid
 
   after_initialize :set_defaults
-  after_update :reindex_referencing_models,
-               :update_pro_account,
-               :invalidate_cached_pages
+
+  after_update :update_pro_account
+  after_update :reindex_referencing_models, :invalidate_cached_pages,
+               unless: :no_xapian_reindex
 
   acts_as_xapian texts: [:name, :about_me],
                  values: [
@@ -330,7 +331,6 @@ class User < ApplicationRecord
 
   # requested_by: and commented_by: search queries also need updating after save
   def reindex_referencing_models
-    return if no_xapian_reindex == true
     return unless saved_change_to_attribute?(:url_name)
 
     expire_comments

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Improve background job performance by limiting the number `NotifyCacheJob`
+  jobs created (Graeme Porteous)
 * Signpost key user administration contributions for requests on request list
   pages (Gareth Rees)
 * Signpost users to find new contact details for requests with delivery errors


### PR DESCRIPTION

## Relevant issue(s)

Fixes #8009

## What does this do?

Update model invalidate cache callbacks.

Only run the callbacks when `no_xapian_reindex` hasn't been set.

## Why was this needed?

This will prevent excessive `NotifyCacheJob` jobs from being created overnight when `script/update_public_bodies_stats` or when user alert tracks email is sent.

## Implementation notes

Might want to consider the naming of `no_xapian_reindex`.

