### PR TITLE
[#8132] Update actions and pages which set "noindex", "nofollow" crawler directives

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,6 +33,7 @@ class ApplicationController < ActionController::Base
   include FastGettext::Translation # make functions like _, n_, N_ etc available)
   include AlaveteliPro::PostRedirectHandler
   include ReadOnly
+  include RobotsHeaders
 
   # NOTE: a filter stops the chain if it redirects or renders something
   before_action :html_response

--- a/app/controllers/attachment_masks_controller.rb
+++ b/app/controllers/attachment_masks_controller.rb
@@ -32,10 +32,6 @@ class AttachmentMasksController < ApplicationController
 
   private
 
-  def set_no_crawl_headers
-    headers['X-Robots-Tag'] = 'noindex'
-  end
-
   def decode_referer
     @referer = verifier.verified(params[:referer])
   end

--- a/app/controllers/citations_controller.rb
+++ b/app/controllers/citations_controller.rb
@@ -5,6 +5,7 @@ class CitationsController < ApplicationController
   before_action :authenticate, except: :index
   before_action :load_resource_and_authorise, except: :index
   before_action :set_in_pro_area, except: :index
+  before_action :set_no_crawl_headers, except: :index
 
   skip_before_action :html_response, only: :index
 

--- a/app/controllers/concerns/prominence_headers.rb
+++ b/app/controllers/concerns/prominence_headers.rb
@@ -3,6 +3,7 @@
 #
 module ProminenceHeaders
   extend ActiveSupport::Concern
+  include RobotsHeaders
 
   included do
     before_action :set_prominence_headers
@@ -24,7 +25,7 @@ module ProminenceHeaders
   end
 
   def set_backpage_headers
-    headers['X-Robots-Tag'] = 'noindex'
+    set_no_crawl_headers
   end
 
   def set_requester_only_headers

--- a/app/controllers/concerns/public_tokenable.rb
+++ b/app/controllers/concerns/public_tokenable.rb
@@ -6,17 +6,14 @@
 #
 module PublicTokenable
   extend ActiveSupport::Concern
+  include RobotsHeaders
 
   included do
-    before_action :set_no_crawl_headers
+    before_action :set_no_crawl_headers, if: -> { public_token }
     helper_method :public_token
   end
 
   private
-
-  def set_no_crawl_headers
-    headers['X-Robots-Tag'] = 'noindex' if public_token
-  end
 
   def public_token
     params[:public_token]

--- a/app/controllers/concerns/robots_headers.rb
+++ b/app/controllers/concerns/robots_headers.rb
@@ -1,0 +1,12 @@
+##
+# Set robots noindex headers.
+#
+module RobotsHeaders
+  extend ActiveSupport::Concern
+
+  private
+
+  def set_no_crawl_headers
+    headers['X-Robots-Tag'] = 'noindex'
+  end
+end

--- a/app/controllers/concerns/robots_headers.rb
+++ b/app/controllers/concerns/robots_headers.rb
@@ -4,6 +4,10 @@
 module RobotsHeaders
   extend ActiveSupport::Concern
 
+  included do
+    before_action :set_no_crawl_headers, if: -> { params[:page].to_i > 1 }
+  end
+
   private
 
   def set_no_crawl_headers

--- a/app/controllers/concerns/robots_headers.rb
+++ b/app/controllers/concerns/robots_headers.rb
@@ -7,6 +7,7 @@ module RobotsHeaders
   private
 
   def set_no_crawl_headers
+    @no_crawl = true
     headers['X-Robots-Tag'] = 'noindex'
   end
 end

--- a/app/controllers/concerns/robots_headers.rb
+++ b/app/controllers/concerns/robots_headers.rb
@@ -12,6 +12,6 @@ module RobotsHeaders
 
   def set_no_crawl_headers
     @no_crawl = true
-    headers['X-Robots-Tag'] = 'noindex'
+    headers['X-Robots-Tag'] = 'noindex, nofollow'
   end
 end

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -16,6 +16,7 @@ class RequestController < ApplicationController
   before_action :redirect_new_form_to_pro_version, only: [:select_authority, :new]
   before_action :set_in_pro_area, only: [:select_authority, :show]
   before_action :setup_results_pagination, only: [:list, :similar]
+  before_action :set_no_crawl_headers, only: [:new, :details, :similar]
 
   helper_method :state_transitions_empty?
 

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -396,9 +396,6 @@ class RequestController < ApplicationController
     @per_page = PER_PAGE
     @max_results = MAX_RESULTS
 
-    # Don't let robots go more than 20 pages in
-    @no_crawl = true if @page > 20
-
     # Later pages are very expensive to load
     return if @page <= MAX_RESULTS / PER_PAGE
 

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -22,7 +22,8 @@ class UserController < ApplicationController
   before_action :set_request_from_foreign_country, only: [ :signup ]
   before_action :set_in_pro_area, only: [ :signup ]
   before_action :set_display_user, only: [ :show, :wall, :get_profile_photo ]
-  before_action :set_no_crawl, only: [ :show, :wall ]
+  before_action :set_no_crawl_headers, only: [ :wall ]
+  before_action :set_no_crawl_headers_if_suspended, only: [ :show ]
 
   # Normally we wouldn't be verifying the authenticity token on these actions
   # anyway as there shouldn't be a user_id in the session when the before
@@ -449,8 +450,8 @@ class UserController < ApplicationController
     @in_pro_area = true if @post_redirect && @post_redirect.reason_params[:pro]
   end
 
-  def set_no_crawl
-    @no_crawl = true unless @display_user&.active?
+  def set_no_crawl_headers_if_suspended
+    set_no_crawl_headers if @display_user&.suspended?
   end
 
   def normalize_url_name

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,7 +1,25 @@
 ##
-# Helper to translate (via gettext) the strings provided by will_paginate.
+# Helper for rendering pagination
 #
 module PaginationHelper
+  def will_paginate(collection, options = {})
+    super(collection, options.merge(renderer: CustomRenderer))
+  end
+
+  ##
+  # Custom pagination link renderer which injects nofollow for pages over 20
+  #
+  class CustomRenderer < WillPaginate::ActionView::LinkRenderer
+    def rel_value(page)
+      rel = [*super]
+      rel << 'nofollow' if page > 20
+      rel.join(' ').presence
+    end
+  end
+
+  ##
+  # Helper to translate (via gettext) the strings provided by will_paginate.
+  #
   def will_paginate_translate(key, options = {})
     case key
     when :previous_label then _("&#8592; Previous")

--- a/app/views/request/_after_actions.html.erb
+++ b/app/views/request/_after_actions.html.erb
@@ -14,20 +14,20 @@
             <ul class="action-menu__menu__submenu owner_actions">
               <li>
                 <% if last_response.nil? %>
-                  <%= link_to _('Send a followup'), new_request_followup_path(info_request.url_title) %>
+                  <%= link_to _('Send a followup'), new_request_followup_path(info_request.url_title), rel: 'nofollow' %>
                 <% else %>
-                  <%= link_to _('Write a reply'), new_request_incoming_followup_path(info_request.url_title, incoming_message_id: last_response.id) %>
+                  <%= link_to _('Write a reply'), new_request_incoming_followup_path(info_request.url_title, incoming_message_id: last_response.id), rel: 'nofollow' %>
                 <% end %>
               </li>
 
               <% if show_owner_update_status_action %>
                 <li>
-                  <%= link_to _('Update the status of this request'), request_path(info_request, update_status: 1) %>
+                  <%= link_to _('Update the status of this request'), request_path(info_request, update_status: 1), rel: 'nofollow' %>
                 </li>
               <% end %>
 
               <li>
-                <%= link_to _('Request an internal review'), new_request_followup_path(info_request.url_title, internal_review: '1') %>
+                <%= link_to _('Request an internal review'), new_request_followup_path(info_request.url_title, internal_review: '1'), rel: 'nofollow' %>
               </li>
             </ul>
           </li>
@@ -42,7 +42,7 @@
 
           <ul class="action-menu__menu__submenu public_body_actions">
             <li>
-              <%= link_to _("Respond to request"), upload_response_path(:url_title => info_request.url_title) %>
+              <%= link_to _("Respond to request"), upload_response_path(:url_title => info_request.url_title), rel: 'nofollow' %>
             </li>
           </ul>
         </li>
@@ -61,7 +61,7 @@
               </li>
             <% else %>
               <li>
-                <%= link_to _("Report this request"), new_request_report_path(info_request.url_title) %><span class="action-menu__info-link">
+                <%= link_to _("Report this request"), new_request_report_path(info_request.url_title), rel: 'nofollow' %><span class="action-menu__info-link">
                 <%= link_to _("Help"), help_about_path(:anchor => "reporting") %>
               </span>
               </li>
@@ -69,7 +69,7 @@
 
             <% if can? :create_comment, info_request %>
               <li>
-                <%= link_to _('Add an annotation'), new_comment_path(:url_title => info_request.url_title) %>
+                <%= link_to _('Add an annotation'), new_comment_path(:url_title => info_request.url_title), rel: 'nofollow' %>
               </li>
             <% end %>
 
@@ -80,11 +80,11 @@
             <% end %>
 
             <li>
-              <%= link_to _("Download a zip file of all correspondence"), download_entire_request_path(:url_title => info_request.url_title) %>
+              <%= link_to _("Download a zip file of all correspondence"), download_entire_request_path(:url_title => info_request.url_title), rel: 'nofollow' %>
             </li>
 
             <li>
-              <%= link_to _('View event history details'), request_details_path(info_request) %>
+              <%= link_to _('View event history details'), request_details_path(info_request), rel: 'nofollow' %>
             </li>
 
             <li>

--- a/app/views/request/_request_listing_via_event.html.erb
+++ b/app/views/request/_request_listing_via_event.html.erb
@@ -31,7 +31,7 @@ end %>
   </div>
 
   <div class="request_right">
-    <span class="desc">
+    <span class="desc" data-nosnippet>
       <%= highlight_and_excerpt(event.search_text_main(true), @highlight_words, 150) %>
     </span>
   </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Update actions and pages which set "noindex", "nofollow" crawler directives
+  (Graeme Porteous)
 * Render public body category notes (Gareth Rees)
 * Prevent external search indexing of password change form (Gareth Rees)
 * Allow customisation of text masks (Gareth Rees)

--- a/spec/controllers/attachment_masks_controller_spec.rb
+++ b/spec/controllers/attachment_masks_controller_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe AttachmentMasksController, type: :controller do
         expect(response).to render_template(:wait)
       end
 
-      it 'sets noindex header' do
+      it 'sets noindex, nofollow header' do
         wait
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
     end
 
@@ -117,9 +117,9 @@ RSpec.describe AttachmentMasksController, type: :controller do
         expect(response).to render_template(:done)
       end
 
-      it 'sets noindex header' do
+      it 'sets noindex, nofollow header' do
         done
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
     end
 

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -205,13 +205,13 @@ RSpec.describe AttachmentsController, type: :controller do
         expect(assigns(:info_request)).to eq(info_request)
       end
 
-      it 'adds noindex header when using public token' do
+      it 'adds noindex, nofollow header when using public token' do
         expect(InfoRequest).to receive(:find_by!).with(public_token: 'ABC').
           and_return(info_request)
 
         show(public_token: 'ABC', id: nil)
 
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
 
       it 'passes public token to current ability' do
@@ -294,14 +294,14 @@ RSpec.describe AttachmentsController, type: :controller do
     context 'when the request is backpage' do
       let(:request_prominence) { 'backpage' }
 
-      it 'sets a noindex header when viewing' do
+      it 'sets a noindex, nofollow header when viewing' do
         show
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
 
-      it 'sets a noindex header when viewing a cached copy' do
+      it 'sets a noindex, nofollow header when viewing a cached copy' do
         show
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
 
       context 'when logged in as requester' do
@@ -507,13 +507,13 @@ RSpec.describe AttachmentsController, type: :controller do
       expect(assigns(:info_request)).to eq(info_request)
     end
 
-    it 'adds noindex header when using public token' do
+    it 'adds noindex, nofollow header when using public token' do
       expect(InfoRequest).to receive(:find_by!).with(public_token: '123').
         and_return(info_request)
 
       show_as_html(public_token: '123', id: nil)
 
-      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
     end
 
     context 'when attachment has not been masked' do
@@ -616,14 +616,14 @@ RSpec.describe AttachmentsController, type: :controller do
     context 'when the request is backpage' do
       let(:request_prominence) { 'backpage' }
 
-      it 'sets a noindex header when viewing a HTML version' do
+      it 'sets a noindex, nofollow header when viewing a HTML version' do
         show_as_html
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
 
-      it 'sets a noindex header when viewing a cached HTML version' do
+      it 'sets a noindex, nofollow header when viewing a cached HTML version' do
         show_as_html
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
     end
 

--- a/spec/controllers/citations_controller_spec.rb
+++ b/spec/controllers/citations_controller_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe CitationsController, type: :controller do
         end
       end
 
-      it 'adds noindex header' do
+      it 'adds noindex, nofollow header' do
         action
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
     end
 

--- a/spec/controllers/citations_controller_spec.rb
+++ b/spec/controllers/citations_controller_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe CitationsController, type: :controller do
           expect(response).to be_successful
         end
       end
+
+      it 'adds noindex header' do
+        action
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
     end
 
     # when requester

--- a/spec/controllers/public_tokens_controller_spec.rb
+++ b/spec/controllers/public_tokens_controller_spec.rb
@@ -25,9 +25,9 @@ RSpec.describe PublicTokensController, type: :controller do
         expect(assigns(:info_request)).to eq info_request
       end
 
-      it 'adds noindex header' do
+      it 'adds noindex, nofollow header' do
         get :show, params: { public_token: 'TOKEN' }
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
 
       it 'returns http success' do

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -748,6 +748,11 @@ RSpec.describe RequestController, "when creating a new request" do
     expect(response).to render_template('new_bad_contact')
   end
 
+  it 'adds noindex header' do
+    get :new, params: { public_body_id: @body.id }
+    expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+  end
+
   context "the outgoing message includes an email address" do
     context "there is no logged in user" do
       it "displays a flash error message without escaping the HTML" do
@@ -1865,6 +1870,11 @@ RSpec.describe RequestController, "when showing similar requests" do
       get :similar, params: { url_title: badger_request.url_title }
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
+
+  it 'adds noindex header' do
+    get :similar, params: { url_title: badger_request.url_title }
+    expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+  end
 end
 
 RSpec.describe RequestController, "when the site is in read_only mode" do
@@ -1926,6 +1936,11 @@ RSpec.describe RequestController do
           get :details, params: { url_title: info_request.url_title }
         }.to raise_error(ActiveRecord::RecordNotFound)
       end
