### PR TITLE
[#7986] Improve redirection flow for user closure actions

### DIFF
--- a/app/controllers/admin_users_account_anonymising_controller.rb
+++ b/app/controllers/admin_users_account_anonymising_controller.rb
@@ -11,7 +11,7 @@ class AdminUsersAccountAnonymisingController < AdminController
       flash[:error] = 'Something went wrong. The user could not be anonymised.'
     end
 
-    redirect_to admin_user_path(@anonymised_user)
+    redirect_to edit_admin_user_path(@anonymised_user)
   end
 
   private

--- a/app/controllers/admin_users_account_closing_controller.rb
+++ b/app/controllers/admin_users_account_closing_controller.rb
@@ -12,7 +12,7 @@ class AdminUsersAccountClosingController < AdminController
         'Something went wrong. The user account could not be closed.'
     end
 
-    redirect_to admin_user_path(@closed_user)
+    redirect_to edit_admin_user_path(@closed_user)
   end
 
   private

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Improve redirection flow after user account closure actions (Gareth Rees)
 * Fix duplicated attachment masking jobs (Graeme Porteous)
 * Display metadata on admin attachment views (Graeme Porteous)
 * Change request URL patterns to be member routes (Alexander Griffen, Graeme

--- a/spec/controllers/admin_users_account_anonymising_controller_spec.rb
+++ b/spec/controllers/admin_users_account_anonymising_controller_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe AdminUsersAccountAnonymisingController do
         expect(assigns[:anonymised_user]).to eq(user)
       end
 
-      it 'redirects to the user page' do
-        expect(response).to redirect_to(admin_user_path(user))
+      it 'redirects to the user edit page' do
+        expect(response).to redirect_to(edit_admin_user_path(user))
       end
 
       context 'on an open account' do

--- a/spec/controllers/admin_users_account_closing_controller_spec.rb
+++ b/spec/controllers/admin_users_account_closing_controller_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe AdminUsersAccountClosingController do
         expect(flash[:notice]).to eq('The user account was closed.')
       end
 
-      it 'redirects to the user page' do
-        expect(response).to redirect_to(admin_user_path(user))
+      it 'redirects to the user edit page' do
+        expect(response).to redirect_to(edit_admin_user_path(user))
       end
     end
 


### PR DESCRIPTION
In practice we often use all three closure actions in a single step – Close; Anonymise; Erase. It's annoying to get taken back to the show page and then have to go back in to edit to take the next action, and so on.

This commit returns you to the edit page for the Close and Anonymise actions. Once an account gets erased, you're returned to the show page to signify the "end" of the possible actions.

Fixes https://github.com/mysociety/alaveteli/issues/7986.
