### PR TITLE
Add admin link to notes

### DIFF
--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -6,12 +6,7 @@ module NotesHelper
 
     tag.aside(**options.merge(id: 'notes')) do
       notes.each do |note|
-        note_classes = ['note']
-        note_classes << "tag-#{note.notable_tag}" if note.notable_tag
-
-        concat tag.article sanitize(note.body, tags: allowed_tags),
-                           id: dom_id(note),
-                           class: note_classes
+        concat render_note(note, allowed_tags: allowed_tags)
       end
     end
   end
@@ -24,5 +19,19 @@ module NotesHelper
 
   def batch_notes_allowed_tags
     notes_allowed_tags - %w(pre h1 h2 h3 h4 h5 h6 img blockquote font iframe)
+  end
+
+  private
+
+  def render_note(note, allowed_tags: notes_allowed_tags)
+    note_classes = ['note']
+    note_classes << "tag-#{note.notable_tag}" if note.notable_tag
+
+    locals = {
+      note_classes: note_classes,
+      allowed_tags: allowed_tags
+    }
+
+    render partial: note, locals: locals
   end
 end

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,3 +1,9 @@
 <%= tag.article(id: dom_id(note), class: note_classes) do %>
   <%= sanitize(note.body, tags: allowed_tags) %>
+
+  <% if @user&.admin_page_links? %>
+    <p class="event_actions">
+      <%= link_to 'Admin', edit_admin_note_path(note) %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,0 +1,3 @@
+<%= tag.article(id: dom_id(note), class: note_classes) do %>
+  <%= sanitize(note.body, tags: allowed_tags) %>
+<% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add admin link to notes (Gareth Rees)
 * Display metadata on admin attachment views (Graeme Porteous)
 * Change request URL patterns to be member routes (Alexander Griffen, Graeme
   Porteous)


### PR DESCRIPTION


![Screenshot 2024-01-17 at 18 06 44](https://github.com/mysociety/alaveteli/assets/282788/23f5623c-13e4-460b-90ad-2710aa9930ef)

```html
<aside class="authority__header__notes" id="notes">
  <article id="note_1" class="note">
    <h1>
      title
    </h1>A note
    <p class="event_actions">
      <a href="/admin/notes/1/edit">Admin</a>
    </p>
  </article>
  <article id="note_4" class="note">
    Another note!
    <p class="event_actions">
      <a href="/admin/notes/4/edit">Admin</a>
    </p>
  </article>
  <article id="note_5" class="note tag-foo">
    A foo-ey note
    <p class="event_actions">
      <a href="/admin/notes/5/edit">Admin</a>
    </p>
  </article>
</aside>
```