### PR TITLE
[#8212] Rescue from missing contact form params

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -11,6 +11,12 @@ class HelpController < ApplicationController
   before_action :catch_spam, only: [:contact]
   before_action :set_recaptcha_required, only: [:contact]
 
+  ContactSpamError = Class.new(StandardError)
+
+  rescue_from ContactSpamError do
+    redirect_to frontpage_url
+  end
+
   def index
     redirect_to help_about_path
   end
@@ -89,7 +95,7 @@ class HelpController < ApplicationController
     return unless request.post? && params[:contact]
     return if params[:contact].fetch(:comment, '').blank?
 
-    redirect_to frontpage_url
+    raise ContactSpamError
   end
 
   def set_recaptcha_required

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -13,7 +13,7 @@ class HelpController < ApplicationController
 
   ContactSpamError = Class.new(StandardError)
 
-  rescue_from ContactSpamError do
+  rescue_from ContactSpamError, ActionController::ParameterMissing do
     redirect_to frontpage_url
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8212

## What does this do?

Rescue from missing contact form params

## Why was this needed?

Prevent exceptions.

[skip changelog]