### PR TITLE
[#7771 & #7809] Add styling and rich text notes

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -11,4 +11,5 @@
 //= require admin/category-order
 //= require admin/censor-rules
 //= require admin/holidays
+//= require admin/notes
 //= require jquery_ujs

--- a/app/assets/javascripts/admin/notes.js
+++ b/app/assets/javascripts/admin/notes.js
@@ -1,0 +1,19 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var selectElement = document.getElementById('note_style');
+  var bodyInput = document.getElementById('bodyInput');
+  var richBodyInput = document.getElementById('richBodyInput');
+
+  function updateBodyVisibility() {
+    if (selectElement.value === 'original') {
+      bodyInput.style.display = 'block';
+      richBodyInput.style.display = 'none';
+    } else {
+      bodyInput.style.display = 'none';
+      richBodyInput.style.display = 'block';
+    }
+  }
+
+  selectElement.addEventListener('change', updateBodyVisibility);
+
+  updateBodyVisibility();
+});

--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -1,0 +1,31 @@
+/*
+ * Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
+ * the trix-editor content (whether displayed or under editing). Feel free to incorporate this
+ * inclusion directly in any other asset bundle and remove this file.
+ *
+ *= require trix
+*/
+
+/*
+ * We need to override trix.css’s image gallery styles to accommodate the
+ * <action-text-attachment> element we wrap around attachments. Otherwise,
+ * images in galleries will be squished by the max-width: 33%; rule.
+*/
+.trix-content .attachment-gallery > action-text-attachment,
+.trix-content .attachment-gallery > .attachment {
+  flex: 1 0 33%;
+  padding: 0 0.5em;
+  max-width: 33%;
+}
+
+.trix-content .attachment-gallery.attachment-gallery--2 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--2 > .attachment, .trix-content .attachment-gallery.attachment-gallery--4 > action-text-attachment,
+.trix-content .attachment-gallery.attachment-gallery--4 > .attachment {
+  flex-basis: 50%;
+  max-width: 50%;
+}
+
+.trix-content action-text-attachment .attachment {
+  padding: 0 !important;
+  max-width: 100% !important;
+}

--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -29,3 +29,7 @@
   padding: 0 !important;
   max-width: 100% !important;
 }
+
+.trix-button-group--file-tools {
+  display: none !important;
+}

