### PR TITLE
[#8268] Fix issue setting custom from address

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -38,8 +38,8 @@ class ApplicationMailer < ActionMailer::Base
       )
 
     else
-      opts[:from] = blackhole_email
       set_reply_to_headers
+      opts[:from] ||= blackhole_email
     end
 
     set_auto_generated_headers

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe ContactMailer do
                                                      pro_user.email,
                                                      "test subject",
                                                      "test message")
-          expect(message.from).to eq [blackhole_email]
+          expect(message.from).to eq [AlaveteliConfiguration.pro_contact_email]
         end
       end
     end
@@ -112,7 +112,7 @@ RSpec.describe ContactMailer do
                                                      user.email,
                                                      "test subject",
                                                      "test message")
-          expect(message.from).to eq [blackhole_email]
+          expect(message.from).to eq [AlaveteliConfiguration.contact_email]
         end
       end
     end
@@ -124,7 +124,7 @@ RSpec.describe ContactMailer do
                                                      "no-such-user@localhost",
                                                      "test subject",
                                                      "test message")
-          expect(message.from).to eq [blackhole_email]
+          expect(message.from).to eq [AlaveteliConfiguration.contact_email]
         end
       end
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8268

## What does this do?

Fix issue setting custom from address

## Why was this needed?

We're currently always overriding the from address in `mail_user`, this probably came from a bad merge.

<hr>

[skip changelog]
