### PR TITLE
Refactor localised admin forms

### DIFF
--- a/app/controllers/admin_announcements_controller.rb
+++ b/app/controllers/admin_announcements_controller.rb
@@ -22,6 +22,7 @@ class AdminAnnouncementsController < AdminController
       redirect_to admin_announcements_path, notice: notice
     else
       @title = 'New announcement'
+      @announcement.build_all_translations
       render :new
     end
   end
@@ -37,6 +38,7 @@ class AdminAnnouncementsController < AdminController
       redirect_to admin_announcements_path, notice: notice
     else
       @title = 'Edit announcement'
+      @announcement.build_all_translations
       render :edit
     end
   end

--- a/app/views/admin/categories/_form.html.erb
+++ b/app/views/admin/categories/_form.html.erb
@@ -19,31 +19,9 @@
   <% end %>
 <% end %>
 
-<div id="div-locales">
-  <ul class="locales nav nav-tabs">
-    <% @category.ordered_translations.each do |translation| %>
-      <li>
-        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
-          <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
-        </a>
-      </li>
-    <% end %>
-  </ul>
-
-  <div class="tab-content">
-    <% @category.ordered_translations.each do |translation| %>
-      <% if AlaveteliLocalization.default_locale?(translation.locale) %>
-        <%= fields_for('category', @category) do |t| %>
-          <%= render partial: 'locale_fields', locals: { t: t, locale: translation.locale } %>
-        <% end %>
-      <% else %>
-        <%= f.fields_for(:translations, translation, child_index: translation.locale) do |t| %>
-          <%= render partial: 'locale_fields', locals: { t: t, locale: translation.locale } %>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
-</div>
+<% f.translated_fields do |t| %>
+  <%= render partial: 'locale_fields', locals: { t: t } %>
+<% end %>
 
 <% if !@category.parents.include?(@root) || @category.new_record? %>
   <h3>Common Fields</h3>

--- a/app/views/admin/categories/_form.html.erb
+++ b/app/views/admin/categories/_form.html.erb
@@ -1,23 +1,4 @@
-<% if @category.errors.any? %>
-  <ul>
-    <% @category.errors.each do |error| %>
-      <% unless error.attribute.to_s.starts_with?('translation') %>
-        <li><%= error.full_message %></li>
-      <% end %>
-    <% end %>
-  </ul>
-<% end %>
-
-<% @category.ordered_translations.each do |translation| %>
-  <% if translation.errors.any? %>
-    <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
-    <ul>
-      <% translation.errors.each do |error| %>
-        <li><%= error.full_message %></li>
-      <% end %>
-    </ul>
-  <% end %>
-<% end %>
+<%= f.error_messages %>
 
 <% f.translated_fields do |t| %>
   <%= render partial: 'locale_fields', locals: { t: t } %>

--- a/app/views/admin/categories/_locale_fields.html.erb
+++ b/app/views/admin/categories/_locale_fields.html.erb
@@ -1,27 +1,13 @@
-<div class="tab-pane" id="div-locale-<%= locale %>">
 <div class="control-group">
-  <%= t.hidden_field :locale, value: locale %>
   <%= t.label :title, class: 'control-label' %>
   <div class="controls">
-    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:title].any? %>
-      <span class="fieldWithErrors">
-    <% end %>
     <%= t.text_field :title, class: "span4" %>
-    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:title].any? %>
-      </span>
-    <% end %>
   </div>
 </div>
+
 <div class="control-group">
   <%= t.label :description, class: 'control-label' %>
   <div class="controls">
-    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:description].any? %>
-      <span class="fieldWithErrors">
-    <% end %>
     <%= t.text_field :description, class: "span4" %>
-    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:description].any? %>
-      </span>
-    <% end %>
   </div>
-</div>
 </div>

--- a/app/views/admin/categories/_locale_fields.html.erb
+++ b/app/views/admin/categories/_locale_fields.html.erb
@@ -1,27 +1,27 @@
 <div class="tab-pane" id="div-locale-<%= locale %>">
-  <div class="control-group">
-    <%= t.hidden_field :locale, value: locale %>
-    <%= t.label :title, class: 'control-label' %>
-    <div class="controls">
-      <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:title].any? %>
-        <span class="fieldWithErrors">
-      <% end %>
-      <%= t.text_field :title, class: "span4" %>
-      <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:title].any? %>
-        </span>
-      <% end %>
-    </div>
+<div class="control-group">
+  <%= t.hidden_field :locale, value: locale %>
+  <%= t.label :title, class: 'control-label' %>
+  <div class="controls">
+    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:title].any? %>
+      <span class="fieldWithErrors">
+    <% end %>
+    <%= t.text_field :title, class: "span4" %>
+    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:title].any? %>
+      </span>
+    <% end %>
   </div>
