### PR TITLE
[#7811] Allow InfoRequest to be categorised 

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -4,6 +4,7 @@
 class Admin::CategoriesController < AdminController
   include TranslatableParams
 
+  before_action :check_klass
   before_action :set_root, expect: [:destroy, :reorder]
   before_action :set_category, only: [:edit, :update, :destroy, :reorder]
 
@@ -19,7 +20,7 @@ class Admin::CategoriesController < AdminController
     @category = Category.new(category_params)
     if @category.save
       flash[:notice] = 'Category was successfully created.'
-      redirect_to admin_categories_path
+      redirect_to admin_categories_path(model_type: current_klass)
     else
       @category.build_all_translations
       render action: 'new'
@@ -33,7 +34,7 @@ class Admin::CategoriesController < AdminController
   def update
     if @category.update(category_params)
       flash[:notice] = 'Category was successfully updated.'
-      redirect_to admin_categories_path
+      redirect_to admin_categories_path(model_type: current_klass)
     else
       @category.build_all_translations
       render action: 'edit'
@@ -43,7 +44,7 @@ class Admin::CategoriesController < AdminController
   def destroy
     @category.destroy
     flash[:notice] = 'Category was successfully destroyed.'
-    redirect_to admin_categories_path
+    redirect_to admin_categories_path(model_type: current_klass)
   end
 
   def reorder
@@ -82,10 +83,19 @@ class Admin::CategoriesController < AdminController
   end
 
   def set_root
-    @root = PublicBody.category_root
+    @root = current_klass.category_root
   end
 
   def set_category
     @category = Category.find(params[:id])
+  end
+
+  helper_method :current_klass
+  def current_klass
+    params.fetch(:model_type, 'PublicBody').safe_constantize
+  end
+
+  def check_klass
+    raise RouteNotFound unless Categorisable.models.include?(current_klass)
   end
 end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -82,7 +82,7 @@ class Admin::CategoriesController < AdminController
   end
 
   def set_root
-    @root = Category.public_body_root
+    @root = PublicBody.category_root
   end
 
   def set_category

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -49,10 +49,6 @@ class Category < ApplicationRecord
     joins(:parent_relationships).where(parent_relationships: { parent: parent })
   end
 
-  def self.public_body_root
-    Category.roots.find_or_create_by(title: 'PublicBody')
-  end
-
   def tree
     children.includes(:translations, children: [:translations])
   end

--- a/app/models/concerns/categorisable.rb
+++ b/app/models/concerns/categorisable.rb
@@ -1,0 +1,22 @@
+##
+# Module concern with methods to help categorise records
+#
+module Categorisable
+  extend ActiveSupport::Concern
+
+  def self.models
+    @models ||= []
+  end
+
+  included do
+    Categorisable.models << self
+
+    def self.category_root
+      Category.roots.find_or_create_by(title: name)
+    end
+
+    def self.categories
+      category_root.tree
+    end
+  end
+end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -49,6 +49,7 @@ class InfoRequest < ApplicationRecord
   include InfoRequest::PublicToken
   include InfoRequest::Sluggable
   include InfoRequest::TitleValidation
+  include Categorisable
   include Taggable
   include Notable
   include LinkToHelper

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -33,6 +33,7 @@ require 'confidence_intervals'
 
 class PublicBody < ApplicationRecord
   include CalculatedHomePage
+  include Categorisable
   include Taggable
   include Notable
   include Rails.application.routes.url_helpers

--- a/app/views/admin/categories/_scope.html.erb
+++ b/app/views/admin/categories/_scope.html.erb
@@ -1,0 +1,7 @@
+<ul class="nav nav-tabs">
+  <% Categorisable.models.sort_by(&:admin_title).each do |klass| %>
+    <%= tag.li class: { active: current_klass == klass } do %>
+      <%= link_to klass.admin_title.pluralize, url_for(model_type: klass.name, query: params[:query]) %>
+    <% end %>
+  <% end %>
+</ul>

--- a/app/views/admin/categories/edit.html.erb
+++ b/app/views/admin/categories/edit.html.erb
@@ -5,13 +5,15 @@
 <div class="row">
   <div class="span8">
     <div id="category_form">
-      <%= form_for @category, url: admin_category_path(@category), html: { class: "form form-horizontal" } do |f| %>
+      <%= form_for @category, url: admin_category_path(@category, model_type: current_klass), html: { class: "form form-horizontal" } do |f| %>
         <%= render partial: 'form', locals: { f: f } %>
 
         <div class="form-actions">
           <%= f.submit 'Save', accesskey: 's', class: 'btn btn-success' %>
-          <%= link_to 'Public page', list_public_bodies_by_tag_path(@category.category_tag), class: 'btn' if @category.category_tag %>
-          <%= link_to 'List all', admin_categories_path, class: 'btn' %>
+          <% if current_klass == PublicBody && @category.category_tag %>
+            <%= link_to 'Public page', list_public_bodies_by_tag_path(@category.category_tag), class: 'btn' %>
+          <% end %>
+          <%= link_to 'List all', admin_categories_path(model_type: current_klass), class: 'btn' %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -1,10 +1,12 @@
-<% @title = 'Listing public authority categories' %>
+<% @title = "Listing #{current_klass.admin_title} categories" %>
 
 <h1><%=@title%></h1>
 
+<%= render partial: 'scope' %>
+
 <div class="btn-toolbar">
   <div class="btn-group">
-    <%= link_to 'New category', new_admin_category_path, class: "btn btn-primary" %>
+    <%= link_to 'New category', new_admin_category_path(model_type: current_klass), class: "btn btn-primary" %>
   </div>
 </div>
 
@@ -21,7 +23,7 @@
               <span class="badge"><%= heading.children.size %></span>
               <%= chevron_right %>
             </a>
-            <strong><%= link_to(heading.title, edit_admin_category_path(heading), title: "view full details") %></strong>
+            <strong><%= link_to(heading.title, edit_admin_category_path(heading, model_type: current_klass), title: "view full details") %></strong>
           </span>
         </div>
 
@@ -34,7 +36,7 @@
                     <i class="icon-move"></i>
                   <% end %>
 
-                  <%= link_to(category.title, edit_admin_category_path(category), title: "view full details") %>
+                  <%= link_to(category.title, edit_admin_category_path(category, model_type: current_klass), title: "view full details") %>
                 </div>
               <% end %>
             </div>

--- a/app/views/admin/categories/new.html.erb
+++ b/app/views/admin/categories/new.html.erb
@@ -5,12 +5,12 @@
 <div class="row">
   <div class="span8">
     <div id="public_category_form">
-      <%= form_for @category, url: admin_categories_path, html: { class: "form form-horizontal" } do |f| %>
+      <%= form_for @category, url: admin_categories_path(model_type: current_klass), html: { class: "form form-horizontal" } do |f| %>
         <%= render partial: 'form', locals: { f: f } %>
 
         <div class="form-actions">
           <%= f.submit "Create", class: "btn btn-primary"  %>
-          <%= link_to 'List all', admin_categories_path, class: "btn" %>
+          <%= link_to 'List all', admin_categories_path(model_type: current_klass), class: "btn" %>
         </div>
       <% end %>
     </div>

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -36,6 +36,7 @@
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Requests', admin_requests_path %></li>
               <li><%= link_to 'Comments', admin_comments_path %></li>
+              <li><%= link_to 'Categories', admin_categories_path(model_type: 'InfoRequest') %></li>
               <li><%= link_to 'Tags', admin_tags_path(model_type: 'InfoRequest') %></li>
               <% if feature_enabled?(:refusal_snippets) %><li><%= link_to 'Snippets', admin_snippets_path %></li><% end %>
             </ul>

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -26,7 +26,7 @@
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Authorities<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Authorities', admin_bodies_path %></li>
-              <li><%= link_to 'Categories', admin_categories_path %></li>
+              <li><%= link_to 'Categories', admin_categories_path(model_type: 'PublicBody') %></li>
               <li><%= link_to 'Tags', admin_tags_path(model_type: 'PublicBody') %></li>
             </ul>
           </li>

--- a/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
+++ b/app/views/alaveteli_pro/batch_request_authority_searches/_browse.html.erb
@@ -3,7 +3,7 @@
 <% else %>
   <% show_add_all = feature_enabled?(:pro_batch_category_add_all, current_user) %>
   <ul class="batch-builder__list">
-  <% Category.public_body_root.tree.each do |heading| %>
+  <% PublicBody.categories.each do |heading| %>
     <li class="batch-builder__list__group">
       <div class="batch-builder__list__item">
         <span class="batch-builder__list__item__anchor">

--- a/app/views/public_body/list.html.erb
+++ b/app/views/public_body/list.html.erb
@@ -31,7 +31,7 @@
     </li>
   </ul>
 
-  <% Category.public_body_root.tree.each do |heading| %>
+  <% PublicBody.categories.each do |heading| %>
     <h3><%= heading.title %></h3>
     <ul>
       <% heading.children.each do |category| %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow `InfoRequest` to be categorised (Graeme Porteous)
 * Replace public body categories with generalised categories (Graeme Porteous)
 * Add admin links to and from batch request show action (Graeme Porteous)
 * Update request base calculated status for internal reviews (Graeme Porteous)

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -1,12 +1,12 @@
 namespace :temp do
   desc 'Migrate PublicBodyCategory into Category model'
   task migrate_public_body_categories: :environment do
-    next if Category.public_body_root.children.any?
+    next if PublicBody.categories.any?
 
     scope = PublicBodyCategoryLink.by_display_order.to_a
     count = scope.count
 
-    root = Category.public_body_root
+    root = PublicBody.category_root
 
     scope.each.with_index do |link, index|
       h = link.public_body_heading

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe Admin::CategoriesController do
     it 'assigns root for correct model' do
       get :index, params: { model_type: 'PublicBody' }
       expect(assigns(:root)).to eq(PublicBody.category_root)
+
+      get :index, params: { model_type: 'InfoRequest' }
+      expect(assigns(:root)).to eq(InfoRequest.category_root)
     end
 
     it 'renders the index template' do
@@ -28,6 +31,9 @@ RSpec.describe Admin::CategoriesController do
     it 'assigns root for correct model' do
       get :new, params: { model_type: 'PublicBody' }
       expect(assigns(:root)).to eq(PublicBody.category_root)
+
+      get :new, params: { model_type: 'InfoRequest' }
+      expect(assigns(:root)).to eq(InfoRequest.category_root)
     end
 
     it 'responds successfully' do
@@ -59,6 +65,12 @@ RSpec.describe Admin::CategoriesController do
         category: { title: 'Title' }
       }
       expect(assigns(:root)).to eq(PublicBody.category_root)
