### PR TITLE
Update spec login helper

### DIFF
--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -106,10 +106,10 @@ def using_pro_session(session_id)
   end
 end
 
-def login(user)
+def login(user, **params)
   u = user.is_a?(User) ? user : users(user)
   alaveteli_session(u.id) do
-    visit 'en/profile/sign_in'
+    visit signin_path(locale: 'en', **params)
     within '#signin_form' do
       fill_in "Your e-mail:", with: u.email
       fill_in "Password:", with: "jonespassword"


### PR DESCRIPTION
Allow specs to specify params for the signin path. EG. `r: '/help'` will redirect to the help pages instead of the homepage after login.

This is useful in theme specs. For example with WDTK theme the homepage might attempt to load remote content which isn't stubbed.

<hr>

[skip changelog]