### PR TITLE
Add metadata in FoiAttachment admin columns

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -51,8 +51,10 @@ class FoiAttachment < ApplicationRecord
   scope :binary, -> { where.not(content_type: AlaveteliTextMasker::TextMask) }
 
   delegate :expire, :log_event, to: :info_request
+  delegate :metadata, to: :file_blob
 
-  admin_columns exclude: %i[url_part_number within_rfc822_subject hexdigest]
+  admin_columns exclude: %i[url_part_number within_rfc822_subject hexdigest],
+                include: %i[metadata]
 
   BODY_MAX_TRIES = 3
   BODY_MAX_DELAY = 5

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Display metadata on admin attachment views (Graeme Porteous)
 * Change request URL patterns to only use titles rather than request IDs
   (Alexander Griffen, Graeme Porteous)
 * Colourise holding pen guess scores (Gareth Rees)


### PR DESCRIPTION
## What does this do?

Add metadata in FoiAttachment admin columns

## Why was this needed?

It will be useful to show details about attachments analyzed via ActiveStorage analyzers.

## Implementation notes

For @HelenWDTK 

## Screenshots

![294923999-ffba3628-31e0-4bc9-85c9-1c62b347324a](https://github.com/mysociety/alaveteli/assets/5426/7174e5fb-817d-49ef-8f83-49ea5aa13a71)

