### PR TITLE
Update reviewdog CI action config

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -21,7 +21,7 @@ jobs:
         ruby-version: 3.0
 
     - name: Run RuboCop linter
-      uses: reviewdog/action-rubocop@v2
+      uses: reviewdog/action-rubocop@v2.14.0
       with:
         github_token: ${{ secrets.github_token }}
         rubocop_flags: -DES


### PR DESCRIPTION
Pin to working version. Since v2.15.0 (or reviewdog core v0.19.0) the filter mode doesn't seem to respected.

<hr>

[skip changelog]