+    end
+
+    it 'adds noindex header' do
+      get :details, params: { url_title: info_request.url_title }
+      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
     end
   end
 end

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -617,9 +617,9 @@ RSpec.describe RequestController, 'when handling prominence' do
       expect(response).to render_template('show')
     end
 
-    it 'sets a noindex header' do
+    it 'sets a noindex, nofollow header' do
       get :show, params: { url_title: info_request.url_title }
-      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
     end
   end
 end
@@ -748,9 +748,9 @@ RSpec.describe RequestController, "when creating a new request" do
     expect(response).to render_template('new_bad_contact')
   end
 
-  it 'adds noindex header' do
+  it 'adds noindex, nofollow header' do
     get :new, params: { public_body_id: @body.id }
-    expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+    expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
   end
 
   context "the outgoing message includes an email address" do
@@ -1871,9 +1871,9 @@ RSpec.describe RequestController, "when showing similar requests" do
     }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
-  it 'adds noindex header' do
+  it 'adds noindex, nofollow header' do
     get :similar, params: { url_title: badger_request.url_title }
-    expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+    expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
   end
 end
 
@@ -1938,9 +1938,9 @@ RSpec.describe RequestController do
       end
     end
 
-    it 'adds noindex header' do
+    it 'adds noindex, nofollow header' do
       get :details, params: { url_title: info_request.url_title }
