### PR TITLE
Fix missing headers when exporting Project data

### DIFF
--- a/app/models/project/export/info_request.rb
+++ b/app/models/project/export/info_request.rb
@@ -24,7 +24,7 @@ class Project::Export::InfoRequest < SimpleDelegator
       latest_status_contributor: status_contributor,
       status: described_state,
       dataset_contributor: dataset_contributor
-    }.merge(extracted_values_as_hash)
+    }.merge(dataset_values)
   end
 
   private
@@ -51,6 +51,12 @@ class Project::Export::InfoRequest < SimpleDelegator
     return unless extraction_submission
 
     extraction_submission.user.name
+  end
+
+  def dataset_values
+    project.key_set.keys.pluck(:title).each_with_object({}) do |key, memo|
+      memo[key] = extracted_values_as_hash[key]
+    end
   end
 
   def extracted_values

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix missing headers when exporting Project data (Gareth Rees)
 * Reduce amount of storage related background jobs (Graeme Porteous)
 * Add automatic parsing of emails contain Excel spreadsheets (Graeme Porteous)
 * Improve rendering of admin hidden request prominence and explanations (Graeme

--- a/spec/models/project/export/info_request_spec.rb
+++ b/spec/models/project/export/info_request_spec.rb
@@ -6,6 +6,10 @@ RSpec.describe Project::Export::InfoRequest do
   include LinkToHelper
 
   let(:project) { FactoryBot.build(:project) }
+
+  let(:key_set) { FactoryBot.build(:dataset_key_set, resource: project) }
+  let!(:dataset_key) { FactoryBot.create(:dataset_key, key_set: key_set) }
+
   let(:contributor) { FactoryBot.build(:user) }
 
   let(:public_body) { FactoryBot.build(:public_body) }
@@ -71,7 +75,8 @@ RSpec.describe Project::Export::InfoRequest do
           request_owner: info_request.user.name,
           latest_status_contributor: contributor.name,
           status: info_request.described_state,
-          dataset_contributor: nil
+          dataset_contributor: nil,
+          'Were there any errors?' => nil
         )
       end
     end


### PR DESCRIPTION
Project::Export uses the first request in the project to generate the CSV headers. However, if the request hasn't had data extracted, the headers for the dataset columns will be blank, even though other requests in the project may have had a dataset extraction.

This commit ensures that headers are always present by looking up the project's key set, and iterating through that to fetch the relevant submission value for that key, or otherwise assigning a nil value.

This has the benefit of ensuring that the keys/values exported are always in sync with the current project key set.

Fixes https://github.com/mysociety/alaveteli/issues/8141.

