### PR TITLE
Refactor attachment logging

### DIFF
--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -9,15 +9,9 @@ class Admin::FoiAttachmentsController < AdminController
   end
 
   def update
-    if @foi_attachment.update(foi_attachment_params)
-      @foi_attachment.log_event(
-        'edit_attachment',
-        attachment_id: @foi_attachment.id,
-        editor: admin_current_user,
-        old_prominence: @foi_attachment.prominence_previously_was,
-        prominence: @foi_attachment.prominence,
-        old_prominence_reason: @foi_attachment.prominence_reason_previously_was,
-        prominence_reason: @foi_attachment.prominence_reason
+    if @foi_attachment.update_and_log_event(
+        **foi_attachment_params,
+        event: { editor: admin_current_user }
       )
       @foi_attachment.expire
 

--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -10,7 +10,7 @@ class Admin::FoiAttachmentsController < AdminController
 
   def update
     if @foi_attachment.update(foi_attachment_params)
-      @info_request.log_event(
+      @foi_attachment.log_event(
         'edit_attachment',
         attachment_id: @foi_attachment.id,
         editor: admin_current_user,
@@ -19,7 +19,7 @@ class Admin::FoiAttachmentsController < AdminController
         old_prominence_reason: @foi_attachment.prominence_reason_previously_was,
         prominence_reason: @foi_attachment.prominence_reason
       )
-      @info_request.expire
+      @foi_attachment.expire
 
       flash[:notice] = 'Attachment successfully updated.'
       redirect_to edit_admin_incoming_message_path(@incoming_message)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -62,7 +62,7 @@ class Ability
         !message.info_request.embargo
       end
       can :_read, FoiAttachment do |attachment|
-        !attachment.incoming_message.info_request.embargo
+        !attachment.info_request.embargo
       end
     end
 

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -338,6 +338,21 @@ class FoiAttachment < ApplicationRecord
     )
   end
 
+  def update_and_log_event(event: {}, **params)
+    return false unless update(params)
+
+    log_event(
+      'edit_attachment',
+      event.merge(
+        attachment_id: id,
+        old_prominence: prominence_previously_was,
+        prominence: prominence,
+        old_prominence_reason: prominence_reason_previously_was,
+        prominence_reason: prominence_reason
+      )
+    )
+  end
+
   private
 
   def load_attachment_from_incoming_message!

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -35,8 +35,8 @@ class FoiAttachment < ApplicationRecord
 
   MissingAttachment = Class.new(StandardError)
 
-  belongs_to :incoming_message,
-             inverse_of: :foi_attachments
+  belongs_to :incoming_message, inverse_of: :foi_attachments
+  has_one :info_request, through: :incoming_message, source: :info_request
   has_one :raw_email, through: :incoming_message, source: :raw_email
 
   has_one_attached :file, service: :attachments
@@ -49,6 +49,8 @@ class FoiAttachment < ApplicationRecord
   before_destroy :delete_cached_file!
 
   scope :binary, -> { where.not(content_type: AlaveteliTextMasker::TextMask) }
+
+  delegate :expire, :log_event, to: :info_request
 
   admin_columns exclude: %i[url_part_number within_rfc822_subject hexdigest]
 
@@ -251,7 +253,7 @@ class FoiAttachment < ApplicationRecord
   def display_filename
     filename = self.filename
     unless incoming_message.nil?
-      filename = incoming_message.info_request.apply_censor_rules_to_text(filename)
+      filename = info_request.apply_censor_rules_to_text(filename)
     end
     # Sometimes filenames have e.g. %20 in - no point butchering that
     # (without unescaping it, this would remove the % and leave 20s in there)
@@ -324,7 +326,7 @@ class FoiAttachment < ApplicationRecord
 
   def cached_urls
     [
-      request_path(incoming_message.info_request)
+      request_path(info_request)
     ]
   end
 

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe FoiAttachment do
       att = FactoryBot.create(:jpeg_attachment)
       im = FactoryBot.create(:plain_incoming_message)
       att.incoming_message = im
-      request_path = "/request/" + att.incoming_message.info_request.url_title
+      request_path = "/request/" + att.info_request.url_title
       expect(att.cached_urls).to eq([request_path])
     end
   end
@@ -421,6 +421,26 @@ RSpec.describe FoiAttachment do
     context 'when the content_type has no name' do
       let(:content_type) { 'content/unnamed' }
       it { is_expected.to be_nil }
+    end
+  end
+
+  describe '#expire' do
+    let(:incoming_message) { FactoryBot.create(:incoming_message) }
+    let(:foi_attachment) { incoming_message.foi_attachments.first }
+
+    it 'delegates to info_request' do
+      expect(foi_attachment.info_request).to receive(:expire)
+      foi_attachment.expire
+    end
+  end
+
+  describe '#log_event' do
+    let(:incoming_message) { FactoryBot.create(:incoming_message) }
+    let(:foi_attachment) { incoming_message.foi_attachments.first }
+
+    it 'delegates to info_request' do
+      expect(foi_attachment.info_request).to receive(:log_event).with('edit')
+      foi_attachment.log_event('edit')
     end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Extracted from #8060

## What does this do?

Refactor attachment logging.

## Why was this needed?

Make it easier to log changes to attachments from other parts of the code. IE automated tasks.

## Implementation notes

No functional difference.

<hr>

[skip changelog]