### PR TITLE
Layout/LineLength RuboCops in spec/helpers

### DIFF
--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -149,9 +149,9 @@ RSpec.describe ApplicationHelper do
     it 'should generate a description for a request' do
       @info_request = FactoryBot.create(:info_request)
       @sent_event = @info_request.last_event
-      expected = "Request sent to " \
-        "#{public_body_link_absolute(@info_request.public_body)} by " \
-        "#{request_user_link_absolute(@info_request)}"
+      public_body_link = public_body_link_absolute(@info_request.public_body)
+      request_user_link = request_user_link_absolute(@info_request)
+      expected = "Request sent to #{public_body_link} by #{request_user_link}"
       expect(event_description(@sent_event)).to match(expected)
     end
 
@@ -160,11 +160,13 @@ RSpec.describe ApplicationHelper do
         :info_request_with_incoming
       )
       @response_event = @info_request_with_incoming.last_event
-      expected = "Response by " \
-        "#{public_body_link_absolute(
-            @info_request_with_incoming.public_body
-          )} " \
-        "to #{request_user_link_absolute(@info_request_with_incoming)}"
+      public_body_link = public_body_link_absolute(
+        @info_request_with_incoming.public_body
+      )
+      request_user_link = request_user_link_absolute(
+        @info_request_with_incoming
+      )
+      expected = "Response by #{public_body_link} to #{request_user_link}"
       expect(event_description(@response_event)).to match(expected)
     end
 
@@ -172,13 +174,14 @@ RSpec.describe ApplicationHelper do
       @info_request_with_internal_review_request = FactoryBot.
         create(:info_request_with_internal_review_request)
       @response_event = @info_request_with_internal_review_request.last_event
-      expected = "Internal review request sent to " \
-        "#{public_body_link_absolute(
-            @info_request_with_internal_review_request.public_body
-          )} " \
-        "by #{request_user_link_absolute(
-            @info_request_with_internal_review_request
-          )}"
+      public_body_link = public_body_link_absolute(
+        @info_request_with_internal_review_request.public_body
+      )
+      request_user_link = request_user_link_absolute(
+        @info_request_with_internal_review_request
+      )
+      expected = "Internal review request sent to #{public_body_link} by " \
+        "#{request_user_link}"
       expect(event_description(@response_event)).to match(expected)
     end
   end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -149,21 +149,36 @@ RSpec.describe ApplicationHelper do
     it 'should generate a description for a request' do
       @info_request = FactoryBot.create(:info_request)
       @sent_event = @info_request.last_event
-      expected = "Request sent to #{public_body_link_absolute(@info_request.public_body)} by #{request_user_link_absolute(@info_request)}"
+      expected = "Request sent to " \
+        "#{public_body_link_absolute(@info_request.public_body)} by " \
+        "#{request_user_link_absolute(@info_request)}"
       expect(event_description(@sent_event)).to match(expected)
     end
 
     it 'should generate a description for a response' do
-      @info_request_with_incoming = FactoryBot.create(:info_request_with_incoming)
+      @info_request_with_incoming = FactoryBot.create(
+        :info_request_with_incoming
+      )
       @response_event = @info_request_with_incoming.last_event
-      expected = "Response by #{public_body_link_absolute(@info_request_with_incoming.public_body)} to #{request_user_link_absolute(@info_request_with_incoming)}"
+      expected = "Response by " \
+        "#{public_body_link_absolute(
+            @info_request_with_incoming.public_body
+          )} " \
+        "to #{request_user_link_absolute(@info_request_with_incoming)}"
       expect(event_description(@response_event)).to match(expected)
     end
 
     it 'should generate a description for a request where an internal review has been requested' do
-      @info_request_with_internal_review_request = FactoryBot.create(:info_request_with_internal_review_request)
+      @info_request_with_internal_review_request = FactoryBot.
+        create(:info_request_with_internal_review_request)
       @response_event = @info_request_with_internal_review_request.last_event
