### PR TITLE
[#8344] Fix rendering invoices view

### DIFF
--- a/app/models/alaveteli_pro/invoice.rb
+++ b/app/models/alaveteli_pro/invoice.rb
@@ -20,10 +20,11 @@ module AlaveteliPro
 
     # charge
     def charge
-      @charge ||= Stripe::Charge.retrieve(__getobj__.charge)
+      charge_id = __getobj__.charge
+      @charge ||= Stripe::Charge.retrieve(charge_id) if charge_id
     end
 
-    delegate :receipt_url, to: :charge
+    delegate :receipt_url, to: :charge, allow_nil: true
 
     private
 

--- a/app/models/alaveteli_pro/invoice.rb
+++ b/app/models/alaveteli_pro/invoice.rb
@@ -10,7 +10,7 @@ module AlaveteliPro
     end
 
     def paid?
-      status == 'paid'
+      status == 'paid' && amount_paid > 0
     end
 
     # attributes

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Fix rendering invoices page when there are discounted Pro subscription (Graeme
+  Porteous)
 * Drop support for Ruby 3.0 (Graeme Porteous)
 * Allow projects owners to publish datasets (Graeme Porteous)
 * Add comment deletion (Helen Cross, Graeme Porteous, Gareth Rees)

--- a/spec/models/alaveteli_pro/invoice_spec.rb
+++ b/spec/models/alaveteli_pro/invoice_spec.rb
@@ -62,6 +62,11 @@ RSpec.describe AlaveteliPro::Invoice, type: :model do
     it 'delegates receipt_url to the charge' do
       expect(invoice.receipt_url).to eq('http://example.com/receipt')
     end
+
+    it 'returns nil when there is no charge' do
+      allow(stripe_invoice).to receive(:charge).and_return(nil)
+      expect(invoice.receipt_url).to be_nil
+    end
   end
 
   describe '#method_missing' do

--- a/spec/models/alaveteli_pro/invoice_spec.rb
+++ b/spec/models/alaveteli_pro/invoice_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AlaveteliPro::Invoice, type: :model do
 
   let(:stripe_invoice) do
     double('Stripe::Invoice',
-           status: 'open', charge: 'ch_123', date: 1722211200)
+           status: 'open', charge: 'ch_123', date: 1722211200, amount_paid: 0)
   end
 
   let(:stripe_charge) do
@@ -29,12 +29,19 @@ RSpec.describe AlaveteliPro::Invoice, type: :model do
   end
 
   describe '#paid?' do
-    it 'returns true when the status is paid' do
+    it 'returns true when the status is paid and an amount has been paid' do
       allow(stripe_invoice).to receive(:status).and_return('paid')
+      allow(stripe_invoice).to receive(:amount_paid).and_return(1000)
       expect(invoice).to be_paid
     end
 
+    it 'returns false when 100% discounted' do
+      allow(stripe_invoice).to receive(:status).and_return('paid')
+      expect(invoice).not_to be_paid
+    end
+
     it 'returns false when the status is not paid' do
+      allow(stripe_invoice).to receive(:amount_paid).and_return(1000)
       expect(invoice).not_to be_paid
     end
   end

--- a/spec/models/alaveteli_pro/invoice_spec.rb
+++ b/spec/models/alaveteli_pro/invoice_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe AlaveteliPro::Invoice, type: :model do
+  let(:invoice) { AlaveteliPro::Invoice.new(stripe_invoice) }
+
+  let(:stripe_invoice) do
+    double('Stripe::Invoice',
+           status: 'open', charge: 'ch_123', date: 1722211200)
+  end
+
+  let(:stripe_charge) do
+    double('Stripe::Charge', receipt_url: 'http://example.com/receipt')
+  end
+
+  before do
+    allow(Stripe::Charge).
+      to receive(:retrieve).with('ch_123').and_return(stripe_charge)
+  end
+
+  describe '#open?' do
+    it 'returns true when the status is open' do
+      expect(invoice).to be_open
+    end
+
+    it 'returns false when the status is not open' do
+      allow(stripe_invoice).to receive(:status).and_return('paid')
+      expect(invoice).not_to be_open
+    end
+  end
+
+  describe '#paid?' do
+    it 'returns true when the status is paid' do
+      allow(stripe_invoice).to receive(:status).and_return('paid')
+      expect(invoice).to be_paid
+    end
+
+    it 'returns false when the status is not paid' do
+      expect(invoice).not_to be_paid
+    end
+  end
+
+  describe '#date' do
+    it 'returns a date object for the invoice' do
+      with_env_tz 'UTC' do
+        expect(invoice.date).to eq(Date.new(2024, 7, 29))
+      end
+    end
+  end
+
+  describe '#charge' do
+    it 'returns a Stripe::Charge object' do
+      expect(invoice.charge).to eq(stripe_charge)
+    end
+
+    it 'memoizes the Stripe::Charge object' do
+      expect(Stripe::Charge).to receive(:retrieve).once.with('ch_123')
+      2.times { invoice.charge }
+    end
+  end
+
+  describe '#receipt_url' do
+    it 'delegates receipt_url to the charge' do
+      expect(invoice.receipt_url).to eq('http://example.com/receipt')
+    end
+  end
+
+  describe '#method_missing' do
+    it 'forwards missing methods to the original object' do
+      allow(stripe_invoice).
+        to receive(:some_missing_method).and_return('result')
+      expect(invoice.some_missing_method).to eq('result')
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8344

## What does this do?

Fix rendering invoices view

## Why was this needed?

Exceptions when Pro/former-pro users attempted to view their Pro invoices. Happened when there were 100% discounted invoices resulting in no charges.