### PR TITLE
[#8179] Replace public body categories

### DIFF
--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -144,8 +144,8 @@ class PublicBodyController < ApplicationController
              count: @public_bodies.total_entries,
              first_letter: @tag)
         else
-          category_name = PublicBodyCategory.get.by_tag[@tag]
-          if category_name.nil?
+          category = PublicBody.category_list.find_by(category_tag: @tag)
+          if category.nil?
             n_('Found {{count}} public authority matching the tag ' \
                '‘{{tag_name}}’',
                'Found {{count}} public authorities matching the tag ' \
@@ -155,12 +155,12 @@ class PublicBodyController < ApplicationController
                tag_name: @tag)
           else
             n_('Found {{count}} public authority in the category ' \
-               '‘{{category_name}}’',
+               '‘{{category}}’',
                'Found {{count}} public authorities in the category ' \
-               '‘{{category_name}}’',
+               '‘{{category}}’',
                @public_bodies.total_entries,
                count: @public_bodies.total_entries,
-               category_name: category_name)
+               category: category.title)
           end
         end
 

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -820,7 +820,9 @@ class PublicBody < ApplicationRecord
     return all if tag.size == 1 || tag.nil? || tag == 'all'
 
     if tag == 'other'
-      tags = PublicBodyCategory.get.tags - ['other']
+      tags = PublicBody.category_list.distinct.
+        where.not(category_tag: [nil, '', 'other']).
+        pluck(:category_tag)
       where.not("EXISTS(#{tag_search_sql(tags)})")
     else
       original_with_tag(tag)

--- a/lib/tasks/export.rake
+++ b/lib/tasks/export.rake
@@ -11,15 +11,6 @@ namespace :export do
     default_scope -> { order(:info_request_batch_id, :public_body_id) }
   end
 
-  class PublicBodyCategoryTranslation < ActiveRecord::Base
-    self.table_name = "public_body_category_translations"
-    belongs_to :public_body_category
-  end
-
-  class PublicBodyHeadingTranslation < ActiveRecord::Base
-    self.table_name = "public_body_heading_translations"
-    belongs_to :public_body_heading
-  end
 
   class HasTagStringTag < ActiveRecord::Base
     self.table_name = "has_tag_string_tags"
@@ -48,11 +39,11 @@ namespace :export do
 
     to_run = to_run.split(",") if to_run
 
-    DataExport.csv_export(PublicBodyCategory, to_run)
-    DataExport.csv_export(PublicBodyHeading, to_run)
-    DataExport.csv_export(PublicBodyCategoryLink, to_run)
-    DataExport.csv_export(PublicBodyCategoryTranslation, to_run)
-    DataExport.csv_export(PublicBodyHeadingTranslation, to_run)
+    DataExport.csv_export(
+      Category, to_run, Category,
+      %w[id title description category_tag created_at updated_at]
+    )
+    DataExport.csv_export(CategoryRelationship, to_run)
     DataExport.csv_export(InfoRequestBatchPublicBody, to_run)
     DataExport.csv_export(HasTagStringTag,
                           to_run,

--- a/spec/controllers/public_body_controller_spec.rb
+++ b/spec/controllers/public_body_controller_spec.rb
@@ -328,14 +328,7 @@ RSpec.describe PublicBodyController, "when listing bodies" do
   end
 
   it "should list a tagged thing on the appropriate list page, and others on the other page, and all still on the all page" do
-    PublicBodyCategory.destroy_all
-    PublicBodyHeading.destroy_all
-    PublicBodyCategoryLink.destroy_all
-
-    category = FactoryBot.create(:public_body_category)
-    heading = FactoryBot.create(:public_body_heading)
-    PublicBodyCategoryLink.create(public_body_heading_id: heading.id,
-                                  public_body_category_id: category.id)
+    category = FactoryBot.create(:category, :public_body, category_tag: 'dink')
     public_bodies(:humpadink_public_body).tag_string = category.category_tag
 
     get :list, params: { tag: category.category_tag }
@@ -351,10 +344,7 @@ RSpec.describe PublicBodyController, "when listing bodies" do
     expect(assigns[:public_bodies]).to eq(
       [
         public_bodies(:other_public_body),
-        public_bodies(:forlorn_public_body),
-        public_bodies(:geraldine_public_body),
         public_bodies(:sensible_walks_public_body),
-        public_bodies(:silly_walks_public_body)
       ]
     )
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -163,9 +163,6 @@ RSpec.describe PublicBody do
     it 'should returns authorities without categories' do
       pbs = PublicBody.with_tag('other')
       expect(pbs).to match_array([
-        public_bodies(:geraldine_public_body),
-        public_bodies(:humpadink_public_body),
-        public_bodies(:silly_walks_public_body),
         public_bodies(:sensible_walks_public_body),
         public_bodies(:other_public_body)
       ])


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8179

## What does this do?

Replace old public body categories models

## Why was this needed?

Model has been replaced but we still have references to it in places.

## Implementation notes

Only remaining references are in the old models and temp rake tasks which migrates to the new Category model.

<hr>

[skip changelog]