### PR TITLE
[#8081] Update type of authority helper

### DIFF
--- a/app/helpers/public_body_helper.rb
+++ b/app/helpers/public_body_helper.rb
@@ -37,7 +37,7 @@ module PublicBodyHelper
   #
   # Returns a String
   def type_of_authority(public_body)
-    categories = PublicBodyCategory.
+    categories = PublicBody.categories.
       where(category_tag: public_body.tag_string.split).order(:id)
 
     types = categories.each_with_index.map do |category, index|

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
     title { 'Popular authorities' }
     description { 'The most popular authorities' }
     category_tag { 'popular_agency' }
+
+    trait :public_body do
+      parents { [PublicBody.category_root] }
+    end
   end
 end

--- a/spec/helpers/public_body_helper_spec.rb
+++ b/spec/helpers/public_body_helper_spec.rb
@@ -54,10 +54,11 @@ RSpec.describe PublicBodyHelper do
     end
 
     it 'handles Unicode' do
-      category = FactoryBot.create(:public_body_category, category_tag: 'spec',
-                                   description: 'ünicode category')
-      heading = FactoryBot.create(:public_body_heading)
-      heading.add_category(category)
+      FactoryBot.create(
+        :category, :public_body,
+        category_tag: 'spec',
+        description: 'ünicode category'
+      )
       public_body = FactoryBot.create(:public_body, tag_string: 'spec')
 
       expect(type_of_authority(public_body)).
@@ -65,15 +66,12 @@ RSpec.describe PublicBodyHelper do
     end
 
     it 'constructs the correct string if there are tags which are not categories' do
-      heading = FactoryBot.create(:public_body_heading)
       3.times do |i|
-        category = FactoryBot.
-          create(
-            :public_body_category,
-            category_tag: "spec_#{i}",
-            description: "spec category #{i}"
-          )
-        heading.add_category(category)
+        FactoryBot.create(
+          :category, :public_body,
+          category_tag: "spec_#{i}",
+          description: "spec category #{i}"
+        )
       end
       public_body = FactoryBot.create(
         :public_body,
@@ -86,13 +84,11 @@ RSpec.describe PublicBodyHelper do
 
     context 'when associated with one category' do
       it 'returns the description wrapped in an anchor tag' do
-        category = FactoryBot.create(
-          :public_body_category,
+        FactoryBot.create(
+          :category, :public_body,
           category_tag: 'spec',
           description: 'spec category'
         )
-        heading = FactoryBot.create(:public_body_heading)
-        heading.add_category(category)
         public_body = FactoryBot.create(:public_body, tag_string: 'spec')
 
         anchor = %Q(<a href="/body/list/spec">Spec category</a>)
@@ -102,14 +98,12 @@ RSpec.describe PublicBodyHelper do
 
     context 'when associated with several categories' do
       it 'joins the category descriptions and capitalizes the first letter' do
-        heading = FactoryBot.create(:public_body_heading)
         3.times do |i|
-          category = FactoryBot.create(
-            :public_body_category,
+          FactoryBot.create(
+            :category, :public_body,
             category_tag: "spec_#{i}",
             description: "spec category #{i}"
           )
-          heading.add_category(category)
         end
         public_body = FactoryBot.create(
           :public_body,
@@ -132,13 +126,11 @@ RSpec.describe PublicBodyHelper do
       it 'creates the anchor href in the correct locale' do
         # Activate the routing filter, normally turned off for helper tests
         RoutingFilter.active = true
-        category = FactoryBot.create(
-          :public_body_category,
+        FactoryBot.create(
+          :category, :public_body,
           category_tag: 'spec',
           description: 'spec category'
         )
-        heading = FactoryBot.create(:public_body_heading)
-        heading.add_category(category)
         public_body = FactoryBot.create(:public_body, tag_string: 'spec')
 
         anchor = %Q(<a href="/es/body/list/spec">Spec category</a>)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8081

## What does this do?

Update type of authority helper

## Why was this needed?

Updated to use new category system introduced in #8023 over the older `PublicBodyCategory` model which isn't being updated anymore.

<hr>

[skip changelog]