### PR TITLE
[#7693] Update InfoRequest#recipient_name_and_email

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1265,13 +1265,17 @@ class InfoRequest < ApplicationRecord
   end
 
   def recipient_name_and_email
-    MailHandler.address_from_name_and_email(
-      # TRANSLATORS: Please don't use double quotes (") in this translation
-      # or it will break the site's ability to send emails to authorities!
-      _("{{law_used_short}} requests at {{public_body}}",
-        law_used_short: legislation,
-        public_body: public_body.short_or_long_name),
-        recipient_email)
+    # TRANSLATORS: Please don't use double quotes (") in this translation
+    # or it will break the site's ability to send emails to authorities!
+    recipient_name = _("{{law_used_short}} requests at {{public_body}}",
+                       law_used_short: legislation,
+                       public_body: public_body.short_or_long_name)
+
+    if MySociety::Validate.is_valid_email(recipient_email)
+      MailHandler.address_from_name_and_email(recipient_name, recipient_email)
+    else
+      recipient_name
+    end
   end
 
   def public_response_events

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix admin error when authority are missing an email address (Graeme Porteous)
 * Allow categories to have notes associated with them (Graeme Porteous)
 * Add styling option and rich text editor to the notes admin (Graeme Porteous)
 * Strengthen 2FA warning. Users *must* remember to keep this code safe (Gareth

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2393,6 +2393,12 @@ RSpec.describe InfoRequest do
       expect(@info_request.recipient_name_and_email).to eq("FOI requests at TGQ <geraldine-requests@localhost>")
     end
 
+    it "has a invalid email" do
+      allow(MySociety::Validate).to receive(:is_valid_email).and_return(false)
+      expect(@info_request.recipient_name_and_email).
+        to eq("FOI requests at TGQ")
+    end
+
     it "copes with indexing after item is deleted" do
       load_raw_emails_data
       IncomingMessage.find_each(&:parse_raw_email!)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7693

## What does this do?

Update InfoRequest#recipient_name_and_email

## Why was this needed?

Handle when authorities don't have valid email addresses. In this case just return the recipients name.