+
+      post :create, params: {
+        model_type: 'InfoRequest',
+        category: { title: 'Title' }
+      }
+      expect(assigns(:root)).to eq(InfoRequest.category_root)
     end
 
     it "default category's parent associations to root" do
@@ -188,6 +200,9 @@ RSpec.describe Admin::CategoriesController do
     it 'assigns root for correct model' do
       get :edit, params: { model_type: 'PublicBody', id: category.id }
       expect(assigns(:root)).to eq(PublicBody.category_root)
+
+      get :edit, params: { model_type: 'InfoRequest', id: category.id }
+      expect(assigns(:root)).to eq(InfoRequest.category_root)
     end
 
     it 'responds successfully' do
@@ -247,6 +262,13 @@ RSpec.describe Admin::CategoriesController do
         category: params
       }
       expect(assigns(:root)).to eq(PublicBody.category_root)
+
+      patch :update, params: {
+        model_type: 'InfoRequest',
+        id: category.id,
+        category: params
+      }
+      expect(assigns(:root)).to eq(InfoRequest.category_root)
     end
 
     it 'finds the category to update' do

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -7,8 +7,14 @@ RSpec.describe Admin::CategoriesController do
       expect(response).to be_successful
     end
 
-    it 'assigns root' do
-      get :index
+    it 'raise 404 for unknown types' do
+      expect { get :index, params: { model_type: 'unknown' } }.to(
+        raise_error ApplicationController::RouteNotFound
+      )
+    end
+
+    it 'assigns root for correct model' do
+      get :index, params: { model_type: 'PublicBody' }
       expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
