### PR TITLE
[ExcelAnalyzer] add on_hidden_metadata callback

### DIFF
--- a/gems/excel_analyzer/lib/excel_analyzer.rb
+++ b/gems/excel_analyzer/lib/excel_analyzer.rb
@@ -19,6 +19,18 @@ module ExcelAnalyzer
   # @return [Proc] the callable to run for spreadsheet attachments
   mattr_accessor :on_spreadsheet_received, default: ->(blob) {}
 
+  # A configurable callable that gets executed when an analyzed spreadsheet
+  # contains signs of hidden data. This can be useful for raising alerts,
+  # logging incidents, or taking other custom actions.
+  #
+  # @example Set a custom callable to handle hidden metadata detection
+  #   ExcelAnalyzer.on_hidden_metadata = ->(blob, metadata) { alert(blob) }
+  #
+  # @!attribute [rw] on_hidden_metadata
+  # @return [Proc] the callable to run when hidden metadata is detected in a
+  # spreadsheet
+  mattr_accessor :on_hidden_metadata, default: ->(blob, metadata) {}
+
   # Provides the list of content types that the ExcelAnalyzer will attempt to
   # analyze in search of hidden data. It currently includes content types for
   # .xls and .xlsx files.

--- a/gems/excel_analyzer/lib/excel_analyzer/xlsx_analyzer.rb
+++ b/gems/excel_analyzer/lib/excel_analyzer/xlsx_analyzer.rb
@@ -19,7 +19,15 @@ module ExcelAnalyzer
     end
 
     def metadata
-      { excel: excel_metadata }
+      data = excel_metadata
+
+      if suspected_problem?(data)
+        # rubocop:disable Style/RescueModifier
+        ExcelAnalyzer.on_hidden_metadata.call(blob, data) rescue nil
+        # rubocop:enable Style/RescueModifier
+      end
+
+      { excel: data }
     end
 
     private
@@ -28,6 +36,10 @@ module ExcelAnalyzer
       download_blob_to_tempfile(&method(:probe))
     rescue StandardError => ex
       { error: ex.message }
+    end
+
+    def suspected_problem?(data)
+      data.any? { |k, v| k != :error && k != :named_ranges && v > 1 }
     end
   end
 end

--- a/gems/excel_analyzer/spec/excel_analyzer/xlsx_analyzer_spec.rb
+++ b/gems/excel_analyzer/spec/excel_analyzer/xlsx_analyzer_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe ExcelAnalyzer::XlsxAnalyzer do
   end
 
   describe "#metadata" do
+    around do |example|
+      original_callback = ExcelAnalyzer.on_hidden_metadata
+      ExcelAnalyzer.on_hidden_metadata = ->(blob) {}
+      example.call
+      ExcelAnalyzer.on_hidden_metadata = original_callback
+    end
+
     let(:metadata) { ExcelAnalyzer::XlsxAnalyzer.new(blob).metadata }
 
     context "when the blob is an Excel file with hidden data" do
@@ -70,6 +77,11 @@ RSpec.describe ExcelAnalyzer::XlsxAnalyzer do
       it "detects pivot cache" do
         expect(metadata[:excel][:pivot_cache]).to eq 1
       end
+
+      it "does not call on_hidden_metadata callback" do
+        expect(ExcelAnalyzer.on_hidden_metadata).to receive(:call)
+        metadata
+      end
     end
 
     context "when the blob is an Excel file without hidden data" do
@@ -89,6 +101,11 @@ RSpec.describe ExcelAnalyzer::XlsxAnalyzer do
           pivot_cache: 0
         )
       end
+
+      it "does not call on_hidden_metadata callback" do
+        expect(ExcelAnalyzer.on_hidden_metadata).to_not receive(:call)
+        metadata
+      end
     end
 
     context "when the blob is not an Excel file" do
@@ -101,6 +118,11 @@ RSpec.describe ExcelAnalyzer::XlsxAnalyzer do
         expect(metadata[:excel]).to eq(
           error: "Zip end of central directory signature not found"
         )
+      end
+
+      it "does not call on_hidden_metadata callback" do
+        expect(ExcelAnalyzer.on_hidden_metadata).to_not receive(:call)
+        metadata
       end
     end
   end


### PR DESCRIPTION
## Relevant issue(s)

Required for #8048

## What does this do?

In the ExcelAnalyzer add on_hidden_metadata callback

## Why was this needed?

Allow a configurable block to be called if spreadsheets are received which contain suspect hidden data.

<hr>

[skip changelog]