### PR TITLE
[#7996] Fix default Guess scores

### DIFF
--- a/app/models/guess.rb
+++ b/app/models/guess.rb
@@ -39,13 +39,13 @@ class Guess
   end
 
   def id_score
-    return 1 unless self[:id]
+    return 0 unless self[:id]
 
     similarity(self[:id], info_request.id)
   end
 
   def idhash_score
-    return 1 unless self[:idhash]
+    return 0 unless self[:idhash]
 
     similarity(self[:idhash], info_request.idhash)
   end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix default holding pen guess scores (Gareth Rees)
 * Add link from incoming message to admin page for attachments (Gareth Rees)
 * Add XSLX spreadsheet analyser to automatically detect hidden data (Helen
   Cross, Graeme Porteous)

--- a/spec/models/guess_spec.rb
+++ b/spec/models/guess_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe Guess do
   describe 'with a subject line given' do
     let(:guess) { described_class.new(info_request, subject: 'subject_line') }
 
-    it 'returns an id_score of 1' do
-      expect(guess.id_score).to eq(1)
+    it 'returns an id_score of 0' do
+      expect(guess.id_score).to eq(0)
     end
 
-    it 'returns an idhash_score of 1' do
-      expect(guess.idhash_score).to eq(1)
+    it 'returns an idhash_score of 0' do
+      expect(guess.idhash_score).to eq(0)
     end
   end
 


### PR DESCRIPTION
The default score should be 0 - as in, no match – unless we actually have some sort of similarity on the attribute. Since these are guard clauses for when there is no attribute, we should return a value that implies there isn't a match.

Fixes https://github.com/mysociety/alaveteli/issues/7996