### PR TITLE
7302 add notes to outgoing and incoming messages

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -67,6 +67,7 @@ class IncomingMessage < ApplicationRecord
   has_many :info_request_events,
            dependent: :destroy,
            inverse_of: :incoming_message
+  has_many :notes, as: :notable
 
   belongs_to :raw_email,
              inverse_of: :incoming_message,

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -67,6 +67,7 @@ class OutgoingMessage < ApplicationRecord
   has_many :info_request_events,
            inverse_of: :outgoing_message,
            dependent: :destroy
+  has_many :notes, as: :notable
 
   delegate :public_body, to: :info_request, private: true, allow_nil: true
 

--- a/app/views/admin_incoming_message/edit.html.erb
+++ b/app/views/admin_incoming_message/edit.html.erb
@@ -44,3 +44,8 @@
 
 <%= render partial: 'foi_attachments',
            locals: { foi_attachments: @incoming_message.foi_attachments } %>
+<hr>
+<h2>Notes</h2>
+<%= render partial: 'admin/notes/show', 
+           locals: { notes: @incoming_message.notes, notable: @incoming_message } %>
+

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -113,4 +113,8 @@
     </div>
   </div>
 <% end %>
+<hr>
+<h2>Notes</h2>
+<%= render partial: 'admin/notes/show', 
+           locals: { notes: @outgoing_message.notes, notable: @outgoing_message } %>
 

--- a/app/views/request/_incoming_correspondence.html.erb
+++ b/app/views/request/_incoming_correspondence.html.erb
@@ -14,6 +14,8 @@
     <% end %>
   </div>
 
+  <%= render_notes(incoming_message.notes, class: 'message-notes') %>
+
   <%= render partial: 'request/prominence', locals: { prominenceable: incoming_message } %>
 
   <%- if can?(:read, incoming_message) %>

--- a/app/views/request/_outgoing_correspondence.html.erb
+++ b/app/views/request/_outgoing_correspondence.html.erb
@@ -27,6 +27,8 @@
       <p><%= link_to _('Try opening the logs in a new window.'), outgoing_message_delivery_status_path(outgoing_message), :target => '_blank' %></p>
     </div>
 
+    <%= render_notes(outgoing_message.notes, class: 'message-notes') %> 
+
     <div class="correspondence_text">
       <div><%= outgoing_message.get_body_for_html_display %></div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -553,6 +553,10 @@ Rails.application.routes.draw do
   direct :admin_note_parent do |note|
     if note.notable_tag
       admin_tag_path(tag: note.notable_tag)
+    elsif note.notable.is_a?(OutgoingMessage)
+      edit_admin_outgoing_message_path(note.notable)
+    elsif note.notable.is_a?(IncomingMessage)
+      edit_admin_incoming_message_path(note.notable)
     elsif note.notable
       url_for([:admin, note.notable])
     else


### PR DESCRIPTION
## Relevant issue(s)
 Based on #7302 
## What does this do?
Adds basic notes to incoming and outgoing messages
## Why was this needed?
Allows display of things like upload links at the right spot in the thread
## Implementation notes

## Screenshots
<img width="1034" alt="Screenshot 2024-02-16 at 10 01 06" src="https://github.com/mysociety/alaveteli/assets/120410992/318faf5c-fa53-42e1-8633-89274a27e7bd">
<img width="869" alt="Screenshot 2024-02-16 at 09 50 19" src="https://github.com/mysociety/alaveteli/assets/120410992/cf2e8524-4c9b-473a-a993-afa5b8f86bf4">
<img width="1232" alt="Screenshot 2024-02-16 at 10 02 34" src="https://github.com/mysociety/alaveteli/assets/120410992/1d9408ed-e88e-4aff-8da1-915b17e176cc">
<img width="1231" alt="Screenshot 2024-02-16 at 10 01 30" src="https://github.com/mysociety/alaveteli/assets/120410992/8da93fc7-f385-4534-91fe-191f60e78ee3">

## Notes to reviewer
Needs more work to work with tags, but this'd be an improvement. Might want to change where we display these depending.
<hr>
Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
(This is a draft!)