### PR TITLE
8129 list attachments on info request admin page

### DIFF
--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -335,4 +335,8 @@ module InfoRequestHelper
   def public_token?
     defined?(public_token) && public_token.present?
   end
+
+  def fetch_foi_attachments(info_request)
+    info_request.incoming_messages.includes(:foi_attachments).flat_map(&:foi_attachments)
+  end
 end

--- a/app/helpers/info_request_helper.rb
+++ b/app/helpers/info_request_helper.rb
@@ -337,6 +337,9 @@ module InfoRequestHelper
   end
 
   def fetch_foi_attachments(info_request)
-    info_request.incoming_messages.includes(:foi_attachments).flat_map(&:foi_attachments)
+  info_request.incoming_messages
+              .includes(:foi_attachments)
+              .flat_map(&:foi_attachments)
+              .reject(&:main_body_part?)
   end
 end

--- a/app/views/admin_request/_some_attachments.html.erb
+++ b/app/views/admin_request/_some_attachments.html.erb
@@ -1,0 +1,27 @@
+<fieldset id="attachments" class="form-horizontal">
+  <% foi_attachments = fetch_foi_attachments(@info_request) %>
+  <% if foi_attachments.any? %>
+    <table class="table">
+      <thead>
+        <tr>
+          <th>Attachment</th>
+          <th>Content Type</th>
+          <th>Hexdigest</th>
+          <th>Display Size</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% foi_attachments.each do |attachment| %>
+          <tr>
+            <td><%= both_links attachment %></td>
+            <td><span class="monospace"><%= attachment.content_type %></span></td>
+            <td><span class="monospace"><%= attachment.hexdigest %></span></td>
+            <td><span class="monospace"><%= attachment.display_size %></span></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>None yet.</p>
+  <% end %>
+</fieldset>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -372,6 +372,11 @@
 
 <hr>
 
+<h2> Attachments </h2>
+<%= render partial: 'admin_request/some_attachments' %>
+
+<hr>
+
 <h2>Annotations</h2>
 
 <%= render partial: 'admin_request/some_annotations' ,


### PR DESCRIPTION
## Relevant issue(s)
Fixes #8129
## What does this do?
Adds attachment links on request admin page
## Why was this needed?
To make it easier to see attachments per request
## Implementation notes

## Screenshots
<img width="1049" alt="Screenshot 2024-02-12 at 21 58 22" src="https://github.com/mysociety/alaveteli/assets/120410992/c2b53ac6-53db-4df4-b83b-1f5f769af6bc">
<img width="968" alt="Screenshot 2024-02-12 at 21 58 42" src="https://github.com/mysociety/alaveteli/assets/120410992/d707413c-f997-4124-a4bb-dee54e2d2177">

## Notes to reviewer

This will probably need fixing, but is a proof of concept
