### PR TITLE
View user profile photos from admin list of users

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -7,6 +7,7 @@
 //= require bootstrap-tab
 //= require bootstrap-dropdown
 //= require bootstrap-tooltip
+//= require bootstrap-popover
 //= require admin/admin
 //= require admin/category-order
 //= require admin/censor-rules

--- a/app/assets/javascripts/admin/admin.js
+++ b/app/assets/javascripts/admin/admin.js
@@ -1,3 +1,8 @@
+// Initialize popover elements
+$(document).ready(function(){
+  $('[rel="popover"]').popover();
+});
+
 (function() {
   jQuery(function() {
     $('.locales a:first').tab('show');

--- a/app/views/admin_user/_user_table.html.erb
+++ b/app/views/admin_user/_user_table.html.erb
@@ -9,6 +9,13 @@
 
         <%= link_to("(#{ h(user.email) })", "mailto:#{ h(user.email) }") %>
 
+        <% if user.profile_photo %>
+          <% photo_html = image_tag(get_profile_photo_url(url_name: user.url_name)).gsub('"', "'") %>
+          <%= link_to '#', rel: 'popover', data: { trigger: 'hover', placement: 'top', html: true, content: photo_html } do %>
+            <%= icon(:picture) %>
+          <% end %>
+        <% end %>
+
         <span class="user-labels">
           <%= user_labels(user) %>
         </span>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* View user profile photos from admin list of users (Gareth Rees)
 * Update user email to be sent from the blackhole address (Graeme Porteous)
 * Remove ability to publicly view authority contact email addresses to prevent
   harvesting (Gareth Rees)


### PR DESCRIPTION
Being able to quickly see that a user has a profile photo – and then be able to preview it – helps detect spam.

Fixes https://github.com/mysociety/alaveteli/issues/5304

**Icon shows presence of a photo:**

![Screenshot 2024-05-28 at 11 11 58](https://github.com/mysociety/alaveteli/assets/282788/f894f566-36fe-4d28-b2a7-f4d5bc0e6388)

**On hover:**

![Screenshot 2024-05-28 at 11 12 07](https://github.com/mysociety/alaveteli/assets/282788/e9e42532-43f2-49a1-82a5-b78e4cc33e1c)