-      expected = "Internal review request sent to #{public_body_link_absolute(@info_request_with_internal_review_request.public_body)} by #{request_user_link_absolute(@info_request_with_internal_review_request)}"
+      expected = "Internal review request sent to " \
+        "#{public_body_link_absolute(
+            @info_request_with_internal_review_request.public_body
+          )} " \
+        "by #{request_user_link_absolute(
+            @info_request_with_internal_review_request
+          )}"
       expect(event_description(@response_event)).to match(expected)
     end
   end

--- a/spec/helpers/currency_helper_spec.rb
+++ b/spec/helpers/currency_helper_spec.rb
@@ -23,17 +23,20 @@ RSpec.describe CurrencyHelper do
 
     context 'when asked to show the amount without trailing zeros' do
       it 'does not show the trailing sub-unit amount when it is 00' do
-        expect(format_currency(123_400, no_cents_if_whole: true)).to eq('£1,234')
+        expect(format_currency(123_400, no_cents_if_whole: true)).
+          to eq('£1,234')
       end
 
       it 'does not rely on the UK currency format' do
         allow(AlaveteliConfiguration).to receive(:iso_currency_code).
           and_return('EUR')
-        expect(format_currency(123_400, no_cents_if_whole: true)).to eq('€1.234')
+        expect(format_currency(123_400, no_cents_if_whole: true)).
+          to eq('€1.234')
       end
 
       it 'still shows the sub-unit value if it is a non-zero amount' do
-        expect(format_currency(1499, no_cents_if_whole: true)).to eq('£14.99')
+        expect(format_currency(1499, no_cents_if_whole: true)).
+          to eq('£14.99')
       end
     end
   end

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -528,10 +528,12 @@ RSpec.describe InfoRequestHelper do
 
       context 'external request' do
         it_behaves_like "when we can't ask the user to update the status" do
