### PR TITLE
[#8369] Remove "All time" filter from admin timeline

### DIFF
--- a/app/helpers/admin_general_timeline_helper.rb
+++ b/app/helpers/admin_general_timeline_helper.rb
@@ -13,8 +13,7 @@ module AdminGeneralTimelineHelper
       'Day' => 1.day.ago,
       '2 days' => 2.days.ago,
       'Week' => 1.week.ago,
-      'Month' => 1.month.ago,
-      'All time' => Time.utc(1970, 1, 1)
+      'Month' => 1.month.ago
     }
   end
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Remove "All time" filter from admin timeline due to performance issues (Gareth
+  Rees)
 * Add example logrotate configuration (Graeme Porteous)
 * Switch application server from Thin to Puma (Graeme Porteous)
 * Fix rendering invoices page when there are discounted Pro subscription (Graeme


### PR DESCRIPTION
On WhatDoTheyKnow this loads 17 million+ events, which attempts to use over 5GB of memory.

In all but the smallest installs pagination will be required for this page to be performant, so this commit removes the filter entirely.

Fixes https://github.com/mysociety/alaveteli/issues/8369.

BEFORE

![Screenshot 2024-08-29 at 16 54 26](https://github.com/user-attachments/assets/828a627a-1bae-4364-86a2-f8bc03c7ed4d)

AFTER

![Screenshot 2024-08-29 at 16 54 18](https://github.com/user-attachments/assets/d6428271-000a-4601-93d0-bc77f86f2b22)