-  <div class="control-group">
-    <%= t.label :description, class: 'control-label' %>
-    <div class="controls">
-      <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:description].any? %>
-        <span class="fieldWithErrors">
-      <% end %>
-      <%= t.text_field :description, class: "span4" %>
-      <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:description].any? %>
-        </span>
-      <% end %>
-    </div>
+</div>
+<div class="control-group">
+  <%= t.label :description, class: 'control-label' %>
+  <div class="controls">
+    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:description].any? %>
+      <span class="fieldWithErrors">
+    <% end %>
+    <%= t.text_field :description, class: "span4" %>
+    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:description].any? %>
+      </span>
+    <% end %>
   </div>
+</div>
 </div>

--- a/app/views/admin/categories/edit.html.erb
+++ b/app/views/admin/categories/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="span8">
     <div id="category_form">
-      <%= form_for @category, url: admin_category_path(@category, model_type: current_klass), html: { class: "form form-horizontal" } do |f| %>
+      <%= translated_form_for @category, url: admin_category_path(@category, model_type: current_klass), html: { class: "form form-horizontal" } do |f| %>
         <%= render partial: 'form', locals: { f: f } %>
 
         <div class="form-actions">

--- a/app/views/admin/categories/new.html.erb
+++ b/app/views/admin/categories/new.html.erb
@@ -5,7 +5,7 @@
 <div class="row">
   <div class="span8">
     <div id="public_category_form">
-      <%= form_for @category, url: admin_categories_path(model_type: current_klass), html: { class: "form form-horizontal" } do |f| %>
+      <%= translated_form_for @category, url: admin_categories_path(model_type: current_klass), html: { class: "form form-horizontal" } do |f| %>
         <%= render partial: 'form', locals: { f: f } %>
 
         <div class="form-actions">

--- a/app/views/admin/notes/_form.html.erb
+++ b/app/views/admin/notes/_form.html.erb
@@ -11,28 +11,6 @@
   <% end %>
 </div>
 
-<div id="div-locales">
-  <ul class="locales nav nav-tabs">
-    <% @note.ordered_translations.each do |translation| %>
-      <li>
-        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
-          <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
-        </a>
-      </li>
-    <% end %>
-  </ul>
-
-  <div class="tab-content">
-    <% @note.ordered_translations.each do |translation| %>
-      <% if AlaveteliLocalization.default_locale?(translation.locale) %>
-        <%= fields_for('note', @note) do |t| %>
-          <%= render partial: 'locale_fields', locals: { t: t, locale: translation.locale } %>
-        <% end %>
-      <% else %>
-        <%= f.fields_for(:translations, translation, child_index: translation.locale) do |t| %>
-          <%= render partial: 'locale_fields', locals: { t: t, locale: translation.locale } %>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
-</div>
+<% f.translated_fields do |t| %>
+  <%= render partial: 'locale_fields', locals: { t: t } %>
+<% end %>

--- a/app/views/admin/notes/_form.html.erb
+++ b/app/views/admin/notes/_form.html.erb
@@ -1,4 +1,4 @@
-<%= foi_error_messages_for :note %>
+<%= f.error_messages %>
 
 <div class="well">
   <% if @note.notable %>

--- a/app/views/admin/notes/_locale_fields.html.erb
+++ b/app/views/admin/notes/_locale_fields.html.erb
@@ -1,16 +1,6 @@
-<div class="tab-pane" id="div-locale-<%= locale %>">
 <div class="control-group">
-  <%= t.hidden_field :locale, :value => locale %>
-
   <%= t.label :body, class: 'control-label' %>
   <div class="controls">
-    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:body].any? %>
-      <span class="fieldWithErrors">
-    <% end %>
     <%= t.text_area :body, class: 'span6', rows: 10 %>
-    <% if AlaveteliLocalization.default_locale?(locale) && t.object.errors[:body].any? %>
-      </span>
-    <%end %>
   </div>
-</div>
 </div>

--- a/app/views/admin/notes/edit.erb
+++ b/app/views/admin/notes/edit.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<%= form_for [:admin, @note], html: { class: 'form form-horizontal' } do |f| %>
+<%= translated_form_for [:admin, @note], html: { class: 'form form-horizontal' } do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <div class="form-actions">
     <%= submit_tag 'Save', class: 'btn btn-success' %>

