### PR TITLE
Fix loading of admin attachment view

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -51,7 +51,7 @@ class FoiAttachment < ApplicationRecord
   scope :binary, -> { where.not(content_type: AlaveteliTextMasker::TextMask) }
 
   delegate :expire, :log_event, to: :info_request
-  delegate :metadata, to: :file_blob
+  delegate :metadata, to: :file_blob, allow_nil: true
 
   admin_columns exclude: %i[url_part_number within_rfc822_subject hexdigest],
                 include: %i[metadata]


### PR DESCRIPTION
When an attachment doesn't have a blob the metadata can't be delegated resulting in exceptions on the admin view where the metadata is displayed.

## What does this do?

Fix loading of admin attachment view

## Why was this needed?

When an attachment doesn't have a blob the metadata can't be delegated resulting in exceptions on the admin view where the metadata is displayed.

<hr>

[skip changelog]
