### PR TITLE
Refactor spec configuration option assignment

### DIFF
--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -753,21 +753,18 @@ RSpec.describe AdminPublicBodyController do
 
   describe "when administering public bodies and paying attention to authentication" do
     before do
-      config = MySociety::Config.load_default
-      config['SKIP_ADMIN_AUTH'] = false
+      allow(AlaveteliConfiguration).to receive(:skip_admin_auth).
+        and_return(false)
       basic_auth_login @request
     end
 
-    after do
-      config = MySociety::Config.load_default
-      config['SKIP_ADMIN_AUTH'] = true
-    end
-
     def setup_emergency_credentials(username, password)
-      config = MySociety::Config.load_default
-      config['SKIP_ADMIN_AUTH'] = false
-      config['ADMIN_USERNAME'] = username
-      config['ADMIN_PASSWORD'] = password
+      allow(AlaveteliConfiguration).to receive(:skip_admin_auth).
+        and_return(false)
+      allow(AlaveteliConfiguration).to receive(:admin_username).
+        and_return(username)
+      allow(AlaveteliConfiguration).to receive(:admin_password).
+        and_return(password)
       @request.env["HTTP_AUTHORIZATION"] = ""
     end
 
@@ -782,8 +779,8 @@ RSpec.describe AdminPublicBodyController do
     end
 
     it "skips admin authorisation when SKIP_ADMIN_AUTH set" do
-      config = MySociety::Config.load_default
-      config['SKIP_ADMIN_AUTH'] = true
+      allow(AlaveteliConfiguration).to receive(:skip_admin_auth).
+        and_return(true)
       @request.env["HTTP_AUTHORIZATION"] = ""
       n = PublicBody.count
       post :destroy, params: { id: public_bodies(:forlorn_public_body).id }
@@ -871,8 +868,8 @@ RSpec.describe AdminPublicBodyController do
       end
 
       it 'returns the REMOTE_USER value from the request environment when skipping admin auth' do
-        config = MySociety::Config.load_default
-        config['SKIP_ADMIN_AUTH'] = true
+        allow(AlaveteliConfiguration).to receive(:skip_admin_auth).
+          and_return(true)
         @request.env["HTTP_AUTHORIZATION"] = ""
         @request.env["REMOTE_USER"] = "i_am_admin"
         post :show, params: { id: public_bodies(:humpadink_public_body).id }

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -115,8 +115,8 @@ RSpec.describe GeneralController, "when showing the frontpage" do
   end
 
   it "should render the front page with default language and ignore the browser setting" do
-    config = MySociety::Config.load_default
-    config['USE_DEFAULT_BROWSER_LANGUAGE'] = false
+    allow(AlaveteliConfiguration).to receive(:use_default_browser_language).
+      and_return(false)
     accept_language = "en-GB,en-US;q=0.8,en;q=0.6"
     request.env['HTTP_ACCEPT_LANGUAGE'] = accept_language
     with_default_locale("es") do
@@ -126,8 +126,8 @@ RSpec.describe GeneralController, "when showing the frontpage" do
   end
 
   it "should render the front page with browser-selected language when there's no default set" do
-    config = MySociety::Config.load_default
-    config['USE_DEFAULT_BROWSER_LANGUAGE'] = true
+    allow(AlaveteliConfiguration).to receive(:use_default_browser_language).
+      and_return(true)
     accept_language = "es-ES,en-GB,en-US;q=0.8,en;q=0.6"
     request.env['HTTP_ACCEPT_LANGUAGE'] = accept_language
     get :frontpage

--- a/spec/integration/statistics_spec.rb
+++ b/spec/integration/statistics_spec.rb
@@ -2,9 +2,10 @@ require "spec_helper"
 
 RSpec.describe "Site statistics" do
   before :each do
-    config = MySociety::Config.load_default
-    config['MINIMUM_REQUESTS_FOR_STATISTICS'] = 1
-    config['PUBLIC_BODY_STATISTICS_PAGE'] = true
+    allow(AlaveteliConfiguration).to receive(:minimum_requests_for_statistics).
+      and_return(1)
+    allow(AlaveteliConfiguration).to receive(:public_body_statistics_page).
+      and_return(true)
   end
 
   describe "for public bodies" do

--- a/spec/lib/alaveteli_text_masker_spec.rb
+++ b/spec/lib/alaveteli_text_masker_spec.rb
@@ -86,9 +86,8 @@ RSpec.describe AlaveteliTextMasker do
 
     context 'applying masks to PDF' do
       def pdf_replacement_test(use_ghostscript_compression)
-        config = MySociety::Config.load_default
-        previous = config['USE_GHOSTSCRIPT_COMPRESSION']
-        config['USE_GHOSTSCRIPT_COMPRESSION'] = use_ghostscript_compression
+        allow(AlaveteliConfiguration).to receive(:use_ghostscript_compression).
+          and_return(use_ghostscript_compression)
         orig_pdf = load_file_fixture('tfl.pdf')
         pdf = orig_pdf.dup
 
@@ -100,7 +99,6 @@ RSpec.describe AlaveteliTextMasker do
         masked_text = MailHandler.get_attachment_text_one_file('application/pdf', result)
         expect(masked_text).not_to match(/foi@tfl.gov.uk/)
         expect(masked_text).to match(/xxx@xxx.xxx.xx/)
-        config['USE_GHOSTSCRIPT_COMPRESSION'] = previous
       end
 
       it "replaces everything in PDF files using pdftk" do


### PR DESCRIPTION
## What does this do?

Refactor spec configuration option assignment

## Why was this needed?

Some spec examples require certain configuration options to be set, this commit switches to stubbing the option instead of reassigning the option to the required value to get the test to pass.

This means we don't need to revert the value after the test example has been run back to the original value.

<hr>

[skip changelog]