--- a/app/views/admin/notes/edit.erb
+++ b/app/views/admin/notes/edit.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<%= form_for [:admin, @note], class: 'form form-horizontal' do |f| %>
+<%= form_for [:admin, @note], html: { class: 'form form-horizontal' } do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <div class="form-actions">
     <%= submit_tag 'Save', class: 'btn btn-success' %>

--- a/app/views/admin/notes/new.html.erb
+++ b/app/views/admin/notes/new.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<%= form_for [:admin, @note], class: 'form form-horizontal' do |f| %>
+<%= form_for [:admin, @note], html: { class: 'form form-horizontal' } do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <div class="form-actions">
     <%= submit_tag 'Create', class: 'btn btn-success' %>

--- a/app/views/admin/notes/new.html.erb
+++ b/app/views/admin/notes/new.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<%= form_for [:admin, @note], html: { class: 'form form-horizontal' } do |f| %>
+<%= translated_form_for [:admin, @note], html: { class: 'form form-horizontal' } do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <div class="form-actions">
     <%= submit_tag 'Create', class: 'btn btn-success' %>

--- a/app/views/admin/outgoing_messages/snippets/_form.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/_form.html.erb
@@ -1,21 +1,7 @@
 <%= f.error_messages %>
 
 <% f.translated_fields do |t| %>
-  <div class="control-group">
-    <%= t.label :name, class: 'control-label' %>
-
-    <div class="controls">
-      <%= t.text_field :name, class: 'span4' %>
-    </div>
-  </div>
-
-  <div class="control-group">
-    <%= t.label :body, class: 'control-label' %>
-
-    <div class="controls">
-      <%= t.text_area :body, class: 'span4' %>
-    </div>
-  </div>
+  <%= render partial: 'locale_fields', locals: { t: t } %>
 <% end %>
 
 <h3>Common Fields</h3>

--- a/app/views/admin/outgoing_messages/snippets/_locale_fields.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/_locale_fields.html.erb
@@ -1,9 +1,5 @@
-<div class="tab-pane" id="div-locale-<%= locale %>">
-<%= t.hidden_field :locale, value: locale %>
-
 <div class="control-group">
   <%= t.label :name, class: 'control-label' %>
-
   <div class="controls">
     <%= t.text_field :name, class: 'span4' %>
   </div>
@@ -11,9 +7,7 @@
 
 <div class="control-group">
   <%= t.label :body, class: 'control-label' %>
-
   <div class="controls">
     <%= t.text_area :body, class: 'span4' %>
   </div>
-</div>
 </div>

--- a/app/views/admin/outgoing_messages/snippets/_locale_fields.html.erb
+++ b/app/views/admin/outgoing_messages/snippets/_locale_fields.html.erb
@@ -1,19 +1,19 @@
 <div class="tab-pane" id="div-locale-<%= locale %>">
-  <%= t.hidden_field :locale, value: locale %>
+<%= t.hidden_field :locale, value: locale %>
 
-  <div class="control-group">
-    <%= t.label :name, class: 'control-label' %>
+<div class="control-group">
+  <%= t.label :name, class: 'control-label' %>
 
-    <div class="controls">
-      <%= t.text_field :name, class: 'span4' %>
-    </div>
+  <div class="controls">
+    <%= t.text_field :name, class: 'span4' %>
   </div>
+</div>
 
-  <div class="control-group">
-    <%= t.label :body, class: 'control-label' %>
+<div class="control-group">
+  <%= t.label :body, class: 'control-label' %>
 
-    <div class="controls">
-      <%= t.text_area :body, class: 'span4' %>
-    </div>
+  <div class="controls">
+    <%= t.text_area :body, class: 'span4' %>
   </div>
+</div>
 </div>

--- a/app/views/admin_announcements/_form.html.erb
+++ b/app/views/admin_announcements/_form.html.erb
@@ -1,4 +1,4 @@
-<%= foi_error_messages_for :announcement %>
+<%= f.error_messages %>
 
 <% f.translated_fields do |t| %>
   <%= render partial: 'locale_fields', locals: { t: t } %>

--- a/app/views/admin_announcements/_form.html.erb
+++ b/app/views/admin_announcements/_form.html.erb
@@ -1,32 +1,8 @@
 <%= foi_error_messages_for :announcement %>
 
