### PR TITLE
Fix specs broken due to extra day in an leap year

### DIFF
--- a/spec/models/user/survey_spec.rb
+++ b/spec/models/user/survey_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe User do
       before do
         FactoryBot.create(
           :user_info_request_sent_alert,
-          user: user, alert_type: 'survey_1', created_at: 366.days.ago
+          user: user, alert_type: 'survey_1', created_at: 367.days.ago
         )
       end
 

--- a/spec/models/user_info_request_sent_alert_spec.rb
+++ b/spec/models/user_info_request_sent_alert_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe UserInfoRequestSentAlert do
     end
 
     let!(:old) do
-      FactoryBot.create(:user_info_request_sent_alert, created_at: 366.days.ago)
+      FactoryBot.create(:user_info_request_sent_alert, created_at: 367.days.ago)
     end
 
     it 'can scope to recent sent alerts' do


### PR DESCRIPTION
## What does this do?

Fix specs broken due to extra day in an leap year

## Why was this needed?

These specs are testing for old content created over an year ago. Normally this would be fine but with an extra day in a leap year they break.

This change increases the creation date to 367 days ago.

[skip changelog]
