### PR TITLE
[#8086] Fix request redirect with format

### DIFF
--- a/config/routes/redirects.rb
+++ b/config/routes/redirects.rb
@@ -26,7 +26,8 @@ info_request_redirect = redirect do |params, request|
   end
 
   # join encoded parts together with slashes
-  encoded_parts.join('/')
+  base = encoded_parts.join('/')
+  params[:format] ? "#{base}.#{params[:format]}" : base
 end
 
 get '/request/:id',

--- a/spec/routing/redirects_spec.rb
+++ b/spec/routing/redirects_spec.rb
@@ -6,6 +6,11 @@ RSpec.describe 'routing redirects', type: :request do
     expect(response).to redirect_to('/request/the_cost_of_boring')
   end
 
+  it 'routes numerical format request route to URL title format route' do
+    get('/request/105.json')
+    expect(response).to redirect_to('/request/the_cost_of_boring.json')
+  end
+
   it 'redirects numerical request routes with locales' do
     get('/fr/request/105')
     expect(response).to redirect_to('/fr/request/the_cost_of_boring')

--- a/spec/routing/redirects_spec.rb
+++ b/spec/routing/redirects_spec.rb
@@ -39,4 +39,35 @@ RSpec.describe 'routing redirects', type: :request do
       '/request/the_cost_of_boring/response/1/attach/html/2/filename.txt.html'
     )
   end
+
+  it 'redirects prefixed request routes to member routes' do
+    get('/details/request/the_cost_of_boring')
+    expect(response).to redirect_to('/request/the_cost_of_boring/details')
+
+    get('/similar/request/the_cost_of_boring')
+    expect(response).to redirect_to('/request/the_cost_of_boring/similar')
+
+    get('/upload/request/the_cost_of_boring')
+    expect(response).to redirect_to('/request/the_cost_of_boring/upload')
+
+    get('/annotate/request/the_cost_of_boring')
+    expect(response).to redirect_to('/request/the_cost_of_boring/annotate')
+
+    get('/track/request/the_cost_of_boring')
+    expect(response).to redirect_to('/request/the_cost_of_boring/track')
+
+    get('/feed/request/the_cost_of_boring')
+    expect(response).to redirect_to('/request/the_cost_of_boring/feed')
+
+    get('/categorise/request/the_cost_of_boring')
+    expect(response).to redirect_to('/request/the_cost_of_boring/categorise')
+  end
+
+  it 'redirects prefixed request routes with locales' do
+    get('/fr/details/request/the_cost_of_boring')
+    expect(response).to redirect_to('/fr/request/the_cost_of_boring/details')
+
+    get('/en_GB/details/request/the_cost_of_boring')
+    expect(response).to redirect_to('/en_GB/request/the_cost_of_boring/details')
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8086

## What does this do?

Fix request ID redirect with format

## Why was this needed?

Broken existing links.

<hr>

[skip changelog]
