### PR TITLE
Switch Authorities and Requests in admin nav

### DIFF
--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -23,15 +23,6 @@
           </li>
 
           <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Authorities<span class="caret"></span></a>
-            <ul class="dropdown-menu" role="menu">
-              <li><%= link_to 'Authorities', admin_bodies_path %></li>
-              <li><%= link_to 'Categories', admin_categories_path(model_type: 'PublicBody') %></li>
-              <li><%= link_to 'Tags', admin_tags_path(model_type: 'PublicBody') %></li>
-            </ul>
-          </li>
-
-          <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Requests<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Requests', admin_requests_path %></li>
@@ -40,6 +31,15 @@
               <li><%= link_to 'Tags', admin_tags_path(model_type: 'InfoRequest') %></li>
               <li><%= link_to 'Citations', admin_citations_path %></li>
               <% if feature_enabled?(:refusal_snippets) %><li><%= link_to 'Snippets', admin_snippets_path %></li><% end %>
+            </ul>
+          </li>
+
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Authorities<span class="caret"></span></a>
+            <ul class="dropdown-menu" role="menu">
+              <li><%= link_to 'Authorities', admin_bodies_path %></li>
+              <li><%= link_to 'Categories', admin_categories_path(model_type: 'PublicBody') %></li>
+              <li><%= link_to 'Tags', admin_tags_path(model_type: 'PublicBody') %></li>
             </ul>
           </li>
 


### PR DESCRIPTION
Mirror the ordering of these items in the main nav as I'm forever clicking Authorities when I want Requests and vice versa.

BEFORE

![Screenshot 2024-04-17 at 12 11 41](https://github.com/mysociety/alaveteli/assets/282788/aa81f829-ce87-4dfb-b990-891b4a413b27)

AFTER

![Screenshot 2024-04-17 at 12 10 43](https://github.com/mysociety/alaveteli/assets/282788/d5b77aa8-bfc9-4660-a7c5-57c81bb241bd)


[skip changelog]