-          let(:info_request) { FactoryBot.create(
+          let(:info_request) do
+            FactoryBot.create(
               :external_request,
               awaiting_description: true
-            ) }
+            )
+          end
           let(:message) do
             status_text(info_request,
                         new_responses_count: 1,

--- a/spec/helpers/info_request_helper_spec.rb
+++ b/spec/helpers/info_request_helper_spec.rb
@@ -13,21 +13,27 @@ RSpec.describe InfoRequestHelper do
 
     it 'delegates the info_request argument for a valid status' do
       allow(info_request).to receive(:calculate_status).and_return('successful')
-      expect(self).to receive(:send).with('status_text_successful', info_request, {})
+      expect(self).
+        to receive(:send).
+        with('status_text_successful', info_request, {})
       status_text(info_request)
     end
 
     it 'delegates the options for a valid status' do
       allow(info_request).to receive(:calculate_status).and_return('successful')
       opts = { is_owning_user: false }
-      expect(self).to receive(:send).with('status_text_successful', info_request, opts)
+      expect(self).
+        to receive(:send).
+        with('status_text_successful', info_request, opts)
       status_text(info_request, opts)
     end
 
     it 'delegates to the custom partial for an unknown status' do
       allow(info_request).to receive(:calculate_status).and_return('unknown')
       opts = { is_owning_user: false }
-      expect(self).to receive(:custom_state_description).with(info_request, opts)
+      expect(self).
+        to receive(:custom_state_description).
+        with(info_request, opts)
       status_text(info_request, opts)
     end
 
@@ -37,8 +43,12 @@ RSpec.describe InfoRequestHelper do
 
         body_link = %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
 
-        allow(info_request).to receive(:calculate_status).and_return("waiting_response")
-        allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("waiting_response")
+        allow(info_request).
+          to receive(:date_response_required_by).
+          and_return(Time.zone.now)
 
         response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
                         'title="2014-12-31 00:00:00 UTC">' \
@@ -78,8 +88,12 @@ RSpec.describe InfoRequestHelper do
       it 'returns a description' do
         travel_to(Time.zone.parse('2014-12-31'))
 
-        allow(info_request).to receive(:calculate_status).and_return("waiting_response_overdue")
-        allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("waiting_response_overdue")
+        allow(info_request).
+          to receive(:date_response_required_by).
+          and_return(Time.zone.now)
 
         response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
                         'title="2014-12-31 00:00:00 UTC">' \
@@ -133,8 +147,12 @@ RSpec.describe InfoRequestHelper do
       it 'returns a description for an internal request' do
         travel_to(Time.zone.parse('2014-12-31'))
 
-        allow(info_request).to receive(:calculate_status).and_return("waiting_response_very_overdue")
-        allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("waiting_response_very_overdue")
+        allow(info_request).
+          to receive(:date_response_required_by).
+          and_return(Time.zone.now)
 
         response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
                         'title="2014-12-31 00:00:00 UTC">' \
@@ -192,9 +210,15 @@ RSpec.describe InfoRequestHelper do
 
         body_link = %Q(<a href="/body/#{ body.url_name }">#{ body.name }</a>)
 
-        allow(info_request).to receive(:calculate_status).and_return("waiting_response_very_overdue")
-        allow(info_request).to receive(:date_response_required_by).and_return(Time.zone.now)
-        allow(info_request).to receive(:is_external?).and_return(true)
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("waiting_response_very_overdue")
+        allow(info_request).
+          to receive(:date_response_required_by).
+          and_return(Time.zone.now)
+        allow(info_request).
+          to receive(:is_external?).
+          and_return(true)
 
         response_date = '<time datetime="2014-12-31T00:00:00Z" ' \
                         'title="2014-12-31 00:00:00 UTC">' \
@@ -240,7 +264,9 @@ RSpec.describe InfoRequestHelper do
     context 'successful' do
       it 'returns a description' do
         expected = 'The request was <strong>successful</strong>.'
-        allow(info_request).to receive(:calculate_status).and_return("successful")
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("successful")
         expect(status_text(info_request)).to eq(expected)
       end
     end
@@ -248,18 +274,24 @@ RSpec.describe InfoRequestHelper do
     context 'partially_successful' do
       it 'returns a description' do
         expected = 'The request was <strong>partially successful</strong>.'
-        allow(info_request).to receive(:calculate_status).and_return("partially_successful")
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("partially_successful")
         expect(status_text(info_request)).to eq(expected)
       end
     end
 
     context 'waiting_clarification' do
       before do
-        allow(info_request).to receive(:calculate_status).and_return("waiting_clarification")
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("waiting_clarification")
       end
 
       it 'returns a description for the request owner' do
-        allow(info_request).to receive(:get_last_public_response).and_return(nil)
+        allow(info_request).
+          to receive(:get_last_public_response).
+          and_return(nil)
 
         expected = "#{ body.name } is <strong>waiting for your clarification" \
                    "</strong>. Please " \
@@ -311,7 +343,9 @@ RSpec.describe InfoRequestHelper do
 
     context 'gone_postal' do
       it 'returns a description' do
-        allow(info_request).to receive(:calculate_status).and_return("gone_postal")
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("gone_postal")
         expected = 'The authority would like to / has <strong>responded by ' \
                    'postal mail</strong> to this request.'
         expect(status_text(info_request)).to eq(expected)
@@ -320,7 +354,9 @@ RSpec.describe InfoRequestHelper do
 
     context 'internal_review' do
       it 'returns a description' do
-        allow(info_request).to receive(:calculate_status).and_return("internal_review")
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("internal_review")
         expected = "Waiting for an <strong>internal review</strong> by " \
                    "<a href=\"/body/#{ body.url_name }\">#{ body.name }</a> " \
                    "of their handling of this request."
@@ -347,7 +383,9 @@ RSpec.describe InfoRequestHelper do
 
     context 'requires_admin' do
       it 'returns a description' do
-        allow(info_request).to receive(:calculate_status).and_return("requires_admin")
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("requires_admin")
         expected = 'This request has had an unusual response, and <strong>' \
                    'requires attention</strong> from the Alaveteli team.'
         expect(status_text(info_request)).to eq(expected)
@@ -356,7 +394,9 @@ RSpec.describe InfoRequestHelper do
 
     context 'user_withdrawn' do
       it 'returns a description' do
-        allow(info_request).to receive(:calculate_status).and_return("user_withdrawn")
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("user_withdrawn")
         expected = 'This request has been <strong>withdrawn</strong> by the ' \
                    'person who made it. There may be an explanation in the ' \
                    'correspondence below.'
@@ -366,7 +406,9 @@ RSpec.describe InfoRequestHelper do
 
     context 'attention_requested' do
       it 'returns a description' do
-        allow(info_request).to receive(:calculate_status).and_return("attention_requested")
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("attention_requested")
         expected = 'This request has been <strong>reported</strong> as ' \
                    'needing administrator attention.'
         expect(status_text(info_request)).to eq(expected)
@@ -375,7 +417,9 @@ RSpec.describe InfoRequestHelper do
 
     context 'vexatious' do
       it 'returns a description' do
-        allow(info_request).to receive(:calculate_status).and_return("vexatious")
+        allow(info_request).
+          to receive(:calculate_status).
+          and_return("vexatious")
         expected = 'This request has been reviewed by an administrator ' \
                    'and is considered to be vexatious'
         expect(status_text(info_request)).to eq(expected)
@@ -484,7 +528,10 @@ RSpec.describe InfoRequestHelper do
 
       context 'external request' do
         it_behaves_like "when we can't ask the user to update the status" do
-          let(:info_request) { FactoryBot.create(:external_request, awaiting_description: true) }
+          let(:info_request) { FactoryBot.create(
+              :external_request,
+              awaiting_description: true
+            ) }
           let(:message) do
             status_text(info_request,
                         new_responses_count: 1,

--- a/spec/helpers/public_body_helper_spec.rb
+++ b/spec/helpers/public_body_helper_spec.rb
@@ -69,7 +69,8 @@ RSpec.describe PublicBodyHelper do
       3.times do |i|
         category = FactoryBot.
           create(
-            :public_body_category, category_tag: "spec_#{i}",
+            :public_body_category,
+            category_tag: "spec_#{i}",
             description: "spec category #{i}"
           )
         heading.add_category(category)

--- a/spec/helpers/public_body_helper_spec.rb
+++ b/spec/helpers/public_body_helper_spec.rb
@@ -14,13 +14,15 @@ RSpec.describe PublicBodyHelper do
 
     it 'includes a reason if the law does not apply to the authority' do
       @body.tag_string = 'not_apply'
-      msg = 'Freedom of Information law does not apply to this authority, so you cannot make a request to it.'
+      msg = 'Freedom of Information law does not apply to this authority, ' \
+        'so you cannot make a request to it.'
       expect(public_body_not_requestable_reasons(@body)).to include(msg)
     end
 
     it 'includes a reason if the body no longer exists' do
       @body.tag_string = 'defunct'
-      msg = 'This authority no longer exists, so you cannot make a request to it.'
+      msg = 'This authority no longer exists, so you cannot make a request ' \
+        'to it.'
       expect(public_body_not_requestable_reasons(@body)).to include(msg)
     end
 
@@ -58,25 +60,36 @@ RSpec.describe PublicBodyHelper do
       heading.add_category(category)
       public_body = FactoryBot.create(:public_body, tag_string: 'spec')
 
-      expect(type_of_authority(public_body)).to eq('<a href="/body/list/spec">Ünicode category</a>')
+      expect(type_of_authority(public_body)).
+        to eq('<a href="/body/list/spec">Ünicode category</a>')
     end
 
     it 'constructs the correct string if there are tags which are not categories' do
       heading = FactoryBot.create(:public_body_heading)
       3.times do |i|
-        category = FactoryBot.create(:public_body_category, category_tag: "spec_#{i}",
-                                     description: "spec category #{i}")
+        category = FactoryBot.
+          create(
+            :public_body_category, category_tag: "spec_#{i}",
+            description: "spec category #{i}"
+          )
         heading.add_category(category)
       end
-      public_body = FactoryBot.create(:public_body, tag_string: 'unknown spec_0 spec_2')
-      expected = '<a href="/body/list/spec_0">Spec category 0</a> and <a href="/body/list/spec_2">spec category 2</a>'
+      public_body = FactoryBot.create(
+        :public_body,
+        tag_string: 'unknown spec_0 spec_2'
+      )
+      expected = '<a href="/body/list/spec_0">Spec category 0</a> and ' \
+        '<a href="/body/list/spec_2">spec category 2</a>'
       expect(type_of_authority(public_body)).to eq(expected)
     end
 
     context 'when associated with one category' do
       it 'returns the description wrapped in an anchor tag' do
-        category = FactoryBot.create(:public_body_category, category_tag: 'spec',
-                                     description: 'spec category')
+        category = FactoryBot.create(
+          :public_body_category,
+          category_tag: 'spec',
+          description: 'spec category'
+        )
         heading = FactoryBot.create(:public_body_heading)
         heading.add_category(category)
         public_body = FactoryBot.create(:public_body, tag_string: 'spec')
@@ -90,11 +103,17 @@ RSpec.describe PublicBodyHelper do
       it 'joins the category descriptions and capitalizes the first letter' do
         heading = FactoryBot.create(:public_body_heading)
         3.times do |i|
-          category = FactoryBot.create(:public_body_category, category_tag: "spec_#{i}",
-                                       description: "spec category #{i}")
+          category = FactoryBot.create(
+            :public_body_category,
+            category_tag: "spec_#{i}",
+            description: "spec category #{i}"
+          )
           heading.add_category(category)
         end
-        public_body = FactoryBot.create(:public_body, tag_string: 'spec_0 spec_1 spec_2')
+        public_body = FactoryBot.create(
+          :public_body,
+          tag_string: 'spec_0 spec_1 spec_2'
+        )
 
         description = [
           %Q(<a href="/body/list/spec_0">Spec category 0</a>),
@@ -112,8 +131,11 @@ RSpec.describe PublicBodyHelper do
       it 'creates the anchor href in the correct locale' do
         # Activate the routing filter, normally turned off for helper tests
         RoutingFilter.active = true
-        category = FactoryBot.create(:public_body_category, category_tag: 'spec',
-                                     description: 'spec category')
+        category = FactoryBot.create(
+          :public_body_category,
+          category_tag: 'spec',
+          description: 'spec category'
+        )
         heading = FactoryBot.create(:public_body_heading)
         heading.add_category(category)
         public_body = FactoryBot.create(:public_body, tag_string: 'spec')

--- a/spec/helpers/widget_helper_spec.rb
+++ b/spec/helpers/widget_helper_spec.rb
@@ -9,16 +9,20 @@ RSpec.describe WidgetHelper do
     end
 
     it 'should return "Awaiting classification" for "waiting_classification' do
-      expect(status_description(@info_request, 'waiting_classification')).to eq('Awaiting classification')
+      expect(status_description(@info_request, 'waiting_classification')).
+        to eq('Awaiting classification')
     end
 
     it 'should call theme_display_status for a theme status' do
-      allow(@info_request).to receive(:theme_display_status).and_return("Special status")
-      expect(status_description(@info_request, 'special_status')).to eq('Special status')
+      allow(@info_request).to receive(:theme_display_status).
+        and_return("Special status")
+      expect(status_description(@info_request, 'special_status')).
+        to eq('Special status')
     end
 
     it 'should return unknown for an unknown status' do
-      expect(status_description(@info_request, 'special_status')).to eq('Unknown')
+      expect(status_description(@info_request, 'special_status')).
+        to eq('Unknown')
     end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)
#7739
## What does this do?
This corrects _most_ of the Layout/LineLength linting issues in the `spec/helper` files
The linting issues it doesn't correct are more complex `Q%()` strings
## Why was this needed?
Improve maintainability of codebase
## Implementation notes

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
