### PR TITLE
[#8308] Allow users to add citations to batch requests

### DIFF
--- a/app/controllers/citations_controller.rb
+++ b/app/controllers/citations_controller.rb
@@ -18,6 +18,8 @@ class CitationsController < ApplicationController
       case @citable
       when InfoRequest
         redirect_to show_request_path(citable.url_title), notice: notice
+      when InfoRequestBatch
+        redirect_to info_request_batch_path(citable), notice: notice
       end
     else
       render :new
@@ -39,6 +41,8 @@ class CitationsController < ApplicationController
     case params.fetch(:resource, 'InfoRequest')
     when 'InfoRequest'
       @resource ||= InfoRequest.find_by_url_title!(params[:url_title])
+    when 'InfoRequestBatch'
+      @resource ||= InfoRequestBatch.find_by_id!(params[:info_request_batch_id])
     end
   end
 

--- a/app/controllers/citations_controller.rb
+++ b/app/controllers/citations_controller.rb
@@ -3,7 +3,7 @@
 #
 class CitationsController < ApplicationController
   before_action :authenticate
-  before_action :load_info_request_and_authorise
+  before_action :load_resource_and_authorise
   before_action :set_in_pro_area
 
   def new
@@ -12,12 +12,13 @@ class CitationsController < ApplicationController
 
   def create
     @citation = current_user.citations.build(citation_params)
-    @citation.citable = citable
 
     if @citation.save
       notice = _('Citation successfully created.')
-      redirect_to show_request_path(info_request.url_title),
-                  notice: notice
+      case @citable
+      when InfoRequest
+        redirect_to show_request_path(citable.url_title), notice: notice
+      end
     else
       render :new
     end
@@ -34,28 +35,32 @@ class CitationsController < ApplicationController
     )
   end
 
-  def info_request
-    @info_request ||= InfoRequest.find_by_url_title!(params[:url_title])
+  def resource
+    case params.fetch(:resource, 'InfoRequest')
+    when 'InfoRequest'
+      @resource ||= InfoRequest.find_by_url_title!(params[:url_title])
+    end
   end
 
-  def load_info_request_and_authorise
-    if cannot?(:read, info_request)
+  def load_resource_and_authorise
+    if cannot?(:read, resource)
       return render_hidden('request/hidden', response_code: 404)
     end
 
-    authorize! :create_citation, info_request
+    authorize! :create_citation, resource
   end
 
   def set_in_pro_area
-    @in_pro_area = current_user.is_pro? && info_request.user == current_user
+    @in_pro_area = current_user.is_pro? && resource.user == current_user
   end
 
   def citation_params
-    params.require(:citation).permit(:source_url, :type)
+    params.require(:citation).permit(:source_url, :type).
+      with_defaults(citable: citable)
   end
 
   def citable
-    (info_request.info_request_batch if params[:applies_to_batch_request]) ||
-      info_request
+    @citable = resource.info_request_batch if params[:applies_to_batch_request]
+    @citable ||= resource
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -180,8 +180,8 @@ class Ability
       end
     end
 
-    can :create_citation, InfoRequest do |info_request|
-      user && (user.is_admin? || user.is_pro? || info_request.user == user)
+    can :create_citation, [InfoRequest, InfoRequestBatch] do |content|
+      user && (user.is_admin? || user.is_pro? || content.user == user)
     end
 
     can :share, InfoRequest do |info_request|

--- a/app/views/citations/new.html.erb
+++ b/app/views/citations/new.html.erb
@@ -44,7 +44,7 @@
     </label>
   </p>
 
-  <% if @info_request.info_request_batch_id %>
+  <% if @resource.is_a?(InfoRequest) && @resource.info_request_batch_id %>
     <p>
       <label for="applies_to_batch_request" class="form_label">
         <%= check_box_tag :applies_to_batch_request, true,

--- a/app/views/citations/new.html.erb
+++ b/app/views/citations/new.html.erb
@@ -1,11 +1,18 @@
 <h1><%= _('In the News') %></h1>
 
 <p>
-  <%= _('Has this request been referenced in a news article or academic ' \
-        'paper? Let us know:') %>
+  <% if @resource.is_a?(InfoRequestBatch) %>
+    <%= _('Has this batch request been referenced in a news article or ' \
+          'academic paper? Let us know:') %>
+  <% else %>
+    <%= _('Has this request been referenced in a news article or academic ' \
+          'paper? Let us know:') %>
+  <% end %>
 </p>
 
