### PR TITLE
[#6600] Add citations on batch pages

### DIFF
--- a/app/controllers/info_request_batch_controller.rb
+++ b/app/controllers/info_request_batch_controller.rb
@@ -14,6 +14,8 @@ class InfoRequestBatchController < ApplicationController
       @public_bodies = load_public_bodies.paginate(page: @page,
                                                    per_page: @per_page)
     end
+
+    @citations = @info_request_batch.citations.newest(3)
   end
 
   private

--- a/app/views/citations/_citation.html.erb
+++ b/app/views/citations/_citation.html.erb
@@ -1,0 +1,7 @@
+<li class="citations-list__citation">
+  <%=
+    MySociety::Format.make_clickable(
+      citation.source_url, contract: true, nofollow: true
+    ).html_safe
+  %>
+</li>

--- a/app/views/info_request_batch/_citations.html.erb
+++ b/app/views/info_request_batch/_citations.html.erb
@@ -1,0 +1,11 @@
+<% if citations.any? %>
+  <div class="sidebar__section citations">
+    <h2><%= _('In the News') %></h2>
+
+    <% if citations.any? %>
+      <ul class="citations-list">
+        <%= render citations %>
+      </ul>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -64,4 +64,8 @@
     <%= render partial: 'downloads',
                locals: { info_request_batch: @info_request_batch } %>
   <% end %>
+
+  <%= render partial: 'citations', locals: {
+    citations: @citations, info_request_batch: @info_request_batch
+  } %>
 </div>

--- a/app/views/request/_citations.html.erb
+++ b/app/views/request/_citations.html.erb
@@ -1,55 +1,23 @@
-<%# FIXME: Slightly messy logic, but can be cleaned up when we allow any user to
-    add citations %>
-
-<% if can? :create_citation, info_request %>
+<% if can?(:create_citation, info_request) || citations.any? %>
   <div class="sidebar__section citations">
     <h2><%= _('In the News') %></h2>
 
     <% if citations.any? %>
       <ul class="citations-list">
-        <% citations.each do |citation| %>
-          <li class="citations-list__citation">
-            <%=
-              MySociety::Format.make_clickable(
-                citation.source_url, contract: true, nofollow: true
-              ).html_safe
-            %>
-          </li>
-        <% end %>
+        <%= render citations %>
       </ul>
-
-      <%= link_to new_citation_path(url_title: info_request.url_title),
-            class: 'citations-new' do %>
-        <%= _('New Citation') %>
-      <% end %>
-    <% else %>
+    <% elsif can? :create_citation, info_request %>
       <p>
         <%= _('Has this request been referenced in a news article or ' \
               'academic paper?') %>
       </p>
+    <% end %>
 
+    <% if can? :create_citation, info_request %>
       <%= link_to new_citation_path(url_title: info_request.url_title),
             class: 'citations-new' do %>
-        <%= _('Let us know') %>
+        <%= citations.any? ? _('New Citation') : _('Let us know') %>
       <% end %>
-    <% end %>
-  </div>
-<% elsif citations.any? %>
-  <div class="sidebar__section citations">
-    <h2><%= _('In the News') %></h2>
-
-    <% if citations.any? %>
-      <ul class="citations-list">
-        <% citations.each do |citation| %>
-          <li class="citations-list__citation">
-            <%=
-              MySociety::Format.make_clickable(
-                citation.source_url, contract: true, nofollow: true
-              ).html_safe
-            %>
-          </li>
-        <% end %>
-      </ul>
     <% end %>
   </div>
 <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Show citations on info request batch pages (Graeme Porteous)
 * Allow pro users to create and manage Projects (Graeme Porteous)
 * Improve Xapian queue health check (Graeme Porteous)
 * Improve nginx configuration file for Sidekiq Web UI (Graeme Porteous)

--- a/spec/views/info_request_batch/_citations.html.erb_spec.rb
+++ b/spec/views/info_request_batch/_citations.html.erb_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+def render_view
+  render partial: self.class.top_level_description,
+         locals: stub_locals
+end
+
+RSpec.describe 'info_request_batch/citations' do
+  let(:info_request_batch) { FactoryBot.create(:info_request_batch) }
+
+  let(:ability) { Object.new.extend(CanCan::Ability) }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(view).to receive(:current_user).and_return(info_request_batch.user)
+  end
+
+  context 'with no citations' do
+    let(:stub_locals) do
+      { citations: [], info_request_batch: info_request_batch }
+    end
+
+    before { render_view }
+
+    it 'renders nothing' do
+      expect(rendered).to be_blank
+    end
+  end
+
+  context 'with citations' do
+    let(:stub_locals) do
+      { citations: FactoryBot.build_list(:citation, 3),
+        info_request_batch: info_request_batch }
+    end
+
+    before { render_view }
+
+    it 'renders the section' do
+      expect(rendered).to match(/In the News/)
+    end
+
+    it 'renders the citations' do
+      expect(rendered).to match(/citations-list/)
+    end
+  end
+end

--- a/spec/views/request/_citations.html.erb_spec.rb
+++ b/spec/views/request/_citations.html.erb_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'request/citations' do
       before { render_view }
 
       it 'renders nothing' do
-        expect(rendered).to eq("\n")
+        expect(rendered).to be_blank
       end
     end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/6600

## What does this do?

Adds list of citations on batch pages.

## Why was this needed?

Citation can already be added to batches (via individual requests). This will make the sidebars consistent and show off good requests and usage of sites.

## Screenshots

<img width="955" alt="image" src="https://github.com/mysociety/alaveteli/assets/5426/d2287907-40dd-46f0-a9ec-9d9f06ff2301">

