### PR TITLE
Update pro batch category feature condition

### DIFF
--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -41,7 +41,7 @@ Rails.configuration.after_initialize do
     :pro_batch_category_ui,
     label: 'Batch category user interface',
     condition: -> {
-      PublicBodyCategory.joins(:public_bodies).any?
+      PublicBody.category_root.children.any?
     }
   )
   batch_add_all = AlaveteliFeatures.features.add(


### PR DESCRIPTION
## What does this do?

Update pro batch category feature condition

## Why was this needed?

Since the migration from `PublicBodyCategory` to `Category` this feature could not be enabled for new installs which have no `PublicBodyCategory` instances.

<hr>

[skip changelog]