@@ -19,8 +25,8 @@ RSpec.describe Admin::CategoriesController do
   end
 
   describe 'GET new' do
-    it 'assigns root' do
-      get :new
+    it 'assigns root for correct model' do
+      get :new, params: { model_type: 'PublicBody' }
       expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
@@ -47,8 +53,11 @@ RSpec.describe Admin::CategoriesController do
   end
 
   describe 'POST create' do
-    it 'assigns root' do
-      post :create, params: { category: { title: 'Title' } }
+    it 'assigns root for correct model' do
+      post :create, params: {
+        model_type: 'PublicBody',
+        category: { title: 'Title' }
+      }
       expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
@@ -93,7 +102,8 @@ RSpec.describe Admin::CategoriesController do
 
       it 'redirects to the categories index' do
         post :create, params: { category: params }
-        expect(response).to redirect_to(admin_categories_path)
+        expect(response).
+          to redirect_to(admin_categories_path(model_type: 'PublicBody'))
       end
     end
 
@@ -175,8 +185,8 @@ RSpec.describe Admin::CategoriesController do
       )
     end
 
-    it 'assigns root' do
-      get :edit, params: { id: category.id }
+    it 'assigns root for correct model' do
+      get :edit, params: { model_type: 'PublicBody', id: category.id }
       expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
