### PR TITLE
Update admin tag routing constraints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -532,7 +532,8 @@ Rails.application.routes.draw do
   ####
   #### AdminTag controller
   namespace :admin do
-    resources :tags, param: :tag, only: [:index, :show]
+    resources :tags, param: :tag, only: [:index, :show],
+      constraints: { tag: /.+/ }
   end
   ####
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix issues loading tags containing `.` or `/` in admin UI (Graeme Porteous)
 * Allow requests to be browsed by category (Graeme Porteous)
 * Add default value and not null constraint to `CensorRule#regexp` (Gareth Rees)
 * Allow requests to be listed and filtered by tag (Graeme Porteous)

--- a/spec/integration/admin_tag_controller_show_spec.rb
+++ b/spec/integration/admin_tag_controller_show_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+require 'integration/alaveteli_dsl'
+
+RSpec.describe 'showing admin tags' do
+  around do |example|
+    using_session(login(:admin_user)) do
+      example.run
+    end
+  end
+
+  context 'when tags contain colons or slashes' do
+    let!(:public_body) do
+      FactoryBot.create(:public_body, tag_string: 'http://foo.bar')
+    end
+
+    let!(:info_request) do
+      FactoryBot.create(:info_request, tag_string: 'url:http://foo.bar')
+    end
+
+    it 'loads taggings correctly' do
+      public_body_path = admin_public_body_path(public_body)
+      info_request_path = admin_info_request_path(info_request)
+
+      visit 'admin/tags/http?model_type=PublicBody'
+      expect(page.has_link?(href: public_body_path)).to eq true
+      expect(page.has_link?(href: info_request_path)).to eq false
+
+      visit 'admin/tags/http:%2F%2Ffoo.bar?model_type=PublicBody'
+      expect(page.has_link?(href: public_body_path)).to eq true
+      expect(page.has_link?(href: info_request_path)).to eq false
+
+      visit 'admin/tags/url?model_type=InfoRequest'
+      expect(page.has_link?(href: public_body_path)).to eq false
+      expect(page.has_link?(href: info_request_path)).to eq true
+
+      visit 'admin/tags/url:http:%2F%2Ffoo.bar?model_type=InfoRequest'
+      expect(page.has_link?(href: public_body_path)).to eq false
+      expect(page.has_link?(href: info_request_path)).to eq true
+    end
+  end
+end


### PR DESCRIPTION

## What does this do?

Update admin tag routing constraints

## Why was this needed?

Allow admin pages for tags with `.` or `/` to be loaded successfully. This means tags can be URLs which is currently a use case used on WDTK.

It does mean we can't have member actions on the tags resource but as of now we don't have any. If ever we want an `edit` action we can adjust the constraint to allow this.

