### PR TITLE
Update Xapian indexing health check

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Improve Xapian queue health check (Graeme Porteous)
 * Improve nginx configuration file for Sidekiq Web UI (Graeme Porteous)
 * View user profile photos from admin list of users (Gareth Rees)
 * Update user email to be sent from the blackhole address (Graeme Porteous)

--- a/spec/integration/health_checks_spec.rb
+++ b/spec/integration/health_checks_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+RSpec.describe 'health checks' do
+  before do
+    # create recent content to satisfy checks.
+    FactoryBot.create(:user)
+    FactoryBot.create(:incoming_message)
+  end
+
+  def status
+    get '/health/checks'
+    response.status
+  end
+
+  it { expect(status).to eq 200 }
+
+  it 'should succeed when Xapain job was queued within the last hour' do
+    travel_to(59.minutes.ago)
+    ActsAsXapian::ActsAsXapianJob.create(
+      model_id: InfoRequestEvent.first.id,
+      model: 'InfoRequestEvent',
+      action: 'update'
+    )
+    expect(status).to eq 200 # initial run to cache ID and Time in Redis
+
+    travel_back
+    expect(status).to eq 200
+  end
+
+  it 'should fail when Xapain job was queued over an hour ago' do
+    travel_to(1.hour.ago)
+    ActsAsXapian::ActsAsXapianJob.create(
+      model_id: 1, model: 'InfoRequestEvent', action: 'update'
+    )
+    expect(status).to eq 200 # initial run to cache ID and Time in Redis
+
+    travel_back
+    expect(status).to eq 500
+  end
+
+  it 'should succeed when oldest Xapain job changes during the hour' do
+    travel_to(1.hour.ago)
+    job1 = ActsAsXapian::ActsAsXapianJob.create(
+      model_id: 1, model: 'InfoRequestEvent', action: 'update'
+    )
+    ActsAsXapian::ActsAsXapianJob.create(
+      model_id: 2, model: 'InfoRequestEvent', action: 'update'
+    )
+    expect(status).to eq 200 # initial run to cache ID and Time in Redis
+
+    job1.destroy
+
+    travel_back
+    expect(status).to eq 200
+  end
+end


### PR DESCRIPTION
Modify the health check to track the oldest job in the queue more effectively.

Previously, the health check inspected the created_at timestamp of the oldest job, which could be misleading if many jobs were queued simultaneously.

Now, during each check, we will determine whether the oldest job in the queue has changed. We will log the current time whenever a change is detected and continue to return this time until we observe a change in the oldest job.

This ensures the health check will only fail if the job queue is stuck, with no jobs processed for over an hour.

