### PR TITLE
Treat unstemmed words as normal search terms.

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Treat unstemmed words as normal search terms. (Matthew Somerville)
 * Fix duplicated attachment masking jobs (Graeme Porteous)
 * Display metadata on admin attachment views (Graeme Porteous)
 * Change request URL patterns to be member routes (Alexander Griffen, Graeme

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -411,11 +411,8 @@ module ActsAsXapian
       #x = ''
       query.terms.each do |t|
         term = t.term
-        #x = x + term.to_yaml + term.size.to_s + term[0..0] + "*"
-        if term.size >= 2 && term[0..0] == 'Z'
-          # normal terms begin Z (for stemmed), then have no capital letter prefix
-          ret = true if term[1..1] == term[1..1].downcase
-        end
+        # normal terms begin Z (for stemmed), or have no capital letter prefix
+        ret = true if term[0..0] == 'Z' || term[0..0] == term[0..0].downcase
       end
       ret
     end

--- a/spec/lib/acts_as_xapian_spec.rb
+++ b/spec/lib/acts_as_xapian_spec.rb
@@ -246,4 +246,28 @@ RSpec.describe ActsAsXapian::Search do
       expect(s.spelling_correction).to eq("bôbby")
     end
   end
+
+  describe '#has_normal_search_terms?' do
+    it 'return false for prefixed search queries' do
+      search = ActsAsXapian::Search.new([PublicBody], 'tag:foo', limit: 1)
+      expect(search.has_normal_search_terms?).to eq(false)
+    end
+
+    it 'return true for prefixed search queries with normal search term' do
+      search = ActsAsXapian::Search.new([PublicBody], 'tag:foo nhs', limit: 1)
+      expect(search.has_normal_search_terms?).to eq(true)
+    end
+
+    it 'return true for normal search term' do
+      search = ActsAsXapian::Search.new([PublicBody], 'nhs', limit: 1)
+      expect(search.has_normal_search_terms?).to eq(true)
+    end
+
+    it 'treats unstemmed words as normal search terms' do
+      search = ActsAsXapian::Search.new([PublicBody], 'NHS', limit: 1)
+      expect(search.has_normal_search_terms?).to eq(true)
+      search = ActsAsXapian::Search.new([PublicBody], 'tag:foo NHS', limit: 1)
+      expect(search.has_normal_search_terms?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/4426

## What does this do?

has_normal_search_terms? was only returning true if the query had a stemmed search term in it, such as Zterm. Searching for a word with capital letters, such as NHS, translates to an unstemmed query term “nhs”. This would not match and the search would default to sorting by newest rather than relevance. Unstemmed query terms should still match as a normal search term, not a prefixed one.

## Why was this needed?

The default search results should not change their sort order based solely upon the capitalisation of the search provided.