### PR TITLE
Configure hash style

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1764,6 +1764,7 @@ Style/HashSyntax:
   EnforcedStyle: ruby19_no_mixed_keys
   Exclude:
     - config/routes.rb
+  EnforcedShorthandSyntax: either_consistent
 
 Style/HashTransformKeys:
   Enabled: false


### PR DESCRIPTION
Allow shorthand syntax but allow key values need to be consistent.

Good:
```
  { foo: 'foo', bar: 'bar' }
```
Good:
```
  foo = 'foo'; bar = 'bar'
  { foo:, bar: }
```
Bad:
```
  foo = 'foo'
  { foo:, bar: 'bar' }
```

<hr>

[skip changelog]
