### PR TITLE
[#7682] Fix admin timeline edit outgoing events

### DIFF
--- a/app/views/admin_general/_edit_outgoing.html.erb
+++ b/app/views/admin_general/_edit_outgoing.html.erb
@@ -1,7 +1,7 @@
-<% outgoing_message = OutgoingMessage.find(event.params[:outgoing_message_id].to_i) %>
+<% outgoing_message = event.outgoing_message %>
 had outgoing message edited by administrator <strong><%= event.params[:editor] %></strong>.
 <% if outgoing_message %>
   <%= event_params_description(event) %>
 <% else %>
-Missing outgoing message, internal error.
+  Missing outgoing message, internal error.
 <% end %>


### PR DESCRIPTION


## Relevant issue(s)

Fixes #7682

## What does this do?

Fix admin timeline edit outgoing events

## Why was this needed?

When an outgoing message is edited the admin timeline breaks. This is due to changes in how the event params are stored in #7173.

<hr>

[skip changelog]