@@ -230,8 +240,12 @@ RSpec.describe Admin::CategoriesController do
       }
     end
 
-    it 'assigns root' do
-      patch :update, params: { id: category.id, category: params }
+    it 'assigns root for correct model' do
+      patch :update, params: {
+        model_type: 'PublicBody',
+        id: category.id,
+        category: params
+      }
       expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
@@ -302,7 +316,8 @@ RSpec.describe Admin::CategoriesController do
 
       it 'redirects to the category edit page' do
         patch :update, params: { id: category.id, category: params }
-        expect(response).to redirect_to(admin_categories_path)
+        expect(response).
+          to redirect_to(admin_categories_path(model_type: 'PublicBody'))
       end
 
       it 'saves edits to category_tag if the category has no associated bodies' do
@@ -405,7 +420,8 @@ RSpec.describe Admin::CategoriesController do
 
       it 'redirects to the edit page after a successful update' do
         patch :update, params: { id: category.id, category: { title: 'Title' } }
-        expect(response).to redirect_to(admin_categories_path)
+        expect(response).
+          to redirect_to(admin_categories_path(model_type: 'PublicBody'))
       end
     end
 
@@ -483,7 +499,8 @@ RSpec.describe Admin::CategoriesController do
 
     it 'redirects to the categories index' do
       delete :destroy, params: { id: category.id }
-      expect(response).to redirect_to(admin_categories_path)
+      expect(response).
+        to redirect_to(admin_categories_path(model_type: 'PublicBody'))
     end
   end
 

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Admin::CategoriesController do
 
     it 'assigns root' do
       get :index
-      expect(assigns(:root)).to eq(Category.public_body_root)
+      expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
     it 'renders the index template' do
@@ -21,7 +21,7 @@ RSpec.describe Admin::CategoriesController do
   describe 'GET new' do
     it 'assigns root' do
       get :new
-      expect(assigns(:root)).to eq(Category.public_body_root)
+      expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
     it 'responds successfully' do
@@ -49,13 +49,13 @@ RSpec.describe Admin::CategoriesController do
   describe 'POST create' do
     it 'assigns root' do
       post :create, params: { category: { title: 'Title' } }
-      expect(assigns(:root)).to eq(Category.public_body_root)
+      expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
     it "default category's parent associations to root" do
       post :create, params: { category: { title: 'Title' } }
       expect(assigns(:category).parents).
-        to match_array(Category.public_body_root)
+        to match_array(PublicBody.category_root)
     end
 
     it "saves new category's parent associations" do
@@ -177,7 +177,7 @@ RSpec.describe Admin::CategoriesController do
 
     it 'assigns root' do
       get :edit, params: { id: category.id }
