### PR TITLE
[#8211] Update helper URI module

### DIFF
--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -349,7 +349,7 @@ module LinkToHelper
   end
 
   def add_query_params_to_url(url, new_params)
-    uri = URI.parse(url)
+    uri = Addressable::URI.parse(url)
     uri.query = Rack::Utils.parse_nested_query(uri.query).
       with_indifferent_access.
       merge(new_params).

--- a/spec/helpers/link_to_helper_spec.rb
+++ b/spec/helpers/link_to_helper_spec.rb
@@ -370,5 +370,11 @@ RSpec.describe LinkToHelper do
       new_params = {}
       expect(add_query_params_to_url(url, new_params)).to eq url
     end
+
+    it 'does not error when URL is not RFC2396 compliant' do
+      url = 'http://example.com/a url with spaces'
+      new_params = { foo: 1 }
+      expect { add_query_params_to_url(url, new_params) }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
Use addressable gem over default URI module. This gem handles non RFC2396 compliant URLs. Required to fix #8211 in WDTK theme.

[skip changelog]