-<!--[form:announcement]-->
-
-<div id="div-locales">
-  <ul class="locales nav nav-tabs">
-    <% @announcement.ordered_translations.each do |translation| %>
-      <li>
-        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab" >
-          <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
-        </a>
-      </li>
-    <% end %>
-  </ul>
-
-  <div class="tab-content">
-    <% @announcement.ordered_translations.each do |translation| %>
-      <% if AlaveteliLocalization.default_locale?(translation.locale) %>
-        <%= fields_for('announcement', @announcement) do |t| %>
-          <%= render partial: 'locale_fields', locals: { t: t, locale: translation.locale } %>
-        <% end %>
-      <% else %>
-        <%= f.fields_for(:translations, translation, child_index: translation.locale) do |t| %>
-          <%= render partial: 'locale_fields', locals: { t: t, locale: translation.locale } %>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
-</div>
+<% f.translated_fields do |t| %>
+  <%= render partial: 'locale_fields', locals: { t: t } %>
+<% end %>
 
 <hr>
 

--- a/app/views/admin_announcements/_locale_fields.html.erb
+++ b/app/views/admin_announcements/_locale_fields.html.erb
@@ -1,31 +1,13 @@
-<div class="tab-pane" id="div-locale-<%= locale %>">
 <div class="control-group">
-  <%= t.hidden_field :locale, value: locale %>
   <%= t.label :title, 'Title (optional)', class: 'control-label' %>
   <div class="controls">
-    <% if AlaveteliLocalization.default_locale?(locale) &&
-                      t.object.errors[:title].any? %>
-      <span class="fieldWithErrors">
-    <% end %>
     <%= t.text_field :title, class: 'span4' %>
-    <% if AlaveteliLocalization.default_locale?(locale) &&
-          t.object.errors[:title].any? %>
-      </span>
-    <%end %>
   </div>
 </div>
+
 <div class="control-group">
   <%= t.label :content, class: 'control-label' %>
   <div class="controls">
-    <% if AlaveteliLocalization.default_locale?(locale) &&
-          t.object.errors[:content].any? %>
-      <span class="fieldWithErrors">
-    <% end %>
     <%= t.text_area :content, class: 'span6', rows: 2 %>
-    <% if AlaveteliLocalization.default_locale?(locale) &&
-          t.object.errors[:content].any? %>
-      </span>
-    <%end %>
   </div>
-</div>
 </div>

--- a/app/views/admin_announcements/_locale_fields.html.erb
+++ b/app/views/admin_announcements/_locale_fields.html.erb
@@ -6,12 +6,12 @@
     <% if AlaveteliLocalization.default_locale?(locale) &&
                       t.object.errors[:title].any? %>
       <span class="fieldWithErrors">
-      <% end %>
-      <%= t.text_field :title, class: 'span4' %>
-      <% if AlaveteliLocalization.default_locale?(locale) &&
-            t.object.errors[:title].any? %>
-        </span>
-      <%end %>
+    <% end %>
+    <%= t.text_field :title, class: 'span4' %>
+    <% if AlaveteliLocalization.default_locale?(locale) &&
+          t.object.errors[:title].any? %>
+      </span>
+    <%end %>
   </div>
 </div>
 <div class="control-group">

--- a/app/views/admin_announcements/edit.html.erb
+++ b/app/views/admin_announcements/edit.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<%= form_for [:admin, @announcement], method: 'put', html: { class: 'form form-horizontal' } do |f| %>
+<%= translated_form_for [:admin, @announcement], method: 'put', html: { class: 'form form-horizontal' } do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <div class="form-actions">
     <%= submit_tag 'Save', accesskey: 's', class: 'btn btn-success' %>

--- a/app/views/admin_announcements/edit.html.erb
+++ b/app/views/admin_announcements/edit.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<%= form_for [:admin, @announcement], method: 'put', class: 'form form-horizontal' do |f| %>
+<%= form_for [:admin, @announcement], method: 'put', html: { class: 'form form-horizontal' } do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <div class="form-actions">
     <%= submit_tag 'Save', accesskey: 's', class: 'btn btn-success' %>

--- a/app/views/admin_announcements/new.html.erb
+++ b/app/views/admin_announcements/new.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<%= form_for [:admin, @announcement], html: { class: 'form form-horizontal' } do |f| %>
+<%= translated_form_for [:admin, @announcement], html: { class: 'form form-horizontal' } do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <div class="form-actions">
     <%= submit_tag 'Create', class: 'btn btn-success' %>

