### PR TITLE
[#8354] link to tictec knowledge hub

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -47,7 +47,7 @@
     <div class="admin-footer">
       <div class="container">
         <div class="row">
-          <span class="span5 offset7">
+          <span class="span7 offset5">
             <ul class="nav nav-pills">
               <li>
                 <a href="https://alaveteli.org/docs/running/admin_manual/">
@@ -60,6 +60,11 @@
               <li>
                 <a href="https://alaveteli.org/community/">
                   Alaveteli Community
+                </a>
+              </li>
+              <li>
+                <a href="https://tictec.mysociety.org/ati-community-of-practice/">
+                  Knowledge Hub
                 </a>
               </li>
             </ul>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -50,7 +50,7 @@
           <span class="span5 offset7">
             <ul class="nav nav-pills">
               <li>
-                <a href="http://alaveteli.org/docs/running/admin_manual/">
+                <a href="https://alaveteli.org/docs/running/admin_manual/">
                   Admin Manual
                 </a>
               </li>
@@ -58,7 +58,7 @@
                 <%= link_to 'Changelog', admin_changelog_index_path %>
               </li>
               <li>
-                <a href="http://alaveteli.org/community/">
+                <a href="https://alaveteli.org/community/">
                   Alaveteli Community
                 </a>
               </li>


### PR DESCRIPTION
Add link to TICTeC ATI homepage from admin footer

While there is a more direct link to the "Knowledge Hub", this feels
like a better place to link to and doesn't clash with the "Community"
link to alaveteli.org.

Fixes https://github.com/mysociety/alaveteli/issues/8354

![Screenshot 2024-08-14 at 17 12 40](https://github.com/user-attachments/assets/ce537a43-f4ca-4ace-bdec-53f2d819ce34)


[skip changelog]