-<%= form_for @citation, class: 'form form-horizontal' do |f| %>
+<%= form_for @citation,
+  url: url_for(action: 'create', **params.permit(:resource, :url_title, :info_request_batch_id)),
+  class: 'form form-horizontal' do |f| %>
   <%= foi_error_messages_for :citation %>
 
   <p>

--- a/app/views/info_request_batch/_citations.html.erb
+++ b/app/views/info_request_batch/_citations.html.erb
@@ -1,4 +1,4 @@
-<% if citations.any? %>
+<% if can?(:create_citation, info_request_batch) || citations.any? %>
   <div class="sidebar__section citations">
     <h2><%= _('In the News') %></h2>
 
@@ -6,6 +6,18 @@
       <ul class="citations-list">
         <%= render citations %>
       </ul>
+    <% elsif can? :create_citation, info_request_batch %>
+      <p>
+        <%= _('Has this batch request been referenced in a news article or ' \
+              'academic paper?') %>
+      </p>
+    <% end %>
+
+    <% if can? :create_citation, info_request_batch %>
+      <%= link_to new_info_request_batch_citation_path(info_request_batch),
+            class: 'citations-new' do %>
+        <%= citations.any? ? _('New Citation') : _('Let us know') %>
+      <% end %>
     <% end %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -237,7 +237,12 @@ Rails.application.routes.draw do
     resources :widget_votes, :only => [:create]
   end
 
