### PR TITLE
Add basic NotificationMailerPreview

### DIFF
--- a/spec/mailers/previews/notification_mailer_preview.rb
+++ b/spec/mailers/previews/notification_mailer_preview.rb
@@ -1,0 +1,21 @@
+class NotificationMailerPreview < ActionMailer::Preview
+  def daily_summary
+    NotificationMailer.daily_summary(user, notifications)
+  end
+
+  private
+
+  def user
+    User.new(
+      name: 'Pro user',
+      email: 'pro@localhost'
+    )
+  end
+
+  # 902: useless_incoming_message_event
+  def notifications
+    [
+      Notification.new(user: user, info_request_event: InfoRequestEvent.find(902))
+    ]
+  end
+end


### PR DESCRIPTION
In service of https://github.com/mysociety/whatdotheyknow-private/issues/332.

This one is quite difficult to create stub data for. Just to get this working quickly I've directly looked up one of the fixture events to act as the Notification association.

Would have used FactoryBot, but that can't build a Notification; only create, which would be annoying in development.

