### PR TITLE
[#8081] Fixes type of authority helper

### DIFF
--- a/app/helpers/public_body_helper.rb
+++ b/app/helpers/public_body_helper.rb
@@ -37,7 +37,7 @@ module PublicBodyHelper
   #
   # Returns a String
   def type_of_authority(public_body)
-    categories = PublicBody.categories.
+    categories = PublicBody.category_list.
       where(category_tag: public_body.tag_string.split).order(:id)
 
     types = categories.each_with_index.map do |category, index|

--- a/app/models/concerns/categorisable.rb
+++ b/app/models/concerns/categorisable.rb
@@ -18,5 +18,9 @@ module Categorisable
     def self.categories
       category_root.tree
     end
+
+    def self.category_list
+      category_root.list
+    end
   end
 end

--- a/spec/helpers/public_body_helper_spec.rb
+++ b/spec/helpers/public_body_helper_spec.rb
@@ -82,10 +82,11 @@ RSpec.describe PublicBodyHelper do
       expect(type_of_authority(public_body)).to eq(expected)
     end
 
-    context 'when associated with one category' do
+    context 'when categories are descendents of non-root parents' do
       it 'returns the description wrapped in an anchor tag' do
         FactoryBot.create(
-          :category, :public_body,
+          :category,
+          parents: [FactoryBot.build(:category, :public_body)],
           category_tag: 'spec',
           description: 'spec category'
         )
@@ -94,13 +95,12 @@ RSpec.describe PublicBodyHelper do
         anchor = %Q(<a href="/body/list/spec">Spec category</a>)
         expect(type_of_authority(public_body)).to eq(anchor)
       end
-    end
 
-    context 'when associated with several categories' do
       it 'joins the category descriptions and capitalizes the first letter' do
         3.times do |i|
           FactoryBot.create(
-            :category, :public_body,
+            :category,
+            parents: [FactoryBot.build(:category, :public_body)],
             category_tag: "spec_#{i}",
             description: "spec category #{i}"
           )

--- a/spec/models/concerns/categorisable.rb
+++ b/spec/models/concerns/categorisable.rb
@@ -13,4 +13,11 @@ RSpec.shared_examples 'concerns/categorisable' do |factory_opts|
       described_class.categories
     end
   end
+
+  describe '.category_list' do
+    it 'calls category_root.list' do
+      expect(described_class).to receive_message_chain(:category_root, :list)
+      described_class.category_list
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8081

## What does this do?

Fixes type of authority helper

## Why was this needed?

Add Category list method to return a flat list of categories for a given root. This will be useful in places as this replicates to functionality of the older `PublicBodyCategory` model.

<hr>

[skip changelog]