-      expect(assigns(:root)).to eq(Category.public_body_root)
+      expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
     it 'responds successfully' do
@@ -232,7 +232,7 @@ RSpec.describe Admin::CategoriesController do
 
     it 'assigns root' do
       patch :update, params: { id: category.id, category: params }
-      expect(assigns(:root)).to eq(Category.public_body_root)
+      expect(assigns(:root)).to eq(PublicBody.category_root)
     end
 
     it 'finds the category to update' do
@@ -243,7 +243,7 @@ RSpec.describe Admin::CategoriesController do
     it "default category's parent associations to root" do
       patch :update, params: { id: category.id, category: params }
       expect(assigns(:category).parents).
-        to match_array(Category.public_body_root)
+        to match_array(PublicBody.category_root)
     end
 
     it "saves edits to a category's parent associations" do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Category, type: :model do
 
   describe '.roots scope' do
     subject { described_class.roots }
-    it { is_expected.to include(described_class.public_body_root) }
+    it { is_expected.to include(PublicBody.category_root) }
   end
 
   describe '.with_parent scope' do
@@ -112,12 +112,6 @@ RSpec.describe Category, type: :model do
     it { is_expected.to include(child) }
     it { is_expected.to include(child_with_muliple_parents) }
     it { is_expected.to_not include(other_child) }
-  end
-
-  describe '.public_body_root' do
-    subject(:root) { described_class.public_body_root }
-    it { is_expected.to be_a(described_class) }
-    it { expect(root.title).to eq('PublicBody') }
   end
 
   describe '#tree' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe Category, type: :model do
   describe '.roots scope' do
     subject { described_class.roots }
     it { is_expected.to include(PublicBody.category_root) }
+    it { is_expected.to include(InfoRequest.category_root) }
   end
 
   describe '.with_parent scope' do

--- a/spec/models/concerns/categorisable.rb
+++ b/spec/models/concerns/categorisable.rb
@@ -1,0 +1,16 @@
+RSpec.shared_examples 'concerns/categorisable' do |factory_opts|
+  let(:record) { FactoryBot.create(*factory_opts) }
+
+  describe '.category_root' do
+    subject(:root) { described_class.category_root }
+    it { is_expected.to be_a(Category) }
+    it { expect(root.title).to eq(described_class.to_s) }
+  end
+
+  describe '.categories' do
+    it 'calls category_root.tree' do
+      expect(described_class).to receive_message_chain(:category_root, :tree)
+      described_class.categories
+    end
+  end
+end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -37,6 +37,7 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/categorisable'
 require 'models/concerns/info_request/title_validation'
 require 'models/concerns/notable'
 require 'models/concerns/notable_and_taggable'
@@ -44,6 +45,7 @@ require 'models/concerns/taggable'
 require 'models/info_request/batch_pagination'
 
 RSpec.describe InfoRequest do
+  it_behaves_like 'concerns/categorisable', :info_request
   it_behaves_like 'concerns/info_request/title_validation', :info_request
   it_behaves_like 'concerns/notable', :info_request
   it_behaves_like 'concerns/notable_and_taggable', :info_request

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -27,11 +27,13 @@
 #
 
 require 'spec_helper'
+require 'models/concerns/categorisable'
 require 'models/concerns/notable'
 require 'models/concerns/notable_and_taggable'
 require 'models/concerns/taggable'
 
 RSpec.describe PublicBody do
+  it_behaves_like 'concerns/categorisable', :public_body
   it_behaves_like 'concerns/notable', :public_body
   it_behaves_like 'concerns/notable_and_taggable', :public_body
   it_behaves_like 'concerns/taggable', :public_body


### PR DESCRIPTION
## Relevant issue(s)

Depends on #8023 
Fixes #7811

## What does this do?
 
Add `categorisable` concern and adds this to `InfoRequest`

## Why was this needed?

So we can so groups of requests on [topic pages](https://github.com/mysociety/alaveteli/milestone/62).

## Screenshots

<img width="812" alt="image" src="https://github.com/mysociety/alaveteli/assets/5426/6ef8c4ba-9884-429e-9241-7ff6f27e3aa0">
