### PR TITLE
[7787] Always use /request/ prefix

### DIFF
--- a/app/controllers/alaveteli_pro/classifications_controller.rb
+++ b/app/controllers/alaveteli_pro/classifications_controller.rb
@@ -10,7 +10,7 @@ class AlaveteliPro::ClassificationsController < AlaveteliPro::BaseController
     set_described_state
 
     flash[:notice] = _('Your request has been updated!')
-    redirect_to show_alaveteli_pro_request_path(
+    redirect_to show_request_path(
       url_title: @info_request.url_title
     )
   end

--- a/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
+++ b/app/controllers/alaveteli_pro/embargo_extensions_controller.rb
@@ -32,7 +32,7 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
                         "request's privacy settings, please try again.")
     end
 
-    redirect_to show_alaveteli_pro_request_path(
+    redirect_to show_request_path(
       url_title: @info_request.url_title
     )
   end
@@ -70,7 +70,7 @@ class AlaveteliPro::EmbargoExtensionsController < AlaveteliPro::BaseController
     if params[:info_request_id]
       @info_request = InfoRequest.find(params[:info_request_id])
 
-      redirect_to show_alaveteli_pro_request_path(
+      redirect_to show_request_path(
         url_title: @info_request.url_title
       )
     else

--- a/app/controllers/alaveteli_pro/embargoes_controller.rb
+++ b/app/controllers/alaveteli_pro/embargoes_controller.rb
@@ -66,7 +66,7 @@ class AlaveteliPro::EmbargoesController < AlaveteliPro::BaseController
     end
     if params[:info_request_id]
       @info_request = InfoRequest.find(params[:info_request_id])
-      redirect_to show_alaveteli_pro_request_path(
+      redirect_to show_request_path(
         url_title: @info_request.url_title)
     else
       redirect_to show_alaveteli_pro_batch_request_path(@info_request_batch)

--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -47,7 +47,7 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
       @embargo.save! if @embargo.present?
       send_initial_message(@outgoing_message)
       destroy_draft
-      redirect_to show_alaveteli_pro_request_path(
+      redirect_to show_request_path(
         url_title: @info_request.url_title)
     else
       show_errors

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -12,7 +12,6 @@ class RequestController < ApplicationController
   before_action :check_read_only, only: [:new, :upload_response]
   before_action :set_render_recaptcha, only: [ :new ]
   before_action :set_info_request, only: [:show]
-  before_action :redirect_public_requests_from_pro_context, only: [:show]
   before_action :redirect_new_form_to_pro_version, only: [:select_authority, :new]
   before_action :set_in_pro_area, only: [:select_authority, :show]
 
@@ -707,15 +706,6 @@ class RequestController < ApplicationController
   def set_render_recaptcha
     @render_recaptcha = AlaveteliConfiguration.new_request_recaptcha &&
                         (!@user || !@user.confirmed_not_spam?)
-  end
-
-  def redirect_public_requests_from_pro_context
-    # Requests which aren't embargoed should always go to the normal request
-    # page, so that pro's seem them in that context after they publish them
-    if feature_enabled?(:alaveteli_pro) && params[:pro] == "1"
-      @info_request = InfoRequest.find_by_url_title!(params[:url_title])
-      redirect_to request_url(@info_request) unless @info_request.embargo
-    end
   end
 
   def redirect_new_form_to_pro_version

--- a/app/services/info_request_batch_metrics.rb
+++ b/app/services/info_request_batch_metrics.rb
@@ -16,7 +16,7 @@ class InfoRequestBatchMetrics
   def metrics
     @metrics ||= @info_request_batch.info_requests.
       includes(public_body: :translations).map do |info_request|
-      url = show_alaveteli_pro_request_url(info_request.url_title)
+      url = show_request_url(info_request.url_title)
       status = InfoRequest::State.short_description(
         info_request.calculate_status(true)
       )

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -34,7 +34,7 @@
             <tr>
               <% if @info_request.embargo %>
                 <th>Request page:</th>
-                <td><%= link_to show_alaveteli_pro_request_url(@info_request.url_title), show_alaveteli_pro_request_path(@info_request.url_title) %></td>
+                <td><%= link_to show_request_url(@info_request.url_title), show_request_path(@info_request.url_title) %></td>
               <% else %>
                 <th>Public page:</th>
                 <td><%= link_to request_url(@info_request), request_path(@info_request) %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -907,13 +907,6 @@ Rails.application.routes.draw do
     end
 
     scope path: :alaveteli_pro do
-      # So that we can show a request using the existing controller from the
-      # pro context
-      match '/info_requests/:url_title' => 'request#show',
-            :as => :show_alaveteli_pro_request,
-            :via => :get,
-            :defaults => { :pro => '1' }
-
       # So that we can show a batch request using the existing controller from
       # the pro context
       match '/info_request_batches/:id' => 'info_request_batch#show',

--- a/config/routes/redirects.rb
+++ b/config/routes/redirects.rb
@@ -95,3 +95,9 @@ get ':locale',
 get ':locale/*path',
   constraints: locale_constraint,
   to: redirect('%{path}?locale=%{locale}')
+
+constraints FeatureConstraint.new(:alaveteli_pro) do
+  get '/alaveteli_pro/info_requests/:url_title',
+    constraints: { url_title: /(?!new).*/ },
+    to: redirect('/request/%{url_title}')
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Change use of `/alaveteli_pro/info_requests/{request}` to instead appear as
+  `/request/{request}` (Alexander Griffen, Graeme Porteous)
 * Remove locale prefixes from URLs (Alexander Griffen, Graeme Porteous)
 * Fix missing headers when exporting Project data (Gareth Rees)
 * Reduce amount of storage related background jobs (Graeme Porteous)

--- a/spec/controllers/alaveteli_pro/classifications_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/classifications_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
       it 'should redirect back to the request' do
         post_status('successful')
         expect(response).to redirect_to(
-          show_alaveteli_pro_request_path(url_title: info_request.url_title)
+          show_request_path(url_title: info_request.url_title)
         )
       end
     end
@@ -128,7 +128,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
       it 'should redirect back to the request' do
         post_status('error_message', message: 'A message')
         expect(response).to redirect_to(
-          show_alaveteli_pro_request_path(url_title: info_request.url_title)
+          show_request_path(url_title: info_request.url_title)
         )
       end
     end
@@ -169,7 +169,7 @@ RSpec.describe AlaveteliPro::ClassificationsController, type: :controller do
       it 'should redirect back to the request' do
         post_status('requires_admin', message: 'A message')
         expect(response).to redirect_to(
-          show_alaveteli_pro_request_path(url_title: info_request.url_title)
+          show_request_path(url_title: info_request.url_title)
         )
       end
     end

--- a/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_controller_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe AlaveteliPro::EmbargoesController do
       end
 
       it "redirects to that request, not the batch" do
-        expected_path = show_alaveteli_pro_request_path(
+        expected_path = show_request_path(
             url_title: info_request_batch.info_requests.first.url_title)
         expect(response).to redirect_to(expected_path)
       end

--- a/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/embargo_extensions_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe AlaveteliPro::EmbargoExtensionsController do
 
         it 'redirects to the request show page' do
           expect(response).
-            to redirect_to show_alaveteli_pro_request_path(
+            to redirect_to show_request_path(
               url_title: info_request.url_title)
         end
       end
@@ -71,7 +71,7 @@ RSpec.describe AlaveteliPro::EmbargoExtensionsController do
 
         it 'redirects to the request show page' do
           expect(response).
-            to redirect_to show_alaveteli_pro_request_path(
+            to redirect_to show_request_path(
               url_title: info_request.url_title)
         end
       end
@@ -307,7 +307,7 @@ RSpec.describe AlaveteliPro::EmbargoExtensionsController do
       end
 
       it 'redirects to that request, not the batch' do
-        expected_path = show_alaveteli_pro_request_path(
+        expected_path = show_request_path(
             url_title: info_request_batch.info_requests.first.url_title)
         expect(response).to redirect_to(expected_path)
       end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -113,8 +113,10 @@ RSpec.describe RequestController, "when showing one request" do
     end
   end
 
-  xdescribe "redirecting pro users to the pro context" do
+  describe "livery used", feature: :alaveteli_pro do
     let(:pro_user) { FactoryBot.create(:pro_user) }
+
+    before { sign_in pro_user }
 
     context "when showing pros their own requests" do
       context "when the request is embargoed" do
@@ -122,14 +124,9 @@ RSpec.describe RequestController, "when showing one request" do
           FactoryBot.create(:embargoed_request, user: pro_user)
         end
 
-        it "should always redirect to the pro version of the page" do
-          with_feature_enabled(:alaveteli_pro) do
-            sign_in pro_user
-            get :show, params: { url_title: info_request.url_title }
-            expect(response).to redirect_to(
-              show_request_path(url_title: info_request.url_title)
-            )
-          end
+        it 'uses the pro livery' do
+          get :show, params: { url_title: info_request.url_title }
+          expect(assigns[:in_pro_area]).to be true
         end
       end
 
@@ -138,12 +135,9 @@ RSpec.describe RequestController, "when showing one request" do
           FactoryBot.create(:info_request, user: pro_user)
         end
 
-        it "should not redirect to the pro version of the page" do
-          with_feature_enabled(:alaveteli_pro) do
-            sign_in pro_user
-            get :show, params: { url_title: info_request.url_title }
-            expect(response).to be_successful
-          end
+        it "should not use the pro livery" do
+          get :show, params: { url_title: info_request.url_title }
+          expect(assigns[:in_pro_area]).to be false
         end
       end
     end
@@ -157,31 +151,16 @@ RSpec.describe RequestController, "when showing one request" do
         FactoryBot.create(:embargoed_request, user: pro_user)
       end
 
-      it 'redirects to the pro version of the page' do
-        with_feature_enabled(:alaveteli_pro) do
-          sign_in pro_user
-          get :show, params: { url_title: info_request.url_title }
-          expect(response).to redirect_to show_request_path(
-            url_title: info_request.url_title)
-        end
-      end
-
       it 'uses the pro livery' do
-        with_feature_enabled(:alaveteli_pro) do
-          sign_in pro_user
-          get :show, params: { url_title: info_request.url_title, pro: '1' }
-          expect(assigns[:in_pro_area]).to be true
-        end
+        get :show, params: { url_title: info_request.url_title }
+        expect(assigns[:in_pro_area]).to be true
       end
     end
 
     context "when showing pros a someone else's request" do
-      it "should not redirect to the pro version of the page" do
-        with_feature_enabled(:alaveteli_pro) do
-          sign_in pro_user
-          get :show, params: { url_title: 'why_do_you_have_such_a_fancy_dog' }
-          expect(response).to be_successful
-        end
+      it "should not user the pro livery" do
+        get :show, params: { url_title: 'why_do_you_have_such_a_fancy_dog' }
+        expect(assigns[:in_pro_area]).to be false
       end
     end
   end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe RequestController, "when showing one request" do
     end
   end
 
-  describe "redirecting pro users to the pro context" do
+  xdescribe "redirecting pro users to the pro context" do
     let(:pro_user) { FactoryBot.create(:pro_user) }
 
     context "when showing pros their own requests" do
@@ -127,7 +127,7 @@ RSpec.describe RequestController, "when showing one request" do
             sign_in pro_user
             get :show, params: { url_title: info_request.url_title }
             expect(response).to redirect_to(
-              show_alaveteli_pro_request_path(url_title: info_request.url_title)
+              show_request_path(url_title: info_request.url_title)
             )
           end
         end
@@ -161,7 +161,7 @@ RSpec.describe RequestController, "when showing one request" do
         with_feature_enabled(:alaveteli_pro) do
           sign_in pro_user
           get :show, params: { url_title: info_request.url_title }
-          expect(response).to redirect_to show_alaveteli_pro_request_path(
+          expect(response).to redirect_to show_request_path(
             url_title: info_request.url_title)
         end
       end

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -4,7 +4,7 @@ module AlaveteliDsl
   end
 
   def browse_pro_request(url_title)
-    visit "/alaveteli_pro/info_requests/#{url_title}"
+    browse_request(url_title)
   end
 
   def create_request(public_body)

--- a/spec/routing/redirects_spec.rb
+++ b/spec/routing/redirects_spec.rb
@@ -87,4 +87,12 @@ RSpec.describe 'routing redirects', type: :request do
     get('/help/about?locale=en_GB')
     expect(response).to redirect_to('/help/about')
   end
+
+  it 'redirects old pro request routes', feature: :alaveteli_pro do
+    get('/alaveteli_pro/info_requests/my-request')
+    expect(response).to redirect_to('/request/my-request')
+
+    get('/alaveteli_pro/info_requests/new')
+    expect(response).to_not redirect_to('/request/new')
+  end
 end

--- a/spec/services/info_request_batch_metrics_spec.rb
+++ b/spec/services/info_request_batch_metrics_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe InfoRequestBatchMetrics do
     subject(:metrics) { described_class.new(batch).metrics }
 
     it 'generates info request batch metrics' do
-      request_url = 'http://test.host/alaveteli_pro/info_requests/' +
-                    request.url_title
+      request_url = 'http://test.host/request/' + request.url_title
       authority_name = request.public_body.name
 
       is_expected.to match_array(

--- a/spec/views/admin_request/show.html.erb_spec.rb
+++ b/spec/views/admin_request/show.html.erb_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "admin_request/show" do
     it 'links to the pro request page' do
       render
       expect(rendered).
-        to match(show_alaveteli_pro_request_url(info_request.url_title))
+        to match(show_request_url(info_request.url_title))
     end
 
     it 'includes embargo information' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7787 

## What does this do?

This PR removes the Alaveteli Pro request path - `/alaveteli_pro/info_requests/:url_title` and ensures that the standard request path - `/request/:url_title` is followed instead.

## Why was this needed?

Simplification of admin procedures.