-  resources :info_request_batch, :only => :show
+  resources :info_request_batch, :only => :show do
+    #### Citations controller
+    resources :citations, only: [:new, :create],
+      defaults: { resource: 'InfoRequestBatch' }
+    ####
+  end
 
   #### OutgoingMessage controller
   resources :outgoing_messages, :only => [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,7 +175,8 @@ Rails.application.routes.draw do
 
   scope path: 'request/:url_title' do
     #### Citations controller
-    resources :citations, only: [:new, :create]
+    resources :citations, only: [:new, :create],
+      defaults: { resource: 'InfoRequest' }
     ####
 
     #### Classifications controller

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## Highlighted Features
 
-* Show citations on info request batch pages (Graeme Porteous)
+* Show and allow creation of citations from info request batch pages (Graeme
+  Porteous)
 * Allow pro users to create and manage Projects (Graeme Porteous)
 * Improve Xapian queue health check (Graeme Porteous)
 * Improve nginx configuration file for Sidekiq Web UI (Graeme Porteous)

--- a/spec/controllers/citations_controller_spec.rb
+++ b/spec/controllers/citations_controller_spec.rb
@@ -10,13 +10,13 @@ RSpec.describe CitationsController, type: :controller do
 
     context 'when unable to read info request' do
       before do
-        allow(controller).to receive(:cannot?).with(:read, info_request).
+        allow(controller).to receive(:cannot?).with(:read, resource).
                           and_return(true)
       end
 
       it 'should find InfoRequest' do
         action
-        expect(assigns[:info_request]).to eq info_request
+        expect(assigns[:resource]).to eq resource
       end
 
       it 'return a 404' do
@@ -26,9 +26,9 @@ RSpec.describe CitationsController, type: :controller do
     end
 
     shared_examples 'successful' do
-      it 'assigns info_request' do
+      it 'assigns resource' do
         action
-        expect(assigns[:info_request]).to eq info_request
+        expect(assigns[:resource]).to eq resource
       end
 
       unless opts[:redirection]
@@ -55,12 +55,12 @@ RSpec.describe CitationsController, type: :controller do
     context 'when not the requester' do
       let(:user) { FactoryBot.create(:user) }
 
-      it 'assigns info_request' do
+      it 'assigns resource' do
         begin
           action
         rescue CanCan::AccessDenied
         end
-        expect(assigns[:info_request]).to eq info_request
+        expect(assigns[:resource]).to eq resource
       end
 
       it 'raise access denied' do
@@ -73,12 +73,13 @@ RSpec.describe CitationsController, type: :controller do
 
   describe 'GET new' do
     context 'logged in' do
-      let(:info_request) { FactoryBot.create(:info_request) }
-      let(:user) { info_request.user }
+      let(:resource) { FactoryBot.create(:info_request) }
+      let(:user) { resource.user }
       before { sign_in user }
 
       def action
-        get :new, params: { url_title: info_request.url_title }
+        get :new, params: { resource: 'InfoRequest',
+                            url_title: resource.url_title }
       end
 
       include_examples 'authorisation', redirection: false
@@ -116,13 +117,14 @@ RSpec.describe CitationsController, type: :controller do
 
   describe 'POST create' do
     context 'logged in' do
-      let(:info_request) { FactoryBot.create(:info_request) }
-      let(:user) { info_request.user }
+      let(:resource) { FactoryBot.create(:info_request) }
+      let(:user) { resource.user }
       before { sign_in user }
 
       def action
         post :create, params: {
-          url_title: info_request.url_title,
+          resource: 'InfoRequest',
+          url_title: resource.url_title,
           citation: params,
           applies_to_batch_request: apply_to_batch
         }
@@ -146,15 +148,15 @@ RSpec.describe CitationsController, type: :controller do
       end
 
       context 'when citation does not apply to a batch' do
-        it 'assigns info_request to citation' do
+        it 'assigns resource to citation' do
           action
-          expect(assigns[:citation].citable).to eq info_request
+          expect(assigns[:citation].citable).to eq resource
         end
       end
 
       context 'when citation applies to a batch' do
         let(:batch) { FactoryBot.create(:info_request_batch, :sent) }
-        let(:info_request) { batch.info_requests.first }
+        let(:resource) { batch.info_requests.first }
         let(:apply_to_batch) { true }
 
         it 'assigns info_request_batch to citation' do
@@ -167,7 +169,7 @@ RSpec.describe CitationsController, type: :controller do
         it 'redirects back to request' do
           action
           expect(response).to redirect_to(
-            show_request_url(info_request.url_title)
+            show_request_url(resource.url_title)
           )
         end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -359,17 +359,26 @@ RSpec.describe Ability do
 
   describe 'create_citation' do
     let(:info_request) { InfoRequest.new(user: owner) }
+    let(:info_request_batch) { InfoRequestBatch.new(user: owner) }
     let(:owner) { nil }
 
     context 'when the user is an admin' do
-      it 'allows creating citations' do
+      it 'allows creating citations for InfoRequest' do
         expect(admin_ability).to be_able_to(:create_citation, info_request)
+      end
+
+      it 'allows creating citations for InfoRequestBatch' do
+        expect(admin_ability).to be_able_to(:create_citation, info_request_batch)
       end
     end
 
     context 'when the user is a pro' do
-      it 'allows creating citations' do
+      it 'allows creating citations for InfoRequest' do
         expect(pro_ability).to be_able_to(:create_citation, info_request)
+      end
+
+      it 'allows creating citations for InfoRequestBatch' do
+        expect(pro_ability).to be_able_to(:create_citation, info_request_batch)
       end
     end
 
@@ -377,20 +386,32 @@ RSpec.describe Ability do
       let(:owner) { FactoryBot.create(:user) }
       let(:owner_ability) { Ability.new(owner) }
 
-      it 'allows creating citations' do
+      it 'allows creating citations for their own InfoRequest' do
         expect(owner_ability).to be_able_to(:create_citation, info_request)
+      end
+
+      it 'allows creating citations for their own InfoRequestBatch' do
+        expect(owner_ability).to be_able_to(:create_citation, info_request_batch)
       end
     end
 
     context 'when the user is not the owner and does not have special permissions' do
-      it 'does not allow creating citations' do
+      it 'does not allow creating citations for InfoRequest' do
         expect(other_user_ability).not_to be_able_to(:create_citation, info_request)
+      end
+
+      it 'does not allow creating citations for InfoRequestBatch' do
+        expect(other_user_ability).not_to be_able_to(:create_citation, info_request_batch)
       end
     end
 
     context 'when there is no user' do
-      it 'does not allow creating citations' do
+      it 'does not allow creating citations for InfoRequest' do
         expect(guest_ability).not_to be_able_to(:create_citation, info_request)
+      end
+
+      it 'does not allow creating citations for InfoRequestBatch' do
+        expect(guest_ability).not_to be_able_to(:create_citation, info_request_batch)
       end
     end
   end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -2,9 +2,6 @@ require 'spec_helper'
 require "cancan/matchers"
 
 RSpec.shared_examples_for "a class with message prominence" do
-  let(:admin_ability) { Ability.new(FactoryBot.create(:admin_user)) }
-  let(:other_user_ability) { Ability.new(FactoryBot.create(:user)) }
-
   context 'if the prominence is hidden' do
     let(:prominence) { 'hidden' }
 
@@ -55,6 +52,11 @@ RSpec.shared_examples_for "a class with message prominence" do
 end
 
 RSpec.describe Ability do
+  let(:pro_ability) { Ability.new(FactoryBot.create(:pro_user)) }
+  let(:admin_ability) { Ability.new(FactoryBot.create(:admin_user)) }
+  let(:other_user_ability) { Ability.new(FactoryBot.create(:user)) }
+  let(:guest_ability) { Ability.guest }
+
   describe '.guest' do
     it 'returns Ability instance with no user' do
       guest = Ability.guest
@@ -351,6 +353,44 @@ RSpec.describe Ability do
         it 'should return true if the user owns the right resource' do
           expect(owner_ability).to be_able_to(:read, resource)
         end
+      end
+    end
+  end
+
+  describe 'create_citation' do
+    let(:info_request) { InfoRequest.new(user: owner) }
+    let(:owner) { nil }
+
+    context 'when the user is an admin' do
+      it 'allows creating citations' do
+        expect(admin_ability).to be_able_to(:create_citation, info_request)
+      end
+    end
+
+    context 'when the user is a pro' do
+      it 'allows creating citations' do
+        expect(pro_ability).to be_able_to(:create_citation, info_request)
+      end
+    end
+
+    context 'when the user is the owner of the content' do
+      let(:owner) { FactoryBot.create(:user) }
+      let(:owner_ability) { Ability.new(owner) }
+
+      it 'allows creating citations' do
+        expect(owner_ability).to be_able_to(:create_citation, info_request)
+      end
+    end
+
+    context 'when the user is not the owner and does not have special permissions' do
+      it 'does not allow creating citations' do
+        expect(other_user_ability).not_to be_able_to(:create_citation, info_request)
+      end
+    end
+
+    context 'when there is no user' do
+      it 'does not allow creating citations' do
+        expect(guest_ability).not_to be_able_to(:create_citation, info_request)
       end
     end
   end

--- a/spec/views/info_request_batch/_citations.html.erb_spec.rb
+++ b/spec/views/info_request_batch/_citations.html.erb_spec.rb
@@ -20,10 +20,31 @@ RSpec.describe 'info_request_batch/citations' do
       { citations: [], info_request_batch: info_request_batch }
     end
 
-    before { render_view }
+    context 'the current_user cannot create a citation' do
+      before { ability.cannot :create_citation, info_request_batch }
+      before { render_view }
 
-    it 'renders nothing' do
-      expect(rendered).to be_blank
+      it 'renders nothing' do
+        expect(rendered).to be_blank
+      end
+    end
+
+    context 'the current_user can create a citation' do
+      before { ability.can :create_citation, info_request_batch }
+      before { render_view }
+
+      it 'renders the section' do
+        expect(rendered).to match(/In the News/)
+      end
+
+      it 'renders the blank slate text' do
+        expect(rendered).to match(/Has this batch request been referenced/)
+      end
+
+      it 'renders the link to add citations' do
+        expect(rendered).
+          to match(new_info_request_batch_citation_path(info_request_batch))
+      end
     end
   end
 
@@ -33,14 +54,47 @@ RSpec.describe 'info_request_batch/citations' do
         info_request_batch: info_request_batch }
     end
 
