### PR TITLE
Only show active users on leaderboards

### DIFF
--- a/app/controllers/request_game_controller.rb
+++ b/app/controllers/request_game_controller.rb
@@ -38,7 +38,7 @@ class RequestGameController < ApplicationController
     end
 
     @league_table_28_days = RequestClassification.league_table(10,
-      [ "created_at >= ?", Time.zone.now - 28.days ])
+      [ "request_classifications.created_at >= ?", Time.zone.now - 28.days ])
     @league_table_all_time = RequestClassification.league_table(10)
     @play_urls = true
   end

--- a/app/models/request_classification.rb
+++ b/app/models/request_classification.rb
@@ -30,7 +30,8 @@ class RequestClassification < ApplicationRecord
       group('user_id').
         order(cnt: :desc).
           limit(size).
-            includes(:user)
+            joins(:user).
+              merge(User.active)
     query = query.where(*conditions) if conditions
     query
   end

--- a/app/models/statistics/leaderboard.rb
+++ b/app/models/statistics/leaderboard.rb
@@ -4,6 +4,7 @@ module Statistics
     def all_time_requesters
       InfoRequest.is_public.
                   joins(:user).
+                  merge(User.not_banned).
                   group(:user).
                   order(count_info_requests_all: :desc).
                   limit(10).
@@ -15,6 +16,7 @@ module Statistics
       InfoRequest.is_public.
                   where('info_requests.created_at >= ?', 28.days.ago).
                   joins(:user).
+                  merge(User.not_banned).
                   group(:user).
                   order(count_info_requests_all: :desc).
                   limit(10).
@@ -24,6 +26,7 @@ module Statistics
     def all_time_commenters
       commenters = Comment.visible.
                            joins(:user).
+                           merge(User.not_banned).
                            group('comments.user_id').
                            order(count_all: :desc).
                            limit(10).
@@ -40,6 +43,7 @@ module Statistics
       commenters = Comment.visible.
                            where('comments.created_at >= ?', 28.days.ago).
                            joins(:user).
+                           merge(User.not_banned).
                            group('comments.user_id').
                            order(count_all: :desc).
                            limit(10).

--- a/app/models/statistics/leaderboard.rb
+++ b/app/models/statistics/leaderboard.rb
@@ -4,7 +4,7 @@ module Statistics
     def all_time_requesters
       InfoRequest.is_public.
                   joins(:user).
-                  merge(User.not_banned).
+                  merge(User.active).
                   group(:user).
                   order(count_info_requests_all: :desc).
                   limit(10).
@@ -16,7 +16,7 @@ module Statistics
       InfoRequest.is_public.
                   where('info_requests.created_at >= ?', 28.days.ago).
                   joins(:user).
-                  merge(User.not_banned).
+                  merge(User.active).
                   group(:user).
                   order(count_info_requests_all: :desc).
                   limit(10).
@@ -26,7 +26,7 @@ module Statistics
     def all_time_commenters
       Comment.visible.
               joins(:user).
-              merge(User.not_banned).
+              merge(User.active).
               group(:user).
               order(count_all: :desc).
               limit(10).
@@ -38,7 +38,7 @@ module Statistics
       Comment.visible.
               where('comments.created_at >= ?', 28.days.ago).
               joins(:user).
-              merge(User.not_banned).
+              merge(User.active).
               group(:user).
               order(count_all: :desc).
               limit(10).

--- a/app/models/statistics/leaderboard.rb
+++ b/app/models/statistics/leaderboard.rb
@@ -24,35 +24,25 @@ module Statistics
     end
 
     def all_time_commenters
-      commenters = Comment.visible.
-                           joins(:user).
-                           merge(User.not_banned).
-                           group('comments.user_id').
-                           order(count_all: :desc).
-                           limit(10).
-                           count
-      # TODO: Have user objects automatically instantiated like the InfoRequest
-      # queries above
-      result = {}
-      commenters.each { |user_id, count| result[User.find(user_id)] = count }
-      result
+      Comment.visible.
+              joins(:user).
+              merge(User.not_banned).
+              group(:user).
+              order(count_all: :desc).
+              limit(10).
+              count
     end
 
     def last_28_day_commenters
       # TODO: Refactor as it's basically the same as all_time_commenters
