### PR TITLE
[#7981] Allow requests to be browsed by categories/topic pages

### DIFF
--- a/app/assets/stylesheets/responsive/_header_layout.scss
+++ b/app/assets/stylesheets/responsive/_header_layout.scss
@@ -12,6 +12,7 @@
   // Hide menu items by default on mobile
   #logged_in_bar,
   #topnav,
+  #subnav,
   #user_locale_switcher,
   #navigation_search{
     display:none;
@@ -94,6 +95,7 @@
       // Show menu items when menu is targeted
       #logged_in_bar,
       #topnav,
+      #subnav,
       #user_locale_switcher,
       #navigation_search{
         display:block;
@@ -107,6 +109,7 @@
     #banner_nav,
     #logged_in_bar,
     #topnav,
+    #subnav,
     #user_locale_switcher,
     #navigation_search{
       display:block;
@@ -143,7 +146,8 @@
 }
 
 
-#topnav{
+#topnav,
+#subnav{
   padding: 0  0 1em 0;
   @include respond-min( $main_menu-mobile_menu_cutoff ){
     padding: 0;

--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -394,3 +394,22 @@ input.cplink__field {
     padding-bottom: 1.2em;
   }
 }
+
+.request-category_container {
+  display: block;
+  margin: 0 -10px;
+
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+}
+
+.request-category {
+  padding: 10px;
+
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    flex: 1 1 30%;
+  }
+}

--- a/app/assets/stylesheets/responsive/_search_layout.scss
+++ b/app/assets/stylesheets/responsive/_search_layout.scss
@@ -3,7 +3,8 @@
 #general_search,
 #general_search_redirect,
 #public_body_show,
-#request_list {
+#request_list,
+#request_index {
   @include grid-row($behavior: nest);
 }
 

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -23,6 +23,10 @@ class RequestController < ApplicationController
   MAX_RESULTS = 500
   PER_PAGE = 25
 
+  def index
+    @title = _('Browse requests by category')
+  end
+
   def select_authority
     # Check whether we force the user to sign in right at the start, or we allow her
     # to start filling the request anonymously
@@ -145,9 +149,9 @@ class RequestController < ApplicationController
                     count: @results[:matches_estimated],
                     tag_name: @tag)
     elsif @page > 1
-      @title = _("Browse and search requests (page {{count}})", count: @page)
+      @title = _("Search requests (page {{count}})", count: @page)
     else
-      @title = _('Browse and search requests')
+      @title = _('Search requests')
     end
 
     @track_thing = TrackThing.create_track_for_search_query(InfoRequestEvent.make_query_from_params(@filters))

--- a/app/views/alaveteli_pro/general/_nav_items.html.erb
+++ b/app/views/alaveteli_pro/general/_nav_items.html.erb
@@ -24,7 +24,7 @@
 </li>
 
 <li class="<%= 'selected' if controller?('request') && !action?('new', 'select_authority', 'show') %>">
