### PR TITLE
Removing duplicate text

### DIFF
--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -222,8 +222,6 @@
           <li><%= _('<a href="{{url}}">Keep it <strong>focused</strong></a>, ' \
                        'you\'ll be more likely to get what you want.',
                     :url => help_requesting_path(:anchor => 'focused').html_safe) %></li>
-          <li><%= _('Make sure the information you are asking for is not ' \
-                       'already publicly available.') %></li>
         </ul>
       </div>
 


### PR DESCRIPTION
Removes duplicate text

## Relevant issue(s)
Fixes #8143

## What does this do?
Remove duplicate text on request page

## Why was this needed?
There was duplicate text on the request page

## Implementation notes
n/a
## Screenshots
<img width="1079" alt="Screenshot 2024-03-01 at 10 15 15" src="https://github.com/mysociety/alaveteli/assets/120410992/d788fcb8-958b-4ecb-a2ed-a02645664724">

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