-      commenters = Comment.visible.
-                           where('comments.created_at >= ?', 28.days.ago).
-                           joins(:user).
-                           merge(User.not_banned).
-                           group('comments.user_id').
-                           order(count_all: :desc).
-                           limit(10).
-                           count
-      # TODO: Have user objects automatically instantiated like the InfoRequest
-      # queries above
-      result = {}
-      commenters.each { |user_id, count| result[User.find(user_id)] = count }
-      result
+      Comment.visible.
+              where('comments.created_at >= ?', 28.days.ago).
+              joins(:user).
+              merge(User.not_banned).
+              group(:user).
+              order(count_all: :desc).
+              limit(10).
+              count
     end
   end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -9,6 +9,8 @@
 * Add admin view of unmasked version of main body part attachments (Gareth Rees)
 * Add internal ID number to authority CSV download (Alex Parsons, Graeme
   Porteous)
+* Don't show users that have closed their account or been banned on leaderboards
+  (Chris Mytton)
 
 # 0.44.0.0
 

--- a/spec/models/request_classification_spec.rb
+++ b/spec/models/request_classification_spec.rb
@@ -19,9 +19,13 @@ RSpec.describe RequestClassification do
     before do
       @user_one = FactoryBot.create(:user)
       @user_two = FactoryBot.create(:user)
+      @banned_user = FactoryBot.create(:user, :banned)
+      @closed_account_user = FactoryBot.create(:user, :closed)
       FactoryBot.create(:request_classification, user: @user_one)
       FactoryBot.create(:request_classification, user: @user_one)
       FactoryBot.create(:request_classification, user: @user_two)
+      10.times { FactoryBot.create(:request_classification, user: @banned_user) }
+      FactoryBot.create(:request_classification, user: @closed_account_user)
     end
 
     it "returns a list of users' classifications with counts in descending order" do

--- a/spec/models/statistics/leaderboard_spec.rb
+++ b/spec/models/statistics/leaderboard_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe Statistics::Leaderboard do
         2.times { FactoryBot.create(:info_request, user: user2) }
         FactoryBot.create(:info_request, user: user3)
         10.times { FactoryBot.create(:info_request, user: banned_user) }
+        3.times { FactoryBot.create(:info_request, :hidden, user: user1) }
+        3.times { FactoryBot.create(:embargoed_request, user: user1) }
       end
 
       expect(statistics.all_time_requesters).
@@ -39,6 +41,10 @@ RSpec.describe Statistics::Leaderboard do
                         created_at: 2.months.ago)
       banned_user = FactoryBot.create(:user, :banned)
       10.times { FactoryBot.create(:info_request, user: banned_user) }