-      expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
     end
   end
 end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe UserController do
     end
 
     context 'when user is suspended' do
-      it 'adds noindex header' do
+      it 'adds noindex, nofollow header' do
         user = FactoryBot.create(:user, :banned)
         get :show, params: { url_name: user.url_name }
-        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
       end
     end
 
@@ -1460,9 +1460,9 @@ RSpec.describe UserController, "when viewing the wall" do
     expect(assigns[:feed_results]).to be_empty
   end
 
-  it 'adds noindex header' do
+  it 'adds noindex, nofollow header' do
     user = FactoryBot.create(:user)
     get :wall, params: { url_name: user.url_name }
-    expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+    expect(response.headers['X-Robots-Tag']).to eq 'noindex, nofollow'
   end
 end

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe UserController do
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
 
+    context 'when user is suspended' do
+      it 'adds noindex header' do
+        user = FactoryBot.create(:user, :banned)
+        get :show, params: { url_name: user.url_name }
+        expect(response.headers['X-Robots-Tag']).to eq 'noindex'
+      end
+    end
+
     # TODO: Use route_for or params_from to check /c/ links better
     # http://rspec.rubyforge.org/rspec-rails/1.1.12/classes/Spec/Rails/Example/
     # ControllerExampleGroup.html
@@ -1450,5 +1458,11 @@ RSpec.describe UserController, "when viewing the wall" do
     update_xapian_index
     get :wall, params: { url_name: user.url_name }
     expect(assigns[:feed_results]).to be_empty
+  end
+
+  it 'adds noindex header' do
+    user = FactoryBot.create(:user)
+    get :wall, params: { url_name: user.url_name }
+    expect(response.headers['X-Robots-Tag']).to eq 'noindex'
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8132

## What does this do?

Update actions and pages which set "noindex", "nofollow" crawler directives

## Why was this needed?

> Snippets of request content often appear on list pages, and create a whack-a-mole situation when unhappy users find that external search engines have indexed a list page (e.g. /body/foo?page=12) that contains a cached snippet of PII that we've removed from the request page itself.

## Implementation notes

@garethrees are you happy with changing the number of paginated pages which are indexed? I'm concerned this might impact search ranking due to newer request pages not being indexed at all.