-    before { render_view }
+    context 'the current_user cannot create a citation' do
+      before { ability.cannot :create_citation, info_request_batch }
+      before { render_view }
 
-    it 'renders the section' do
-      expect(rendered).to match(/In the News/)
+      it 'renders the section' do
+        expect(rendered).to match(/In the News/)
+      end
+
+      it 'does not render the blank slate text' do
+        expect(rendered).not_to match(/Has this batch request been referenced/)
+      end
+
+      it 'renders the citations' do
+        expect(rendered).to match(/citations-list/)
+      end
+
+      it 'does not render the link to add a citation' do
+        expect(rendered).
+          not_to match(new_info_request_batch_citation_path(info_request_batch))
+      end
     end
 
-    it 'renders the citations' do
-      expect(rendered).to match(/citations-list/)
+    context 'the current_user can create a citation' do
+      before { ability.can :create_citation, info_request_batch }
+      before { render_view }
+
+      it 'renders the section' do
+        expect(rendered).to match(/In the News/)
+      end
+
+      it 'does not render the blank slate text' do
+        expect(rendered).not_to match(/Has this request been referenced/)
+      end
+
+      it 'renders the citations' do
+        expect(rendered).to match(/citations-list/)
+      end
+
+      it 'renders the link to add citations' do
+        expect(rendered).to match('New Citation')
+      end
     end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli/issues/8308

## What does this do?

Allow users to add citations to batch requests directly. Previously this was only possible via individual requests.

## Screenshots

![image](https://github.com/mysociety/alaveteli/assets/5426/483ad439-7af4-4d7a-b924-75aa006f162e)
![image](https://github.com/mysociety/alaveteli/assets/5426/3d42b16a-f2f4-4f11-ae13-30c4f7d0510c)