+      user_with_embargoed_request = FactoryBot.create(:user)
+      FactoryBot.create(:embargoed_request, user: user_with_embargoed_request)
+      user_with_hidden_request = FactoryBot.create(:user)
+      FactoryBot.create(:info_request, :hidden, user: user_with_hidden_request)
 
       expect(statistics.last_28_day_requesters).
         to eql({ user_with_3_requests => 3,

--- a/spec/models/statistics/leaderboard_spec.rb
+++ b/spec/models/statistics/leaderboard_spec.rb
@@ -2,19 +2,20 @@ require 'spec_helper'
 
 RSpec.describe Statistics::Leaderboard do
   let(:statistics) { described_class.new }
+  before { User.destroy_all }
 
   describe '#all_time_requesters' do
     it 'gets most frequent requesters' do
-      User.destroy_all
-
       user1 = FactoryBot.create(:user)
       user2 = FactoryBot.create(:user)
       user3 = FactoryBot.create(:user)
+      banned_user = FactoryBot.create(:user, :banned)
 
       travel_to(6.months.ago) do
         5.times { FactoryBot.create(:info_request, user: user1) }
         2.times { FactoryBot.create(:info_request, user: user2) }
         FactoryBot.create(:info_request, user: user3)
+        10.times { FactoryBot.create(:info_request, user: banned_user) }
       end
 
       expect(statistics.all_time_requesters).
@@ -36,6 +37,8 @@ RSpec.describe Statistics::Leaderboard do
       FactoryBot.create(:info_request,
                         user: user_with_an_old_request,
                         created_at: 2.months.ago)
+      banned_user = FactoryBot.create(:user, :banned)
+      10.times { FactoryBot.create(:info_request, user: banned_user) }
 
       expect(statistics.last_28_day_requesters).
         to eql({ user_with_3_requests => 3,
@@ -48,6 +51,7 @@ RSpec.describe Statistics::Leaderboard do
     let(:many_comments) { FactoryBot.create(:user) }
     let(:some_comments) { FactoryBot.create(:user) }
     let!(:none_comments) { FactoryBot.create(:user) }
+    let(:banned_user) { FactoryBot.create(:user, :banned) }
 
     before do
       FactoryBot.create(:comment, user: many_comments)
@@ -56,14 +60,13 @@ RSpec.describe Statistics::Leaderboard do
       FactoryBot.create(:comment, user: many_comments)
       FactoryBot.create(:comment, user: some_comments)
       FactoryBot.create(:comment, user: many_comments)
+      10.times { FactoryBot.create(:comment, user: banned_user) }
     end
 
     it 'gets most frequent commenters' do
-      # FIXME: This uses fixtures. Change it to use factories when we can.
       expect(statistics.all_time_commenters).
         to eql({ many_comments => 4,
-                 some_comments => 2,
-                 users(:silly_name_user) => 1 })
+                 some_comments => 2 })
     end
   end
 
@@ -79,6 +82,8 @@ RSpec.describe Statistics::Leaderboard do
       FactoryBot.create(:comment,
                         user: user_with_an_old_comment,
                         created_at: 2.months.ago)
+      banned_user = FactoryBot.create(:user, :banned)
+      10.times { FactoryBot.create(:comment, user: banned_user) }
 
       expect(statistics.last_28_day_commenters).
         to eql({ user_with_3_comments => 3,

--- a/spec/models/statistics/leaderboard_spec.rb
+++ b/spec/models/statistics/leaderboard_spec.rb
@@ -10,12 +10,14 @@ RSpec.describe Statistics::Leaderboard do
       user2 = FactoryBot.create(:user)
       user3 = FactoryBot.create(:user)
       banned_user = FactoryBot.create(:user, :banned)
+      closed_account_user = FactoryBot.create(:user, :closed)
 
       travel_to(6.months.ago) do
         5.times { FactoryBot.create(:info_request, user: user1) }
         2.times { FactoryBot.create(:info_request, user: user2) }
         FactoryBot.create(:info_request, user: user3)
         10.times { FactoryBot.create(:info_request, user: banned_user) }
+        10.times { FactoryBot.create(:info_request, user: closed_account_user) }
         3.times { FactoryBot.create(:info_request, :hidden, user: user1) }
         3.times { FactoryBot.create(:embargoed_request, user: user1) }
       end
@@ -41,6 +43,8 @@ RSpec.describe Statistics::Leaderboard do
                         created_at: 2.months.ago)
       banned_user = FactoryBot.create(:user, :banned)
       10.times { FactoryBot.create(:info_request, user: banned_user) }
+      closed_account_user = FactoryBot.create(:user, :closed)
+      10.times { FactoryBot.create(:info_request, user: closed_account_user) }
       user_with_embargoed_request = FactoryBot.create(:user)
       FactoryBot.create(:embargoed_request, user: user_with_embargoed_request)
       user_with_hidden_request = FactoryBot.create(:user)
@@ -58,6 +62,7 @@ RSpec.describe Statistics::Leaderboard do
     let(:some_comments) { FactoryBot.create(:user) }
     let!(:none_comments) { FactoryBot.create(:user) }
     let(:banned_user) { FactoryBot.create(:user, :banned) }
+    let(:closed_account_user) { FactoryBot.create(:user, :closed) }
 
     before do
       FactoryBot.create(:comment, user: many_comments)
@@ -67,6 +72,7 @@ RSpec.describe Statistics::Leaderboard do
       FactoryBot.create(:comment, user: some_comments)
       FactoryBot.create(:comment, user: many_comments)
       10.times { FactoryBot.create(:comment, user: banned_user) }
+      10.times { FactoryBot.create(:comment, user: closed_account_user) }
     end
 
     it 'gets most frequent commenters' do
@@ -90,6 +96,8 @@ RSpec.describe Statistics::Leaderboard do
                         created_at: 2.months.ago)
       banned_user = FactoryBot.create(:user, :banned)
       10.times { FactoryBot.create(:comment, user: banned_user) }
+      closed_account_user = FactoryBot.create(:user, :closed)
+      10.times { FactoryBot.create(:comment, user: closed_account_user) }
 
       expect(statistics.last_28_day_commenters).
         to eql({ user_with_3_comments => 3,


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/7946

## What does this do?

Change the `Statistics::Leaderboard` class to only consider active users (i.e. users that haven't closed their account or been banned) from appearing on leaderboards.