### PR TITLE
[#8215] Update InfoRequest#set_described_state

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1021,7 +1021,7 @@ class InfoRequest < ApplicationRecord
 
     calculate_event_states
 
-    if requires_admin?
+    if old_described_state != described_state && requires_admin?
       # Check there is someone to send the message "from"
       if set_by && user
         RequestMailer.requires_admin(self, set_by, message).deliver_now

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Prevent multiple require admin emails from being sent (Graeme Porteous)
 * Add default value and not null constraint to `CensorRule#regexp` (Gareth Rees)
 * Allow requests to be listed and filtered by tag (Graeme Porteous)
 * Fix admin error when authority are missing an email address (Graeme Porteous)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8215

## What does this do?

Update InfoRequest#set_described_state

## Why was this needed?

Prevent multiple require admin emails from being sent when the state hasn't changed. This happens when multiple bounce message are received and the requester classifies each as `error_message` or `requires_admin` making it hard to keep track of outstanding issues in need of fixing.

