### PR TITLE
Add basic admin notes index

### DIFF
--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -2,6 +2,10 @@ class Admin::NotesController < AdminController
   include Admin::TagHelper
   include TranslatableParams
 
+  def index
+    @notes = Note.paginate(page: params[:page], per_page: 50)
+  end
+
   def new
     @note = scope.build
     @note.build_all_translations

--- a/app/views/admin/notes/_show.html.erb
+++ b/app/views/admin/notes/_show.html.erb
@@ -26,8 +26,10 @@
   <% end %>
 </div>
 
-<div class="row">
-  <p class="span12">
-    <%= link_to "New note", new_admin_note_path(notable_type: notable.class, notable_id: notable), class: "btn btn-info" %>
-  </p>
-</div>
+<% if notable %>
+  <div class="row">
+    <p class="span12">
+      <%= link_to "New note", new_admin_note_path(notable_type: notable.class, notable_id: notable), class: "btn btn-info" %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/admin/notes/index.html.erb
+++ b/app/views/admin/notes/index.html.erb
@@ -1,0 +1,18 @@
+<div class="row">
+  <div class="span12">
+    <div class="page-header">
+      <h1><%= @title = 'Notes' %></h1>
+    </div>
+  </div>
+</div>
+
+<div class="row">
+  <div class="span12">
+    <p class="lead">Create notes either directly on a record or <%= link_to 'via a tag', admin_tags_path %>.</p>
+  </div>
+</div>
+
+<%= render partial: 'admin/notes/show',
+           locals: { notes: @notes, notable: nil } %>
+
+<%= will_paginate(@notes) %>

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -57,6 +57,7 @@
               <li><%= link_to 'Blog Posts', admin_blog_posts_path %></li>
               <li><%= link_to 'Censor Rules', admin_censor_rules_path %></li>
               <li><%= link_to 'Holidays', admin_holidays_path %></li>
+              <li><%= link_to 'Notes', admin_notes_path %></li>
               <li><%= link_to 'Spam Addresses', admin_spam_addresses_path %></li>
             </ul>
           </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -537,7 +537,7 @@ Rails.application.routes.draw do
 
   #### AdminNote controller
   namespace :admin do
-    resources :notes, except: [:index, :show]
+    resources :notes, except: [:show]
   end
 
   direct :admin_note_parent do |note|

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add basic admin notes index page (Gareth Rees)
 * Add link from incoming message to admin page for attachments (Gareth Rees)
 * Add XSLX spreadsheet analyser to automatically detect hidden data (Helen
   Cross, Graeme Porteous)

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -3,6 +3,22 @@ require 'spec_helper'
 RSpec.describe Admin::NotesController do
   before(:each) { basic_auth_login(@request) }
 
+  describe 'GET index' do
+    before { get :index }
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'assigns the notes' do
+      expect(assigns[:notes]).to all(be_a(Note))
+    end
+
+    it 'renders the correct template' do
+      expect(response).to render_template(:index)
+    end
+  end
+
   describe 'GET new' do
     before { get :new }
 

--- a/spec/views/admin/notes/_show.html.erb_spec.rb
+++ b/spec/views/admin/notes/_show.html.erb_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe 'admin/notes/show' do
+  subject { rendered }
+
+  def render_view
+    render partial: self.class.top_level_description,
+           locals: { notes: notes, notable: notable }
+  end
+
+  before { render_view }
+
+  context 'with notes' do
+    let(:notes) { FactoryBot.create_list(:note, 2) }
+    let(:notable) { double }
+    # TODO: Improve CSS class name
+    it { is_expected.to match(/censor-rule-list/) }
+  end
+
+  context 'with no notes' do
+    let(:notes) { [] }
+    let(:notable) { double }
+    it { is_expected.to match(/None yet/) }
+  end
+
+  context 'with a notable' do
+    let(:notes) { [] }
+    let(:notable) { double }
+    it { is_expected.to match(/New note/) }
+  end
+
+  context 'with no notable' do
+    let(:notes) { [] }
+    let(:notable) { nil }
+    it { is_expected.not_to match(/New note/) }
+  end
+end


### PR DESCRIPTION
Allow admins to view all notes in one place and navigate to any Note's Notable record.

The use case here is that I'm dealing with some support and want to add a note. I know a similar note will have been added in the past, so I want to base my note off that (for speed, consistency, checking I'm saying the right thing, etc). It's basically impossible to find the kind of note I'm thinking of without them in a list.

Ideally this will evolve to include the usual search & sort filtering, but even as-is it helps since I can just paginate to the end to see recent notes (which is likely where what I want will be).

![Screenshot 2023-12-20 at 09 58 48](https://github.com/mysociety/alaveteli/assets/282788/4528176d-287c-446f-9b8f-1250fcf668ff)

Screenshot paginates 1-per-page to check that it works.