--- a/app/views/admin_announcements/new.html.erb
+++ b/app/views/admin_announcements/new.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 
-<%= form_for [:admin, @announcement], class: 'form form-horizontal' do |f| %>
+<%= form_for [:admin, @announcement], html: { class: 'form form-horizontal' } do |f| %>
   <%= render partial: 'form', locals: { f: f } %>
   <div class="form-actions">
     <%= submit_tag 'Create', class: 'btn btn-success' %>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -1,23 +1,4 @@
-<% if @public_body.errors.any? %>
-  <ul>
-    <% @public_body.errors.each do |error| %>
-      <% unless error.attribute.to_s.starts_with?('translation') %>
-        <li><%= error.message %></li>
-      <% end %>
-    <% end %>
-  </ul>
-<% end %>
-
-<% @public_body.ordered_translations.each do |translation| %>
-  <% if translation.errors.any? %>
-    <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
-    <ul>
-      <% translation.errors.each do |error| %>
-        <li><%= error.message %></li>
-      <% end %>
-    </ul>
-  <% end %>
-<% end %>
+<%= f.error_messages %>
 
 <% f.translated_fields do |t| %>
   <%= render partial: 'locale_fields', locals: { t: t } %>

--- a/app/views/admin_public_body/_form.html.erb
+++ b/app/views/admin_public_body/_form.html.erb
@@ -19,33 +19,9 @@
   <% end %>
 <% end %>
 
-<!--[form:public_body]-->
-
-<div id="div-locales">
-  <ul class="locales nav nav-tabs">
-    <% @public_body.ordered_translations.each do |translation| %>
-      <li>
-        <a href="#div-locale-<%= translation.locale.to_s %>" data-toggle="tab">
-          <%= locale_name(translation.locale.to_s) || translation.locale.to_s %>
-        </a>
-      </li>
-    <% end %>
-  </ul>
-
-  <div class="tab-content">
-    <% @public_body.ordered_translations.each do |translation| %>
-      <% if AlaveteliLocalization.default_locale?(translation.locale) %>
-        <%= fields_for('public_body', @public_body) do |t| %>
-          <%= render :partial => 'locale_fields', :locals => { :t => t, :locale => translation.locale } %>
-        <% end %>
-      <% else %>
-        <%= f.fields_for(:translations, translation, :child_index => translation.locale) do |t| %>
-          <%= render :partial => 'locale_fields' , :locals => { :t => t, :locale => translation.locale } %>
-        <% end %>
-      <% end %>
-    <% end %>
-  </div>
-</div>
+<% f.translated_fields do |t| %>
+  <%= render partial: 'locale_fields', locals: { t: t } %>
+<% end %>
 
 <h3>Common Fields</h3>
 <div class="control-group">

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -1,6 +1,4 @@
-<div class="tab-pane" id="div-locale-<%= locale %>">
 <div class="control-group">
-  <%= t.hidden_field :locale, :value => locale %>
   <%= t.label :name, 'Name', :class => 'control-label' %>
   <div class="controls">
     <%= t.text_field :name, :class => "span4" %>
@@ -51,5 +49,4 @@
   <div class="controls">
     <%= t.url_field :disclosure_log, size: 60, class: 'span4' %>
   </div>
-</div>
 </div>

--- a/app/views/admin_public_body/_locale_fields.html.erb
+++ b/app/views/admin_public_body/_locale_fields.html.erb
@@ -1,56 +1,55 @@
-
 <div class="tab-pane" id="div-locale-<%= locale %>">
-  <div class="control-group">
-    <%= t.hidden_field :locale, :value => locale %>
-    <%= t.label :name, 'Name', :class => 'control-label' %>
-    <div class="controls">
-      <%= t.text_field :name, :class => "span4" %>
-    </div>
+<div class="control-group">
+  <%= t.hidden_field :locale, :value => locale %>
+  <%= t.label :name, 'Name', :class => 'control-label' %>
+  <div class="controls">
+    <%= t.text_field :name, :class => "span4" %>
   </div>
+</div>
 
-  <div class="control-group">
-    <%= t.label :short_name, 'Short name', :class => 'control-label' %>
-    <div class="controls">
-      <%= t.text_field :short_name, :class => "span2"  %>
-      <p class="help-block">
-        Only put in abbreviations which are really used, otherwise leave blank.
-        Short or long name is used in the URL – don't worry about breaking URLs
-        through renaming, as the history is used to redirect.
-      </p>
-    </div>
+<div class="control-group">
+  <%= t.label :short_name, 'Short name', :class => 'control-label' %>
+  <div class="controls">
+    <%= t.text_field :short_name, :class => "span2"  %>
+    <p class="help-block">
+      Only put in abbreviations which are really used, otherwise leave blank.
+      Short or long name is used in the URL – don't worry about breaking URLs
+      through renaming, as the history is used to redirect.
+    </p>
   </div>
