### PR TITLE
Fix broken HTML in translations

### DIFF
--- a/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
+++ b/app/views/alaveteli_pro/info_request_batches/_info_request_batch.html.erb
@@ -21,8 +21,8 @@
                 collection: info_request_batch.info_requests %>
     <% end %>
     <div class="show-all-batch-link">
-      <%= link_to n_('Show {{count}} request in detail</span>',
-                     'Show {{count}} requests in detail</span>',
+      <%= link_to n_('Show {{count}} request in detail',
+                     'Show {{count}} requests in detail',
                      info_request_batch.public_bodies.count,
                      batch_request_title: info_request_batch.title,
                      count: info_request_batch.public_bodies.count),

--- a/app/views/alaveteli_pro/plans/index.html.erb
+++ b/app/views/alaveteli_pro/plans/index.html.erb
@@ -49,7 +49,7 @@
                   'contact details</strong> for {{authority_count}} authorities',
                   authority_count: PublicBody.is_requestable.count) %></li>
         <li><%= _('A <strong class="marketing-highlight">searchable archive</strong> of Freedom of Information requests') %></li>
-        <li><%= _('<strong class="marketing-highlight">Delivery verification</strong> for proof of receipt</strong>') %></li>
+        <li><%= _('<strong class="marketing-highlight">Delivery verification</strong> for proof of receipt') %></li>
         <li><%= _('A permanent, searchable, <strong class="marketing-highlight">public record</strong> of your request and the responses') %></li>
         <li><%= _('<strong class="marketing-highlight">Streamlined process</strong> for requesting internal reviews') %></li>
       </ul>

--- a/app/views/comment/_suggestions.html.erb
+++ b/app/views/comment/_suggestions.html.erb
@@ -57,7 +57,7 @@
 
   <% if [ 'internal_review' ].include?(@info_request.described_state) %>
     <li> <%= _("<strong>Advice</strong> on how to get a response that will " \
-                  "satisfy the requester. </li>") %>
+                  "satisfy the requester.") %> </li>
   <% end %>
 
   <% if [ 'error_message' ].include?(@info_request.described_state) %>


### PR DESCRIPTION
Noticed these when pulling new translation from Transifex. 

<hr>

[skip changelog]