### PR TITLE
Add link to admin attachments

### DIFF
--- a/app/views/request/_attachments.html.erb
+++ b/app/views/request/_attachments.html.erb
@@ -33,7 +33,12 @@
                 <%= link_to "View as HTML", attachment_path(a, :html => true) %>
               <% end %>
               <%= a.extra_note %>
+
+              <% if @user.present? && @user.admin_page_links? %>
+                <%= link_to 'Admin', edit_admin_foi_attachment_path(a) %>
+              <% end %>
             </p>
+
           <% end %>
         <% end %>
       <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add link from incoming message to admin page for attachments (Gareth Rees)
 * Add XSLX spreadsheet analyser to automatically detect hidden data (Helen
   Cross, Graeme Porteous)
 * Update attachment processing to automatically rebuild if cached file goes


### PR DESCRIPTION
Makes it easier to navigate directly to the admin page for an attachment. On several occasions admins have navigated to the incoming message – because it's the closest link available – and changed the prominence of the incoming message rather than the attachment.

No user:

![Screenshot 2023-12-15 at 13 48 30](https://github.com/mysociety/alaveteli/assets/282788/ad3bc452-7f6c-4d32-ae74-fba070f872f5)

Bob (non-admin):

![Screenshot 2023-12-15 at 13 48 48](https://github.com/mysociety/alaveteli/assets/282788/3e8738de-c145-4ee1-af68-0e3e1ea93cfe)

Annie (admin):

![Screenshot 2023-12-15 at 13 49 52](https://github.com/mysociety/alaveteli/assets/282788/68753e9d-ffe6-4eb8-bc67-2b94a92fb2e2)