+</div>
 
-  <div class="control-group">
-    <%= t.label :request_email, 'Request email', :class => 'control-label' %>
-    <div class="controls">
-      <%= t.text_field :request_email, :class => "span3" %>
-      <p class="help-block">
-        Set to <strong>blank</strong> (empty string) if can't find an address;
-        these emails are <strong>public</strong> as anyone can view with a
-        reCAPTCHA.
-      </p>
+<div class="control-group">
+  <%= t.label :request_email, 'Request email', :class => 'control-label' %>
+  <div class="controls">
+    <%= t.text_field :request_email, :class => "span3" %>
+    <p class="help-block">
+      Set to <strong>blank</strong> (empty string) if can't find an address;
+      these emails are <strong>public</strong> as anyone can view with a
+      reCAPTCHA.
+    </p>
 
-      <% if @public_body.ordered_translations.many? %>
-        <div class="alert alert-info">
-          <i class="icon-info-sign"></i>
-          Make sure you add the request email for <em>all</em> locales that have
-          translated attributes.
-        </div>
-      <% end %>
-    </div>
+    <% if @public_body.ordered_translations.many? %>
+      <div class="alert alert-info">
+        <i class="icon-info-sign"></i>
+        Make sure you add the request email for <em>all</em> locales that have
+        translated attributes.
+      </div>
+    <% end %>
   </div>
+</div>
 
-  <div class="control-group">
-    <%= t.label :publication_scheme, 'Publication scheme URL', :class => 'control-label' %>
-    <div class="controls">
-      <%= t.url_field :publication_scheme, size: 60, class: 'span4' %>
-    </div>
+<div class="control-group">
+  <%= t.label :publication_scheme, 'Publication scheme URL', :class => 'control-label' %>
+  <div class="controls">
+    <%= t.url_field :publication_scheme, size: 60, class: 'span4' %>
   </div>
+</div>
 
-  <div class="control-group">
-    <%= t.label :disclosure_log, 'Disclosure log URL', :class => 'control-label' %>
-    <div class="controls">
-      <%= t.url_field :disclosure_log, size: 60, class: 'span4' %>
-    </div>
+<div class="control-group">
+  <%= t.label :disclosure_log, 'Disclosure log URL', :class => 'control-label' %>
+  <div class="controls">
+    <%= t.url_field :disclosure_log, size: 60, class: 'span4' %>
   </div>
+</div>
 </div>

--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -11,7 +11,7 @@
 <div class="row">
   <div class="span8">
     <div id="public_body_form">
-      <%= form_for @public_body, :url => admin_body_path(@public_body),  :method => 'put', :html => { :class => "form form-horizontal" } do |f| %>
+      <%= translated_form_for @public_body, :url => admin_body_path(@public_body),  :method => 'put', :html => { :class => "form form-horizontal" } do |f| %>
         <%= render :partial => 'form', :locals => {:f => f} %>
         <div class="form-actions">
           <%= f.submit 'Save', :accesskey => 's', :class => "btn btn-success" %></p>

--- a/app/views/admin_public_body/new.html.erb
+++ b/app/views/admin_public_body/new.html.erb
@@ -4,7 +4,7 @@
 <div class="row">
   <div class="span8">
     <div id="public_body_form">
-      <%= form_for @public_body, :as => :public_body, :url => admin_bodies_path, :html => {:class => "form form-horizontal"} do |f| %>
+      <%= translated_form_for @public_body, :as => :public_body, :url => admin_bodies_path, :html => {:class => "form form-horizontal"} do |f| %>
         <%= render :partial => 'form', :locals => {:f => f} %>
 
 


### PR DESCRIPTION
## What does this do?

Refactor localised admin forms

## Why was this needed?

To reduce complexity and make the forms consistent with each other.

## Implementation notes

Switches admin forms with translated fields to use the `translated_form_for` form builder and `translated_fields` form helper. Means we don't have to manually build the tabbed interface for the different locales in use.

This is already in use for the `OutgoingMessage::Snippet` forms and can be re-used for `Announcement` `Category`, `PublicBody` and `Note` forms.

<hr>

[skip changelog]