### PR TITLE
[#1636] Show AlaveteliConfiguration in admin interface

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -274,6 +274,12 @@ body.admin {
 
 }
 
+/* Debug */
+
+table.table-debug {
+  font-family: monospace;
+}
+
 /* Timeline */
 
 .timeline_date {

--- a/app/controllers/admin/debug_controller.rb
+++ b/app/controllers/admin/debug_controller.rb
@@ -1,0 +1,11 @@
+class Admin::DebugController < AdminController
+  def index
+    @admin_current_user = admin_current_user
+    @current_commit = Statistics::General.new.to_h[:alaveteli_git_commit]
+    @current_branch = `git branch | perl -ne 'print $1 if /^\\* (.*)/'`
+    @current_version = ALAVETELI_VERSION
+    repo = `git remote show origin -n | perl -ne 'print $1 if m{Fetch URL: .*github\\.com[:/](.*)\\.git}'`
+    @github_origin = "https://github.com/#{repo}/tree/"
+    @request_env = request.env
+  end
+end

--- a/app/controllers/admin/debug_controller.rb
+++ b/app/controllers/admin/debug_controller.rb
@@ -7,5 +7,6 @@ class Admin::DebugController < AdminController
     repo = `git remote show origin -n | perl -ne 'print $1 if m{Fetch URL: .*github\\.com[:/](.*)\\.git}'`
     @github_origin = "https://github.com/#{repo}/tree/"
     @request_env = request.env
+    @alaveteli_configuration = AlaveteliConfiguration.to_sanitized_hash
   end
 end

--- a/app/controllers/admin_general_controller.rb
+++ b/app/controllers/admin_general_controller.rb
@@ -130,16 +130,6 @@ class AdminGeneralController < AdminController
     @tracks_by_type = TrackThing.group('track_type').count
   end
 
-  def debug
-    @admin_current_user = admin_current_user
-    @current_commit = Statistics::General.new.to_h[:alaveteli_git_commit]
-    @current_branch = `git branch | perl -ne 'print $1 if /^\\* (.*)/'`
-    @current_version = ALAVETELI_VERSION
-    repo = `git remote show origin -n | perl -ne 'print $1 if m{Fetch URL: .*github\\.com[:/](.*)\\.git}'`
-    @github_origin = "https://github.com/#{repo}/tree/"
-    @request_env = request.env
-  end
-
   private
 
   def get_events_title

--- a/app/views/admin/changelog/index.html.erb
+++ b/app/views/admin/changelog/index.html.erb
@@ -14,7 +14,7 @@
 
 <p>
   You are currently running Alaveteli version:
-  <tt><%= link_to ALAVETELI_VERSION, admin_debug_path %></tt>
+  <tt><%= link_to ALAVETELI_VERSION, admin_debug_index_path %></tt>
 </p>
 
 <hr />

--- a/app/views/admin/debug/index.html.erb
+++ b/app/views/admin/debug/index.html.erb
@@ -52,4 +52,3 @@
     <tr><td><%= k %></td><td><%= v %></td></tr>
   <% end %>
 </table>
-

--- a/app/views/admin/debug/index.html.erb
+++ b/app/views/admin/debug/index.html.erb
@@ -1,4 +1,4 @@
-<% @title = "Debug" %>
+<% @title = 'Debug' %>
 
 <h1><%= @title %></h1>
 
@@ -6,49 +6,85 @@
 
 <h2>Version numbers</h2>
 
-<p>
-  Alaveteli version: <%= @current_version %>
-  <br>
-  <% if @current_branch == "(no branch)" %>
-    Alaveteli branch: (no branch)
-  <% else %>
-    Alaveteli branch: <%= link_to @current_branch, @github_origin + @current_branch %>
-  <% end %>
-  <br>
-  Alaveteli commit: <%= link_to @current_commit, @github_origin + @current_commit %>
-  <br>
-  RUBY_VERSION <%= RUBY_VERSION %>
-  <br>
-  Rails::VERSION::STRING <%= Rails::VERSION::STRING %>
-  <br>
-  Xapian::version_string <%= Xapian::version_string %>
-</p>
+<table class="table table-condensed table-debug">
+  <tr>
+    <td>Alaveteli version:</td>
+    <td><%= @current_version %></td>
+  </tr>
+
+  <tr>
+    <td>Alaveteli Branch:</td>
+
+    <% if @current_branch == '(no branch)' %>
+      <td>(no branch)</td>
+    <% else %>
+      <td><%= link_to @current_branch, @github_origin + @current_branch %></td>
+    <% end %>
+  </tr>
+
+  <tr>
+    <td>Alaveteli commit:</td>
+    <td><%= link_to @current_commit, @github_origin + @current_commit %></td>
+  </tr>
+
+  <tr>
+    <td>RUBY_VERSION</td>
+    <td><%= RUBY_VERSION %></td>
+  </tr>
+
+  <tr>
+    <td>Rails::VERSION::STRING</td>
+    <td><%= Rails::VERSION::STRING %></td>
+  </tr>
+
+  <tr>
+    <td>Xapian::version_string</td>
+    <td><<%= Xapian::version_string %></td>
+  </tr>
+</table>
 
 <h2>Configuration</h2>
 
-<p>
-  Rails env: <%= Rails.env %>
-  <br>
-  Rails root: <%= Rails.root %>
-</p>
+<table class="table table-condensed table-debug">
+  <tr>
+    <td>Rails env:</td>
+    <td><%= Rails.env %></td>
+  </tr>
+  <tr>
+    <td>Rails root:</td>
+    <td><%= Rails.root %></td>
+  </tr>
+</table>
 
 <h2>Environment variables</h2>
-<table>
+
+<table class="table table-condensed table-debug">
   <% @request_env.each do |k,v| %>
-    <tr><td><%= k %></td><td><%= v %></td></tr>
+    <tr>
+      <td><%= k %></td>
+      <td><%= v %></td>
+    </tr>
   <% end %>
 </table>
 
 <h2>Parameters</h2>
-<table>
+
+<table class="table table-condensed table-debug">
   <% params.each do |k,v| %>
-    <tr><td><%= k %></td><td><%= v %></td></tr>
+    <tr>
+      <td><%= k %></td>
+      <td><%= v %></td>
+    </tr>
   <% end %>
 </table>
 
 <h2>Session</h2>
-<table>
+
+<table class="table table-condensed table-debug">
   <% session.to_hash.each do |k,v| %>
-    <tr><td><%= k %></td><td><%= v %></td></tr>
+    <tr>
+      <td><%= k %></td>
+      <td><%= v %></td>
+    </tr>
   <% end %>
 </table>

--- a/app/views/admin/debug/index.html.erb
+++ b/app/views/admin/debug/index.html.erb
@@ -45,6 +45,18 @@
 
 <h2>Configuration</h2>
 
+<div class="help-block">
+  <p>
+    See the <a href="https://alaveteli.org/docs/customising/config/">
+    documentation</a> for more information about configuring Alaveteli.
+  </p>
+
+  <p>
+    Sensitive values are replaced with <tt>[FILTERED]</tt>. Use the
+    <tt>config/general.yml</tt> configuration file to view these.
+  </p>
+</div>
+
 <table class="table table-condensed table-debug">
   <tr>
     <td>Rails env:</td>
@@ -54,6 +66,15 @@
     <td>Rails root:</td>
     <td><%= Rails.root %></td>
   </tr>
+</table>
+
+<table class="table table-condensed table-debug">
+  <% @alaveteli_configuration.each do |k,v| %>
+    <tr>
+      <td><%= k %></td>
+      <td><%= v %></td>
+    </tr>
+  <% end %>
 </table>
 
 <h2>Environment variables</h2>

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -18,7 +18,7 @@
               <li><%= link_to 'Summary', admin_general_index_path %></li>
               <li><%= link_to 'Timeline', admin_timeline_path %></li>
               <li><%= link_to 'Stats', admin_stats_path %></li>
-              <li><%= link_to 'Debug', admin_debug_path %></li>
+              <li><%= link_to 'Debug', admin_debug_index_path %></li>
             </ul>
           </li>
 

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -12,6 +12,13 @@
 # Default values for these settings can be found in
 # RAILS_ROOT/lib/configuration.rb
 #
+#
+# WARNING: AlaveteliConfiguration is rendered to admin users in
+#          Admin::DebugController.
+#
+# Ensure any sensitive values are matched by
+# AlaveteliConfiguration.sensitive_key_patterns
+#
 # ==============================================================================
 
 # Site name appears in various places throughout the site

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -547,7 +547,15 @@ Rails.application.routes.draw do
   end
   ####
 
+  #### Admin::Debug controller
+  namespace :admin do
+    # FIXME: For some reason the resources call is generating the route as
+    # admin_debug_index_path rather than the standard admin_debug_path.
+    # resources :debug, only: [:index]
+    get 'debug', to: 'debug#index', as: :debug
+  end
   ####
+
   #### AdminTag controller
   namespace :admin do
     resources :tags, param: :tag, only: [:index, :show],
@@ -637,9 +645,6 @@ Rails.application.routes.draw do
         :via => :get
   match '/admin/timeline' => 'admin_general#timeline',
         :as => :admin_timeline,
-        :via => :get
-  match '/admin/debug' => 'admin_general#debug',
-        :as => :admin_debug,
         :via => :get
   match '/admin/stats' => 'admin_general#stats',
         :as => :admin_stats,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -549,10 +549,7 @@ Rails.application.routes.draw do
 
   #### Admin::Debug controller
   namespace :admin do
-    # FIXME: For some reason the resources call is generating the route as
-    # admin_debug_index_path rather than the standard admin_debug_path.
-    # resources :debug, only: [:index]
-    get 'debug', to: 'debug#index', as: :debug
+    resources :debug, only: :index
   end
   ####
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Render Alaveteli configuration values on admin debug page (Gareth Rees)
 * Clarify no sign ins message (Gareth Rees)
 * Check user spam scoring on email address change (Graeme Porteous)
 * Make requests sortable in the admin interface (Gareth Rees)

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -13,6 +13,14 @@ MySociety::Config.load_default
 # TODO: Make this return different values depending on the current rails environment
 
 module AlaveteliConfiguration
+  # WARNING: AlaveteliConfiguration is rendered to admin users in
+  #          Admin::DebugController.
+  #
+  # Ensure any sensitive values match this pattern, or add to the pattern if
+  # adding a new value that doesn't fit.
+  mattr_accessor :sensitive_key_patterns,
+                 default: /SECRET|PASSWORD|LICENSE_KEY/
+
   unless const_defined?(:DEFAULTS)
 
     # rubocop:disable Layout/LineLength
@@ -158,6 +166,14 @@ module AlaveteliConfiguration
       end
     else
       super
+    end
+  end
+
+  def self.to_sanitized_hash
+    DEFAULTS.keys.each_with_object({}) do |key, memo|
+      value = send(key)
+      value = '[FILTERED]' if value.present? && key =~ sensitive_key_patterns
+      memo[key] = value
     end
   end
 end

--- a/spec/controllers/admin/debug_controller_spec.rb
+++ b/spec/controllers/admin/debug_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe Admin::DebugController do
+  describe 'GET #index' do
+    let(:admin_user) { FactoryBot.create(:admin_user) }
+
+    it 'renders the view' do
+      sign_in admin_user
+      get :index
+      expect(response).to render_template('index')
+    end
+  end
+end

--- a/spec/integration/admin_spec.rb
+++ b/spec/integration/admin_spec.rb
@@ -99,14 +99,14 @@ RSpec.describe "When administering the site" do
   describe "the debug page" do
     it "should show the current user name" do
       using_session(@admin) do
-        visit admin_debug_path
+        visit admin_debug_index_path
         expect(page).to have_content "joe_admin"
       end
     end
 
     it "should show the current Alaveteli version" do
       using_session(@admin) do
-        visit admin_debug_path
+        visit admin_debug_index_path
         expect(page).to have_content ALAVETELI_VERSION
       end
     end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+RSpec.describe AlaveteliConfiguration do
+  include AlaveteliConfiguration
+
+  describe '#to_sanitized_hash' do
+    subject { described_class.to_sanitized_hash }
+    it { is_expected.to include(:INCOMING_EMAIL_SECRET => '[FILTERED]') }
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #1636

## What does this do?

Extract `AdminGeneralController#debug` to `Admin::DebugController#index`, tidy up its view, and render a sanitised version of`AlaveteliConfiguration` so that admins can view the configuration without a server ssh session.

## Why was this needed?

Helps less technical users and admins of Alavetelis hosted by mySociety.

Playing around with speaking at chatGPT after work because I was annoyed at having to ssh to figure out the `AlaveteliConfiguration.reply_very_late_after_days` value.

## Implementation notes

Weird issue with the routing – will try to resolve that before merge

## Screenshots

![Screenshot 2024-05-29 at 18 48 22](https://github.com/mysociety/alaveteli/assets/282788/8e1f848e-e58f-4abd-94a3-538cefe49556)
