### PR TITLE
[#8040] Fix missing attachments exceptions

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -133,7 +133,7 @@ class AttachmentsController < ApplicationController
       end
     end
 
-  rescue Timeout::Error
+  rescue Timeout::Error, ActiveRecord::RecordNotFound
     redirect_to wait_for_attachment_mask_path(
       @attachment.to_signed_global_id,
       referer: verifier.generate(request.fullpath)

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -135,10 +135,15 @@ class FoiAttachment < ApplicationRecord
     )
 
   rescue MailHandler::MismatchedAttachmentHexdigest
-    attributes = MailHandler.attempt_to_find_original_attachment_attributes(
-      raw_email.mail,
-      body: file.download
-    ) if file.attached?
+    begin
+      attributes = MailHandler.attempt_to_find_original_attachment_attributes(
+        raw_email.mail,
+        body: file.download
+      ) if file.attached?
+
+    rescue ActiveStorage::FileNotFoundError
+      raise MissingAttachment, "attachment missing from storage (ID=#{id})"
+    end
 
     unless attributes
       raise MissingAttachment, "attachment missing in raw email (ID=#{id})"

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -100,7 +100,6 @@ class FoiAttachment < ApplicationRecord
     update_display_size!
   end
 
-  # raw body, encoded as binary
   def body
     return @cached_body if @cached_body
 

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -112,12 +112,10 @@ class FoiAttachment < ApplicationRecord
 
     if persisted?
       FoiAttachmentMaskJob.perform_once_now(self)
-      reload
-      body
+      return body unless destroyed?
     end
 
-  rescue ActiveRecord::RecordNotFound
-    load_attachment_from_incoming_message!.body
+    load_attachment_from_incoming_message!.body if destroyed?
   end
 
   # body as UTF-8 text, with scrubbing of invalid chars if needed

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Update attachment processing to automatically rebuild if cached file goes
+  missing (Graeme Porteous)
 * Allow `InfoRequest` to be categorised (Graeme Porteous)
 * Replace public body categories with generalised categories (Graeme Porteous)
 * Add admin links to and from batch request show action (Graeme Porteous)

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -262,6 +262,20 @@ RSpec.describe FoiAttachment do
       end
     end
 
+    context 'when unable to find original attachment in storage' do
+      before do
+        allow(foi_attachment.file).
+          to receive(:download).and_raise(ActiveStorage::FileNotFoundError)
+      end
+
+      it 'raises missing attachment exception' do
+        expect { unmasked_body }.to raise_error(
+          FoiAttachment::MissingAttachment,
+          "attachment missing from storage (ID=#{foi_attachment.id})"
+        )
+      end
+    end
+
     context 'when unable to find original attachment through other means' do
       before do
         allow(MailHandler).to receive(:attachment_body_for_hexdigest).

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -200,6 +200,21 @@ RSpec.describe FoiAttachment do
         )
       end
     end
+
+    context 'when attachment has been destroy' do
+      let(:foi_attachment) { FactoryBot.create(:foi_attachment) }
+
+      before { foi_attachment.destroy }
+
+      it 'returns load_attachment_from_incoming_message.body' do
+        allow(foi_attachment).to(
+          receive(:load_attachment_from_incoming_message).and_return(
+            double(body: 'thisisthenewtext')
+          )
+        )
+        expect(foi_attachment.body).to eq('thisisthenewtext')
+      end
+    end
   end
 
   describe '#body_as_text' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8040

## What does this do?

Fix missing attachments exceptions

## Why was this needed?

There seems to be some missing attachments on WDTK. This seems to stem from when we migrated attachments to `ActiveStorage` where the files either weren't present or weren't migrated correctly. Or I guess have been lost since (hopefully not). Luckily we can alwasy restore from the raw emails. This used to guard against missing attachments before the recent attachment processing changes. This change re-adds this functionality.

