### PR TITLE
Improve note style colour contrast

### DIFF
--- a/app/assets/stylesheets/responsive/_notes_styles.scss
+++ b/app/assets/stylesheets/responsive/_notes_styles.scss
@@ -2,19 +2,19 @@ $note-text:          $oil;
 $note-bg:            lighten($primary-color, 60%);
 $note-border:        $primary-color;
 
-$note-red-text:      darken($alert-color, 10%);
+$note-red-text:      darken($alert-color, 25%);
 $note-red-bg:        lighten($alert-color, 40%);
 $note-red-border:    $alert-color;
 
-$note-green-text:    darken($success-color, 10%);
+$note-green-text:    darken($success-color, 25%);
 $note-green-bg:      lighten($success-color, 40%);
 $note-green-border:  $success-color;
 
-$note-blue-text:     darken($primary-color, 10%);
+$note-blue-text:     darken($primary-color, 15%);
 $note-blue-bg:       lighten($primary-color, 60%);
 $note-blue-border:   $primary-color;
 
-$note-yellow-text:   darken($warning-color, 10%);
+$note-yellow-text:   darken($warning-color, 30%);
 $note-yellow-bg:     lighten($warning-color, 40%);
 $note-yellow-border: $warning-color;
 


### PR DESCRIPTION
BEFORE:

* Red: https://webaim.org/resources/contrastchecker/?fcolor=D32A0E&bcolor=FDE7E3 (4.31:1 – bad)
* Yellow: https://webaim.org/resources/contrastchecker/?fcolor=D3710E&bcolor=FDF0E3 (3.05:1 – bad)
* Green: https://webaim.org/resources/contrastchecker/?fcolor=358753&bcolor=CFECDA (3.51:1 – bad)
* Blue: https://webaim.org/resources/contrastchecker/?fcolor=006687&bcolor=EDFBFF (6.1:1 – pretty good)

AFTER:

* Red: https://webaim.org/resources/contrastchecker/?fcolor=8b1c0a&bcolor=FDE7E3 (7.81:1 – pass)
* Yellow: https://webaim.org/resources/contrastchecker/?fcolor=733e08&bcolor=FDF0E3 (7.74:1 – pass)
* Green: https://webaim.org/resources/contrastchecker/?fcolor=1f5031&bcolor=CFECDA (7.4:1 – pass)
* Blue: https://webaim.org/resources/contrastchecker/?fcolor=00526e&bcolor=EDFBFF (8.15:1 – pass)

Fixes https://github.com/mysociety/alaveteli/issues/8277.

## Screenshots

BEFORE

![Screenshot 2024-05-28 at 12 21 32](https://github.com/mysociety/alaveteli/assets/282788/ec4e6870-b8e2-46bf-9d84-ed7955673d75)


AFTER

![Screenshot 2024-05-28 at 12 21 24](https://github.com/mysociety/alaveteli/assets/282788/b56cdbe5-b289-4c95-af17-7bcb4143206c)


 [skip changelog]
