### PR TITLE
Update `WorldFOIWebsites.can_ask_the_eu?`

### DIFF
--- a/lib/world_foi_websites.rb
+++ b/lib/world_foi_websites.rb
@@ -24,8 +24,7 @@ class WorldFOIWebsites
                    'SI' => 'Slovenia',
                    'SK' => 'Slovakia',
                    'FI' => 'Finland',
-                   'SE' => 'Sweden',
-                   'GB' => 'United Kingdom' }.freeze
+                   'SE' => 'Sweden' }.freeze
 
   def self.world_foi_websites
     world_foi_websites = [


### PR DESCRIPTION
No longer really makes sense to direct our users to AskTheEU in the context that this method is used.

Related to https://github.com/mysociety/whatdotheyknow-theme/pull/1890/

[skip changelog]
