### PR TITLE
Add helper to add query params to a URL

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -309,22 +309,7 @@ class ApplicationController < ActionController::Base
   end
 
   def add_post_redirect_param_to_uri(uri)
-    # TODO: what is the built in Ruby URI munging function that can do this
-    # choice of & vs. ? more elegantly than this dumb if statement?
-    if uri.include?("?")
-      # TODO: This looks odd. What would a fragment identifier be doing server-side?
-      #     But it also looks harmless, so I’ll leave it just in case.
-      if uri.include?("#")
-        uri.sub!("#", "&post_redirect=1#")
-      else
-        uri += "&post_redirect=1"
-      end
-    elsif uri.include?("#")
-      uri.sub!("#", "?post_redirect=1#")
-    else
-      uri += "?post_redirect=1"
-    end
-    uri
+    add_query_params_to_url(uri, post_redirect: 1)
   end
 
   # If we are in a faked redirect to POST request, then set post params.

--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -338,4 +338,13 @@ module LinkToHelper
 
     [prefix, param_key, record.to_param].compact.join('-')
   end
+
+  def add_query_params_to_url(url, new_params)
+    uri = URI.parse(url)
+    uri.query = Rack::Utils.parse_nested_query(uri.query).
+      with_indifferent_access.
+      merge(new_params).
+      to_param
+    uri.to_s
+  end
 end

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -8,6 +8,7 @@
 #
 class Blog
   include ConfigHelper
+  include LinkToHelper
 
   def self.enabled?
     AlaveteliConfiguration.blog_feed.present?
@@ -33,11 +34,10 @@ class Blog
   end
 
   def feed_url
-    uri = URI(AlaveteliConfiguration.blog_feed)
-    uri.query = URI.decode_www_form(uri.query || '').to_h.merge(
-      lang: AlaveteliLocalization.html_lang.to_s
-    ).to_param
-    uri.to_s
+    add_query_params_to_url(
+      AlaveteliConfiguration.blog_feed,
+      lang: AlaveteliLocalization.html_lang
+    )
   end
 
   private

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -5,6 +5,8 @@
 # have requests to the same PublicBody
 #
 class Survey
+  include LinkToHelper
+
   def self.enabled?
     url.present?
   end
@@ -25,14 +27,7 @@ class Survey
   def url
     return Survey.url if user_too_identifiable?
 
-    uri = URI(Survey.url)
-
-    new_query = Hash[URI.decode_www_form(uri.query.to_s)].merge(
-      authority_id: public_body.to_param
-    )
-    uri.query = URI.encode_www_form(new_query)
-
-    uri.to_s
+    add_query_params_to_url(Survey.url, authority_id: public_body)
   end
 
   protected

--- a/spec/helpers/link_to_helper_spec.rb
+++ b/spec/helpers/link_to_helper_spec.rb
@@ -295,4 +295,54 @@ RSpec.describe LinkToHelper do
       it { is_expected.to be_nil }
     end
   end
+
+  describe '#add_query_params_to_url' do
+    it 'adds new parameters to a URL without existing parameters' do
+      url = 'http://example.com/'
+      new_params = { foo: 1 }
+      expect(add_query_params_to_url(url, new_params)).
+        to eq 'http://example.com/?foo=1'
+    end
+
+    it 'adds ActiveModel object parameters to a URL by calling #to_param' do
+      url = 'http://example.com/'
+      new_params = { user: users(:bob_smith_user) }
+      expect(add_query_params_to_url(url, new_params)).
+        to eq 'http://example.com/?user=1'
+    end
+
+    it 'adds new parameters to a URL with existing parameters' do
+      url = 'http://example.com/?bar=2'
+      new_params = { foo: 1 }
+      expect(add_query_params_to_url(url, new_params)).
+        to eq 'http://example.com/?bar=2&foo=1'
+    end
+
+    it 'overwrites an existing parameter if a new value is provided' do
+      url = 'http://example.com/?foo=2'
+      new_params = { foo: 1 }
+      expect(add_query_params_to_url(url, new_params)).
+        to eq 'http://example.com/?foo=1'
+    end
+
+    it 'keeps existing url fragments' do
+      url = 'http://example.com/#bar'
+      new_params = { foo: 1 }
+      expect(add_query_params_to_url(url, new_params)).
+        to eq 'http://example.com/?foo=1#bar'
+    end
+
+    it 'handles special characters in parameter values' do
+      url = 'http://example.com/'
+      new_params = { special: 'chars like %&=' }
+      updated_url = add_query_params_to_url(url, new_params)
+      expect(URI.parse(updated_url).query).to eq 'special=chars+like+%25%26%3D'
+    end
+
+    it 'returns the original URL unchanged if no new parameters are provided' do
+      url = 'http://example.com/?foo=1'
+      new_params = {}
+      expect(add_query_params_to_url(url, new_params)).to eq url
+    end
+  end
 end


### PR DESCRIPTION
## What does this do?

Add helper to add query params to a URL

## Why was this needed?

In a couple of places we do this in different ways, this helper will allow us to do this in one line and is tested independently.

## Implementation notes

This helper will be useful in #7961

<hr>

[skip changelog]