### PR TITLE
Update attachment body assignment

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -94,11 +94,15 @@ class FoiAttachment < ApplicationRecord
     self.hexdigest ||= Digest::MD5.hexdigest(d)
 
     ensure_filename!
-    file.attach(
-      io: StringIO.new(d.to_s),
-      filename: filename,
-      content_type: content_type
-    )
+    if file.attached?
+      file_blob.upload(StringIO.new(d.to_s), identify: false)
+    else
+      file.attach(
+        io: StringIO.new(d.to_s),
+        filename: filename,
+        content_type: content_type
+      )
+    end
 
     @cached_body = d.force_encoding("ASCII-8BIT")
     update_display_size!

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Reduce amount of storage related background jobs (Graeme Porteous)
 * Add admin list of all citations (Gareth Rees)
 * Improve redirection flow after user account closure actions (Gareth Rees)
 * Fix duplicated attachment masking jobs (Graeme Porteous)

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -107,6 +107,24 @@ RSpec.describe FoiAttachment do
         ActiveStorage::Blob.services.fetch(blob.service_name).exist?(blob.key)
       }.from(false).to(true)
     end
+
+    it 'does not reset existing blob key' do
+      attachment = FactoryBot.create(
+        :foi_attachment, :unmasked, body: 'unmasked'
+      )
+
+      expect { attachment.update(body: 'masked', masked_at: Time.now) }.
+        to_not change { attachment.file_blob.key }
+    end
+
+    it 'does not reset existing blob metadata' do
+      attachment = FactoryBot.create(
+        :foi_attachment, :unmasked, body: 'unmasked'
+      )
+
+      expect { attachment.update(body: 'masked', masked_at: Time.now) }.
+        to_not change { attachment.file_blob.metadata }
+    end
   end
 
   describe '#body' do


### PR DESCRIPTION
## What does this do?

Update attachment body assignment

## Why was this needed?

When masking attachments avoid replacing the blob with a new blob, instead update which retains the blob key and existing metadata.

This means no `ActiveStorage::PurgeJob` or an additional `ActiveStorage::AnalyzeJob` for the new blob.

