### PR TITLE
Add default and constraint to CensorRule#regexp

### DIFF
--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20240313094449
 #
 # Table name: censor_rules
 #
@@ -13,7 +13,7 @@
 #  last_edit_comment :text             not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  regexp            :boolean
+#  regexp            :boolean          default(FALSE), not null
 #
 
 # models/censor_rule.rb:

--- a/db/migrate/20240313094449_add_not_null_constraint_to_censor_rule_regexp.rb
+++ b/db/migrate/20240313094449_add_not_null_constraint_to_censor_rule_regexp.rb
@@ -1,0 +1,12 @@
+class AddNotNullConstraintToCensorRuleRegexp < ActiveRecord::Migration[7.0]
+  def up
+    change_column_default :censor_rules, :regexp, false
+    CensorRule.where(regexp: nil).update_all(regexp: false)
+    change_column_null :censor_rules, :regexp, false
+  end
+
+  def down
+    change_column_null :censor_rules, :regexp, true
+    change_column_default :censor_rules, :regexp, nil
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add default value and not null constraint to `CensorRule#regexp` (Gareth Rees)
 * Reduce amount of storage related background jobs (Graeme Porteous)
 * Add automatic parsing of emails contain Excel spreadsheets (Graeme Porteous)
 * Improve rendering of admin hidden request prominence and explanations (Graeme

--- a/spec/factories/censor_rules.rb
+++ b/spec/factories/censor_rules.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20240313094449
 #
 # Table name: censor_rules
 #
@@ -13,7 +13,7 @@
 #  last_edit_comment :text             not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  regexp            :boolean
+#  regexp            :boolean          default(FALSE), not null
 #
 
 FactoryBot.define do

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20210114161442
+# Schema version: 20240313094449
 #
 # Table name: censor_rules
 #
@@ -13,7 +13,7 @@
 #  last_edit_comment :text             not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
-#  regexp            :boolean
+#  regexp            :boolean          default(FALSE), not null
 #
 
 require 'spec_helper'


### PR DESCRIPTION
Add default value and not null constraint to `CensorRule#regexp`. While effectively the same behaviour, this makes the intent explicit and prevents empty values appearing in admin tables where we render censor rules.

**BEFORE**

![Screenshot 2024-03-13 at 09 59 23](https://github.com/mysociety/alaveteli/assets/282788/bc3404f1-0e58-4b24-a714-1b95088fd5fd)

**AFTER**

![Screenshot 2024-03-13 at 09 59 32](https://github.com/mysociety/alaveteli/assets/282788/630b892e-6540-45c7-8414-2e9cd3b4d36c)