-  <%= link_to _("Browse public requests"),
+  <%= link_to _("View public requests"),
               request_list_successful_path,
               :onclick => track_analytics_event(
                 AnalyticsEvent::Category::PRO_NAV_CLICK,

--- a/app/views/general/_nav_items.html.erb
+++ b/app/views/general/_nav_items.html.erb
@@ -3,7 +3,7 @@
 </li>
 
 <li class="<%= 'selected' if controller?('request') && !action?('new', 'select_authority') %>">
-  <%= link_to _("Browse requests"), request_list_successful_path %>
+  <%= link_to _("View requests"), request_list_successful_path %>
 </li>
 
 <li class="<%= 'selected' if controller?('public_body') %>">

--- a/app/views/general/_responsive_topnav.html.erb
+++ b/app/views/general/_responsive_topnav.html.erb
@@ -8,3 +8,11 @@
     <% end %>
   </ul>
 </div>
+
+<% if content_for? :subnav %>
+  <div id="subnav" class="subnav">
+    <ul id="navigation" class="navigation" role="navigation">
+      <%= yield :subnav %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/request/_tabs.html.erb
+++ b/app/views/request/_tabs.html.erb
@@ -1,0 +1,8 @@
+<% content_for :subnav do %>
+  <li class="<%= 'selected' unless current_page?(requests_path) %>">
+    <%= link_to _('Search requests'), request_list_path %>
+  </li>
+  <li class="<%= 'selected' if current_page?(requests_path) %>">
+    <%= link_to _('Browse by category'), requests_path %>
+  </li>
+<% end %>

--- a/app/views/request/index.html.erb
+++ b/app/views/request/index.html.erb
@@ -1,0 +1,20 @@
+<%= render partial: 'tabs' %>
+
+<h1><%= @title %></h1>
+
+<div class="request-category_container">
+  <% InfoRequest.categories.each do |heading| %>
+    <% next unless heading.children.present? %>
+    <div class="request-category">
+      <h3><%= heading.title %></h3>
+      <ul>
+        <% heading.children.each do |category| %>
+          <% next unless category.category_tag.present? %>
+          <li>
+            <%= link_to category.title, request_list_path(tag: category.category_tag) %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+</div>

--- a/app/views/request/list.html.erb
+++ b/app/views/request/list.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: 'tabs' %>
+
 <div id="header_left" class="header_left">
   <h1><%= @title %></h1>
   <%= render :partial => 'request/request_search_form',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
   get '/body_statistics' => redirect('/statistics#public_bodies'), :as => :public_bodies_statistics
 
   ##### Request controller
+  get '/browse' => 'request#index', as: :requests
   get '/list/all' => redirect('/list')
   get '/list/recent' => redirect('/list')
   match '/list(/:tag)/successful' => 'request#list',

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow requests to be browsed by category (Graeme Porteous)
 * Add default value and not null constraint to `CensorRule#regexp` (Gareth Rees)
 * Allow requests to be listed and filtered by tag (Graeme Porteous)
 * Fix admin error when authority are missing an email address (Graeme Porteous)

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1,5 +1,22 @@
 require 'spec_helper'
 
+RSpec.describe RequestController, "when listing request categories" do
+  it "should be successful" do
+    get :index
+    expect(response).to be_successful
+  end
+
+  it "should render with 'index' template" do
+    get :index
+    expect(response).to render_template('index')
+  end
+
+  it 'sets title based on page' do
+    get :index
+    expect(assigns[:title]).to eq('Browse requests by category')
+  end
+end
+
 RSpec.describe RequestController, "when listing recent requests" do
   it "should be successful" do
     get :list, params: { view: 'all' }
@@ -30,10 +47,10 @@ RSpec.describe RequestController, "when listing recent requests" do
 
   it 'sets title based on page' do
     get :list, params: { view: 'all' }
-    expect(assigns[:title]).to eq('Browse and search requests')
+    expect(assigns[:title]).to eq('Search requests')
 
     get :list, params: { view: 'all', page: 2 }
-    expect(assigns[:title]).to eq('Browse and search requests (page 2)')
+    expect(assigns[:title]).to eq('Search requests (page 2)')
   end
 
   it 'sets title based on if tag matches an request category' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7981
WDTK styling: https://github.com/mysociety/whatdotheyknow-theme/pull/1854

## What does this do?

Allow requests to be browsed by categories/topic pages

## Why was this needed?

Show request categories to allow users to filter requests based on topics they are interested in.

## Screenshots

Whitelabel:
![Screenshot 2024-04-19 at 13-19-20 Search requests](https://github.com/mysociety/alaveteli/assets/5426/71ca4d89-8bb4-400b-a106-059a28d6efe2)
![Screenshot 2024-04-19 at 13-19-28 Browse requests by category](https://github.com/mysociety/alaveteli/assets/5426/8b3f7fa6-a43b-4039-a1b2-2e2d9d5de588)


WDTK:
![Screenshot 2024-04-19 at 13-03-09 Search requests](https://github.com/mysociety/alaveteli/assets/5426/2a8f65cc-6b11-496c-8ee7-d8a7cc9e55ac)
![Screenshot 2024-04-19 at 13-03-01 Browse requests by category](https://github.com/mysociety/alaveteli/assets/5426/105307f6-84a4-424c-9c52-7644f8eb27ec)

