### PR TITLE
[#8181] Fix attachment blob integrity error

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -96,6 +96,8 @@ class FoiAttachment < ApplicationRecord
     ensure_filename!
     if file.attached?
       file_blob.upload(StringIO.new(d.to_s), identify: false)
+      file_blob.save
+
     else
       file.attach(
         io: StringIO.new(d.to_s),

--- a/config/sidekiq.yml-example
+++ b/config/sidekiq.yml-example
@@ -7,6 +7,8 @@ production:
 :queues:
   - default
   - xapian
+  - low
 
 :limits:
   xapian: 1
+  low: 1

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -125,6 +125,16 @@ RSpec.describe FoiAttachment do
       expect { attachment.update(body: 'masked', masked_at: Time.now) }.
         to_not change { attachment.file_blob.metadata }
     end
+
+    it 'persists changes to existing blob checksum' do
+      attachment = FactoryBot.create(
+        :foi_attachment, :unmasked, body: 'unmasked'
+      )
+
+      expect { attachment.update(body: 'masked', masked_at: Time.now) }.
+        to change { attachment.file_blob.checksum }
+      expect(attachment.file_blob.changed?).to eq false
+    end
   end
 
   describe '#body' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8181

## What does this do?

Fix attachment blob integrity error

## Why was this needed?

Error introduced in https://github.com/mysociety/alaveteli/pull/8125 which meant the on disk attachment could be updated but the checksum wasn't which means `ActiveStorage::IntegrityError` can be raised. This happens when running the storage mirror task and probably at other times too.

## Implementation notes

Change to the task only need to be temporary until attachments are mirrored.

<hr>

[skip changelog] - not needed as fix for unreleased change