--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -1,3 +1,5 @@
+//= require "actiontext"
+
 /* As we're namespacing bootstrap to class admin, which is applied to the body
 element in the admin interface (no id or class allowed on the HTML element
 in HTML 4.01) and to the navbar also, so it can be styled with bootstrap

--- a/app/assets/stylesheets/responsive/_notes_layout.scss
+++ b/app/assets/stylesheets/responsive/_notes_layout.scss
@@ -1,19 +1,20 @@
 #notes {
-  // Variables to keep consistency speacilly with the spacing.
+  // Variables to keep consistency specially with the spacing.
   $padding-x: 1em;
-  $border: 1px solid rgba(0, 0, 0, 0.1);
+  $border: 1px solid rgba(0, 0, 0, 0);
+  $border-top-size: 8px;
 
-  padding: 0 $padding-x;
+  padding: $border-top-size $padding-x 0;
   margin-bottom: 2em;
 
-  border-top: 8px solid $primary-color;
-
-  article {
+  .note {
     margin: 0 -#{$padding-x};
     padding: $padding-x $padding-x;
     border: $border;
-    border-top: none;
     word-break: break-word;
+
+    &:first-child { box-shadow: 0 -#{$border-top-size} 0 0 rgba(0, 0, 0, 0); }
+    border-top-width: 0;
 
     h1, h2, h3, h4, h5, h6 {
       margin-bottom: 0.5em;

--- a/app/assets/stylesheets/responsive/_notes_styles.scss
+++ b/app/assets/stylesheets/responsive/_notes_styles.scss
@@ -1,7 +1,17 @@
-#notes {
-  background-color: lighten($primary-color, 60%);
+$note-text:          $oil;
+$note-bg:            lighten($primary-color, 60%);
+$note-border:        $primary-color;
 
-  article {
+$border-top-size: 8px;
+
+#notes {
+  .note {
+    color: $note-text;
+    background-color: $note-bg;
+    border-color: rgba(0, 0, 0, 0.1);
+
+    &:first-child { box-shadow: 0 -#{$border-top-size} 0 0 $note-border; }
+
     h1 {
       font-size: 1.5em;
     }

--- a/app/assets/stylesheets/responsive/_notes_styles.scss
+++ b/app/assets/stylesheets/responsive/_notes_styles.scss
@@ -2,6 +2,22 @@ $note-text:          $oil;
 $note-bg:            lighten($primary-color, 60%);
 $note-border:        $primary-color;
 
+$note-red-text:      darken($alert-color, 10%);
+$note-red-bg:        lighten($alert-color, 40%);
+$note-red-border:    $alert-color;
+
+$note-green-text:    darken($success-color, 10%);
+$note-green-bg:      lighten($success-color, 40%);
+$note-green-border:  $success-color;
+
+$note-blue-text:     darken($primary-color, 10%);
+$note-blue-bg:       lighten($primary-color, 60%);
+$note-blue-border:   $primary-color;
+
+$note-yellow-text:   darken($warning-color, 10%);
+$note-yellow-bg:     lighten($warning-color, 40%);
+$note-yellow-border: $warning-color;
+
 $border-top-size: 8px;
 
 #notes {
@@ -11,6 +27,34 @@ $border-top-size: 8px;
     border-color: rgba(0, 0, 0, 0.1);
 
     &:first-child { box-shadow: 0 -#{$border-top-size} 0 0 $note-border; }
+
+    &.note--style-red {
+      color: $note-red-text;
+      background-color: $note-red-bg;
+      &:first-child { box-shadow: 0 -#{$border-top-size} 0 0 $note-red-border; }
+      h1 { color: $note-red-text; }
+    }
+
+    &.note--style-green {
+      color: $note-green-text;
+      background-color: $note-green-bg;
+      &:first-child { box-shadow: 0 -#{$border-top-size} 0 0 $note-green-border; }
+      h1 { color: $note-green-text; }
+    }
+
+    &.note--style-blue {
+      color: $note-blue-text;
+      background-color: $note-blue-bg;
+      &:first-child { box-shadow: 0 -#{$border-top-size} 0 0 $note-blue-border; }
+      h1 { color: $note-blue-text; }
+    }
+
+    &.note--style-yellow {
+      color: $note-yellow-text;
+      background-color: $note-yellow-bg;
+      &:first-child { box-shadow: 0 -#{$border-top-size} 0 0 $note-yellow-border; }
+      h1 { color: $note-yellow-text; }
+    }
 
     h1 {
       font-size: 1.5em;
@@ -30,6 +74,15 @@ $border-top-size: 8px;
     h6 {
       font-size: 0.9em;
       text-transform: uppercase;
+    }
+
+    &.note--style-red,
+    &.note--style-green,
+    &.note--style-blue,
+    &.note--style-yellow {
+      h1 {
+        font-size: 1.3em;
+      }
     }
   }
 }

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -54,7 +54,7 @@ class Admin::NotesController < AdminController
   def note_params
     translatable_params(
       params.require(:note),
-      translated_keys: [:locale, :body],
+      translated_keys: [:locale, :body, :rich_body],
       general_keys: [:notable_tag, :notable_id, :notable_type, :style]
     )
   end

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -55,7 +55,7 @@ class Admin::NotesController < AdminController
     translatable_params(
       params.require(:note),
       translated_keys: [:locale, :body],
-      general_keys: [:notable_tag, :notable_id, :notable_type]
+      general_keys: [:notable_tag, :notable_id, :notable_type, :style]
     )
   end
 end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -14,6 +14,7 @@ module NotesHelper
     tag.aside(**options.merge(id: 'notes')) do
       notes.each do |note|
         note_classes = ['note']
+        note_classes << "note--style-#{note.style}"
         note_classes << "tag-#{note.notable_tag}" if note.notable_tag
 
         concat tag.article note_as_html(note, batch: batch),

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -1,11 +1,8 @@
 module NotesHelper
-  def note_as_text(note)
-    strip_tags(note.body)
-  end
-
   def note_as_html(note, batch: false)
     allowed_tags = batch ? batch_notes_allowed_tags : notes_allowed_tags
-    sanitize(note.body, tags: allowed_tags)
+    content = note.original_style? ? note.body : note.rich_body.to_trix_html
+    sanitize(content, tags: allowed_tags)
   end
 
   def render_notes(notes, batch: false, **options)

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -1,15 +1,22 @@
 module NotesHelper
+  def note_as_text(note)
+    strip_tags(note.body)
+  end
+
+  def note_as_html(note, batch: false)
+    allowed_tags = batch ? batch_notes_allowed_tags : notes_allowed_tags
+    sanitize(note.body, tags: allowed_tags)
+  end
+
   def render_notes(notes, batch: false, **options)
     return unless notes.present?
-
-    allowed_tags = batch ? batch_notes_allowed_tags : notes_allowed_tags
 
     tag.aside(**options.merge(id: 'notes')) do
       notes.each do |note|
         note_classes = ['note']
         note_classes << "tag-#{note.notable_tag}" if note.notable_tag
 
-        concat tag.article sanitize(note.body, tags: allowed_tags),
+        concat tag.article note_as_html(note, batch: batch),
                            id: dom_id(note),
                            class: note_classes
       end

--- a/app/helpers/notes_helper.rb
+++ b/app/helpers/notes_helper.rb
@@ -12,7 +12,7 @@ module NotesHelper
     return unless notes.present?
 
     tag.aside(**options.merge(id: 'notes')) do
-      notes.each do |note|
+      Note.sort(notes).each do |note|
         note_classes = ['note']
         note_classes << "note--style-#{note.style}"
         note_classes << "tag-#{note.notable_tag}" if note.notable_tag

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220720085105
+# Schema version: 20240227080436
 #
 # Table name: notes
 #
@@ -9,6 +9,7 @@
 #  notable_tag  :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  style        :string           default("original"), not null
 #  body         :text
 #
 
@@ -18,9 +19,23 @@ class Note < ApplicationRecord
   translates :body
   include Translatable
 
+  cattr_accessor :default_style, default: 'original'
+  cattr_accessor :style_labels, default: {
+    '🔵 Blue': 'blue',
+    '🔴 Red': 'red',
+    '🟢 Green': 'green',
+    '🟡 Yellow': 'yellow',
+    'Original': 'original'
+  }
+
+  enum :style, Note.style_labels.values.index_by(&:itself),
+               default: Note.default_style,
+               suffix: true
+
   belongs_to :notable, polymorphic: true
 
   validates :body, presence: true
+  validates :style, presence: true
   validates :notable_or_notable_tag, presence: true
 
   private

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -38,6 +38,10 @@ class Note < ApplicationRecord
   validates :style, presence: true
   validates :notable_or_notable_tag, presence: true
 
+  def self.sort(notes)
+    notes.sort_by! { Note.style_labels.values.index(_1.style) }
+  end
+
   private
 
   def notable_or_notable_tag

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -666,7 +666,7 @@ class PublicBody < ApplicationRecord
   end
 
   def notes_as_string
-    notes.map(&:body).join(' ')
+    notes.map(&:to_plain_text).join(' ')
   end
 
   def has_notes?

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -662,7 +662,7 @@ class PublicBody < ApplicationRecord
   end
 
   def notes
-    all_notes
+    Note.sort(all_notes)
   end
 
   def notes_as_string

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/admin/notes/_form.html.erb
+++ b/app/views/admin/notes/_form.html.erb
@@ -11,6 +11,13 @@
   <% end %>
 </div>
 
+<div class="control-group">
+  <%= f.label :style, class: 'control-label' %>
+  <div class="controls">
+    <%= f.select :style, Note.style_labels %>
+  </div>
+</div>
+
 <% f.translated_fields do |t| %>
   <%= render partial: 'locale_fields', locals: { t: t } %>
 <% end %>

--- a/app/views/admin/notes/_locale_fields.html.erb
+++ b/app/views/admin/notes/_locale_fields.html.erb
@@ -1,6 +1,13 @@
-<div class="control-group">
+<div id="bodyInput" class="control-group">
   <%= t.label :body, class: 'control-label' %>
   <div class="controls">
-    <%= t.text_area :body, class: 'span6', rows: 10 %>
+    <%= t.text_area :body, class: 'input-block-level', rows: 10 %>
+  </div>
+</div>
+
+<div id="richBodyInput" class="control-group">
+  <%= t.label :rich_body, 'Body', class: 'control-label' %>
+  <div class="controls">
+    <%= t.rich_text_area :rich_body %>
   </div>
 </div>

--- a/app/views/admin/notes/_note.html.erb
+++ b/app/views/admin/notes/_note.html.erb
@@ -2,7 +2,7 @@
   <div class="accordion-heading accordion-toggle row">
     <span class="item-title span6">
       <%= link_to chevron_right, "##{dom_id(note)}", data: { toggle: 'collapse', parent: 'notes' } %>
-      <%= link_to(note_as_text(note), edit_admin_note_path(note), title: 'view full details') %>
+      <%= link_to(note.to_plain_text, edit_admin_note_path(note), title: 'view full details') %>
     </span>
 
     <span class="item-metadata span6">

--- a/app/views/admin/notes/_note.html.erb
+++ b/app/views/admin/notes/_note.html.erb
@@ -2,7 +2,7 @@
   <div class="accordion-heading accordion-toggle row">
     <span class="item-title span6">
       <%= link_to chevron_right, "##{dom_id(note)}", data: { toggle: 'collapse', parent: 'notes' } %>
-      <%= link_to(note.body, edit_admin_note_path(note), title: 'view full details') %>
+      <%= link_to(note_as_text(note), edit_admin_note_path(note), title: 'view full details') %>
     </span>
 
     <span class="item-metadata span6">

--- a/app/views/admin/notes/_show.html.erb
+++ b/app/views/admin/notes/_show.html.erb
@@ -14,7 +14,7 @@
         <tr class="<%= cycle('odd', 'even') %>">
           <td class="id"><%= h note.id %></td>
           <td class="notable_id"><%= h note.notable_id %></td>
-          <td class="body_snippet"><%= truncate(h(note.body), length: 50) %></td>
+          <td class="body_snippet"><%= truncate(note_as_text(note), length: 50) %></td>
           <td class="notable_type"><%= h note.notable_type %></td>
           <td class="notable_tag"><%= h note.notable_tag %></td>
           <td><%= link_to "Edit", edit_admin_note_path(note) %></td>

--- a/app/views/admin/notes/_show.html.erb
+++ b/app/views/admin/notes/_show.html.erb
@@ -16,7 +16,7 @@
           <td class="id"><%= h note.id %></td>
           <td class="notable_id"><%= h note.notable_id %></td>
           <td class="style"><%= note.style %></td>
-          <td class="body_snippet"><%= truncate(note_as_text(note), length: 50) %></td>
+          <td class="body_snippet"><%= truncate(note.to_plain_text, length: 50) %></td>
           <td class="notable_type"><%= h note.notable_type %></td>
           <td class="notable_tag"><%= h note.notable_tag %></td>
           <td><%= link_to "Edit", edit_admin_note_path(note) %></td>

--- a/app/views/admin/notes/_show.html.erb
+++ b/app/views/admin/notes/_show.html.erb
@@ -4,6 +4,7 @@
       <tr>
         <th>ID</th>
         <th>Notable ID</th>
+        <th>Style</th>
         <th>Note Body</th>
         <th>Notable type</th>
         <th>Notable tag</th>
@@ -14,6 +15,7 @@
         <tr class="<%= cycle('odd', 'even') %>">
           <td class="id"><%= h note.id %></td>
           <td class="notable_id"><%= h note.notable_id %></td>
+          <td class="style"><%= note.style %></td>
           <td class="body_snippet"><%= truncate(note_as_text(note), length: 50) %></td>
           <td class="notable_type"><%= h note.notable_type %></td>
           <td class="notable_tag"><%= h note.notable_tag %></td>

--- a/app/views/layouts/action_text/contents/_content.html.erb
+++ b/app/views/layouts/action_text/contents/_content.html.erb
@@ -1,0 +1,3 @@
+<div class="trix-content">
+  <%= yield -%>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -11,6 +11,9 @@
     <%= javascript_include_tag "admin" %>
     <%= stylesheet_link_tag "admin", :title => "Main", :rel => "stylesheet" %>
     <%= stylesheet_link_tag 'admin/print', :rel => "stylesheet", :media => "print"  %>
+
+    <script type="text/javascript" src="https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js"></script>
+
     <%= render :partial => 'layouts/favicon' %>
 
   </head>

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require "active_storage/engine"
 require "action_controller/railtie"
 require "action_mailer/railtie"
 # require "action_mailbox/engine"
-# require "action_text/engine"
+require "action_text/engine"
 require "action_view/railtie"
 # require "action_cable/engine"
 require "sprockets/railtie"
@@ -34,6 +34,7 @@ module Alaveteli
     config.autoloader = :zeitwerk
     config.active_record.legacy_connection_handling = false
     config.active_support.use_rfc4122_namespaced_uuids = true
+    config.active_storage.replace_on_assign_to_many = true
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/db/migrate/20240227080436_add_style_to_notes.rb
+++ b/db/migrate/20240227080436_add_style_to_notes.rb
@@ -1,0 +1,5 @@
+class AddStyleToNotes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :notes, :style, :string, default: 'original', null: false
+  end
+end

--- a/db/migrate/20240228122324_create_action_text_tables.action_text.rb
+++ b/db/migrate/20240228122324_create_action_text_tables.action_text.rb
@@ -1,0 +1,29 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :action_text_rich_texts, id: primary_key_type do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record,
+        null: false, polymorphic: true, index: false, type: foreign_key_type
+
+      t.timestamps
+
+      t.index [:record_type, :record_id, :name],
+        name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+
+  private
+
+  def primary_and_foreign_key_types
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    primary_key_type = setting || :primary_key
+    foreign_key_type = setting || :bigint
+    [primary_key_type, foreign_key_type]
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add styling option and rich text editor to the notes admin (Graeme Porteous)
 * Strengthen 2FA warning. Users *must* remember to keep this code safe (Gareth
   Rees)
 * Broaden citation type classifications to cover wider thematic areas and add

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe Admin::NotesController do
       end
 
       it 'creates the note' do
-        expect(assigns[:note].body).to eq('New body')
+        expect(assigns[:note].rich_body.to_plain_text).to eq('New body')
       end
 
       it 'sets a notice' do
@@ -64,7 +64,7 @@ RSpec.describe Admin::NotesController do
         {
           id: note.id,
           note: {
-            body: 'New body',
+            rich_body: 'New body',
             notable_id: public_body.id,
             notable_type: public_body.class.name,
             style: 'blue'
@@ -86,7 +86,7 @@ RSpec.describe Admin::NotesController do
       let(:params) do
         {
           id: note.id,
-          note: { body: 'New body', notable_tag: tag, style: 'blue' }
+          note: { rich_body: 'New body', notable_tag: tag, style: 'blue' }
         }
       end
 
@@ -97,7 +97,7 @@ RSpec.describe Admin::NotesController do
 
     context 'on an unsuccessful create' do
       let(:params) do
-        { note: { body: '', style: '' } }
+        { note: { rich_body: '', style: '' } }
       end
 
       it 'assigns the note' do
@@ -145,7 +145,7 @@ RSpec.describe Admin::NotesController do
       end
 
       it 'updates the note' do
-        expect(note.reload.body).to eq('New body')
+        expect(note.reload.rich_body.to_plain_text).to eq('New body')
       end
 
       it 'sets a notice' do
@@ -163,7 +163,7 @@ RSpec.describe Admin::NotesController do
         {
           id: note.id,
           note: {
-            body: 'New body',
+            rich_body: 'New body',
             notable_id: public_body.id,
             notable_type: public_body.class.name,
             style: 'blue'
@@ -185,7 +185,7 @@ RSpec.describe Admin::NotesController do
       let(:params) do
         {
           id: note.id,
-          note: { body: 'New body', notable_tag: tag, style: 'blue' }
+          note: { rich_body: 'New body', notable_tag: tag, style: 'blue' }
         }
       end
 
@@ -196,7 +196,7 @@ RSpec.describe Admin::NotesController do
 
     context 'on an unsuccessful update' do
       let(:params) do
-        { id: note.id, note: { body: '', style: '' } }
+        { id: note.id, note: { rich_body: '', style: '' } }
       end
 
       it 'assigns the note' do
@@ -204,7 +204,7 @@ RSpec.describe Admin::NotesController do
       end
 
       it 'does not update the note' do
-        expect(note.reload.body).not_to be_blank
+        expect(note.reload.rich_body).not_to be_blank
       end
 
       it 'renders the form again' do

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -66,7 +66,8 @@ RSpec.describe Admin::NotesController do
           note: {
             body: 'New body',
             notable_id: public_body.id,
-            notable_type: public_body.class.name
+            notable_type: public_body.class.name,
+            style: 'blue'
           }
         }
       end
@@ -85,7 +86,7 @@ RSpec.describe Admin::NotesController do
       let(:params) do
         {
           id: note.id,
-          note: { body: 'New body', notable_tag: tag }
+          note: { body: 'New body', notable_tag: tag, style: 'blue' }
         }
       end
 
@@ -96,7 +97,7 @@ RSpec.describe Admin::NotesController do
 
     context 'on an unsuccessful create' do
       let(:params) do
-        { note: { body: '' } }
+        { note: { body: '', style: '' } }
       end
 
       it 'assigns the note' do
@@ -164,7 +165,8 @@ RSpec.describe Admin::NotesController do
           note: {
             body: 'New body',
             notable_id: public_body.id,
-            notable_type: public_body.class.name
+            notable_type: public_body.class.name,
+            style: 'blue'
           }
         }
       end
@@ -183,7 +185,7 @@ RSpec.describe Admin::NotesController do
       let(:params) do
         {
           id: note.id,
-          note: { body: 'New body', notable_tag: tag }
+          note: { body: 'New body', notable_tag: tag, style: 'blue' }
         }
       end
 
@@ -194,7 +196,7 @@ RSpec.describe Admin::NotesController do
 
     context 'on an unsuccessful update' do
       let(:params) do
-        { id: note.id, note: { body: '' } }
+        { id: note.id, note: { body: '', style: '' } }
       end
 
       it 'assigns the note' do

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -15,7 +15,7 @@
 
 FactoryBot.define do
   factory :note do
-    body { 'Test note' }
+    rich_body { 'Test note' }
     association :notable, factory: :public_body
     notable_tag { 'some_tag' }
     style { 'blue' }
@@ -28,6 +28,11 @@ FactoryBot.define do
     trait :tagged do
       notable { nil }
       notable_tag { 'foo' }
+    end
+
+    trait :original do
+      body { 'Test note' }
+      style { 'original' }
     end
   end
 end

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220720085105
+# Schema version: 20240227080436
 #
 # Table name: notes
 #
@@ -9,6 +9,7 @@
 #  notable_tag  :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  style        :string           default("original"), not null
 #  body         :text
 #
 
@@ -17,6 +18,7 @@ FactoryBot.define do
     body { 'Test note' }
     association :notable, factory: :public_body
     notable_tag { 'some_tag' }
+    style { 'blue' }
 
     trait :for_public_body do
       association :notable, factory: :public_body

--- a/spec/factories/public_bodies.rb
+++ b/spec/factories/public_bodies.rb
@@ -52,7 +52,7 @@ FactoryBot.define do
       end
 
       concrete_notes do
-        [association(:note, body: note_body)]
+        [association(:note, rich_body: note_body)]
       end
     end
 

--- a/spec/fixtures/notes.yml
+++ b/spec/fixtures/notes.yml
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220928093559
+# Schema version: 20240227080436
 #
 # Table name: notes
 #
@@ -9,6 +9,7 @@
 #  notable_tag  :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  style        :string           default("original"), not null
 #  body         :text
 #
 

--- a/spec/helpers/notes_helper_spec.rb
+++ b/spec/helpers/notes_helper_spec.rb
@@ -3,35 +3,61 @@ require 'spec_helper'
 RSpec.describe NotesHelper do
   include NotesHelper
 
-  describe '#render_notes' do
+  describe '#note_as_text' do
+    subject { note_as_text(note) }
+
+    let(:note) { FactoryBot.build(:note, body: '<h1>title</h1>') }
+
+    it { is_expected.to eq('title') }
+  end
+
+  describe '#note_as_html' do
     let(:note) { FactoryBot.build(:note, body: '<h1>title</h1>') }
 
     context 'when not a batch' do
-      subject { render_notes([note], class: 'notes') }
+      subject { note_as_html(note, batch: false) }
 
       it 'allows more tags' do
-        is_expected.to eq(
-          '<aside class="notes" id="notes">' \
-            '<article id="new_note" class="note tag-some_tag">' \
-              '<h1>title</h1>' \
-            '</article>' \
-          '</aside>'
-        )
+        is_expected.to eq('<h1>title</h1>')
       end
     end
 
     context 'when batch' do
-      subject { render_notes([note], batch: true, class: 'notes') }
+      subject { note_as_html(note, batch: true) }
 
       it 'removes more tags' do
-        is_expected.to eq(
-          '<aside class="notes" id="notes">' \
-            '<article id="new_note" class="note tag-some_tag">' \
-              'title' \
-            '</article>' \
-          '</aside>'
-        )
+        is_expected.to eq('title')
       end
+    end
+  end
+
+  describe '#render_notes' do
+    let(:note) { FactoryBot.build(:note, body: '<h1>title</h1>') }
+
+    it 'wrap notes in aside and article tags' do
+      expect(self).to receive(:note_as_html).with(note, batch: false).
+        and_return('foo')
+
+      expect(render_notes([note], class: 'notes')).to eq(
+        '<aside class="notes" id="notes">' \
+          '<article id="new_note" class="note tag-some_tag">' \
+            'foo' \
+          '</article>' \
+        '</aside>'
+      )
+    end
+
+    it 'pass batch argument to note_as_html' do
+      expect(self).to receive(:note_as_html).with(note, batch: true).
+        and_return('bar')
+
+      expect(render_notes([note], batch: true)).to eq(
+        '<aside id="notes">' \
+          '<article id="new_note" class="note tag-some_tag">' \
+            'bar' \
+          '</article>' \
+        '</aside>'
+      )
     end
 
     context 'without notes' do

--- a/spec/helpers/notes_helper_spec.rb
+++ b/spec/helpers/notes_helper_spec.rb
@@ -3,16 +3,15 @@ require 'spec_helper'
 RSpec.describe NotesHelper do
   include NotesHelper
 
-  describe '#note_as_text' do
-    subject { note_as_text(note) }
-
-    let(:note) { FactoryBot.build(:note, body: '<h1>title</h1>') }
-
-    it { is_expected.to eq('title') }
-  end
-
   describe '#note_as_html' do
-    let(:note) { FactoryBot.build(:note, body: '<h1>title</h1>') }
+    let(:note) { FactoryBot.build(:note, rich_body: '<h1>title</h1>') }
+
+    it { expect(note_as_html(note)).to eq('<h1>title</h1>') }
+
+    context 'with original style note' do
+      let(:note) { FactoryBot.build(:note, :original, body: '<h1>title</h1>') }
+      it { expect(note_as_html(note)).to eq('<h1>title</h1>') }
+    end
 
     context 'when not a batch' do
       subject { note_as_html(note, batch: false) }
@@ -32,7 +31,7 @@ RSpec.describe NotesHelper do
   end
 
   describe '#render_notes' do
-    let(:note) { FactoryBot.build(:note, body: '<h1>title</h1>') }
+    let(:note) { FactoryBot.build(:note, rich_body: '<h1>title</h1>') }
 
     it 'wrap notes in aside and article tags' do
       expect(self).to receive(:note_as_html).with(note, batch: false).

--- a/spec/helpers/notes_helper_spec.rb
+++ b/spec/helpers/notes_helper_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe NotesHelper do
 
       expect(render_notes([note], class: 'notes')).to eq(
         '<aside class="notes" id="notes">' \
-          '<article id="new_note" class="note tag-some_tag">' \
+          '<article id="new_note" class="note note--style-blue tag-some_tag">' \
             'foo' \
           '</article>' \
         '</aside>'
@@ -53,7 +53,7 @@ RSpec.describe NotesHelper do
 
       expect(render_notes([note], batch: true)).to eq(
         '<aside id="notes">' \
-          '<article id="new_note" class="note tag-some_tag">' \
+          '<article id="new_note" class="note note--style-blue tag-some_tag">' \
             'bar' \
           '</article>' \
         '</aside>'

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -70,4 +70,21 @@ RSpec.describe Note, type: :model do
       end
     end
   end
+
+  describe '.sort' do
+    let(:original) { FactoryBot.build(:note, :original) }
+    let(:red) { FactoryBot.build(:note, style: 'red') }
+    let(:green) { FactoryBot.build(:note, style: 'green') }
+    let(:blue_1) { FactoryBot.build(:note, style: 'blue') }
+    let(:blue_2) { FactoryBot.build(:note, style: 'blue') }
+    let(:yellow) { FactoryBot.build(:note, style: 'yellow') }
+
+    subject do
+      described_class.sort([yellow, blue_1, green, red, original, blue_2])
+    end
+
+    it 'sorts based on enum value index' do
+      is_expected.to match_array([original, blue_1, blue_2, red, green, yellow])
+    end
+  end
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20220720085105
+# Schema version: 20240227080436
 #
 # Table name: notes
 #
@@ -9,6 +9,7 @@
 #  notable_tag  :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  style        :string           default("original"), not null
 #  body         :text
 #
 
@@ -23,6 +24,16 @@ RSpec.describe Note, type: :model do
     it 'requires body' do
       note.body = nil
       expect(note).not_to be_valid
+    end
+
+    it 'requires style' do
+      note.style = nil
+      expect(note).not_to be_valid
+    end
+
+    it 'requires known style' do
+      expect { note.style = 'invalid' }.
+        to raise_error(ArgumentError, "'invalid' is not a valid style")
     end
 
     it 'requires notable or notable_tag' do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -597,11 +597,12 @@ RSpec.describe PublicBody do
 
     let!(:concrete_note) do
       FactoryBot.create(:note, :for_public_body,
-                        body: 'bar', notable: public_body)
+                        rich_body: 'bar', notable: public_body)
     end
 
     let!(:tagged_note) do
-      FactoryBot.create(:note, :tagged, body: 'baz', notable_tag: 'important')
+      FactoryBot.create(:note, :tagged,
+                        rich_body: 'baz', notable_tag: 'important')
     end
 
     it 'concaterates note bodies' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7771
Fixes #7809

## What does this do?

Add styling and rich text notes

## Why was this needed?

Enable easier styling of note content.

## Implementation notes

Have added an "original" style which renders notes as they are currently. Eventually we might choose to migrate current notes on WDTK and remove this style.

## Screenshots

<img width="954" alt="image" src="https://github.com/mysociety/alaveteli/assets/5426/2b75e044-948e-4341-963d-aab710581300">
<img width="1009" alt="image" src="https://github.com/mysociety/alaveteli/assets/5426/7bd4e00f-9040-4fd9-ac38-4ead9e0b244b">
