### PR TITLE
Layout and spacing improvements to popup banner

### DIFF
--- a/app/assets/stylesheets/responsive/_popups_layout.scss
+++ b/app/assets/stylesheets/responsive/_popups_layout.scss
@@ -9,20 +9,24 @@
 .popup__close {
   position: absolute;
   display: inline-block;;
-  top: -0.25em;
+  top: 50%;
+  transform: translateY(-50%); // positions the icon vertically in the middle of the banner.
   right: 0.9375rem; // equal to the padding of .popup minus padding
   z-index: 50;
   padding: 0.5em;
+  font-size: 1.5rem; // The element's clickable area is big enough
 }
 
 .popup__content {
 
     padding-top: 1em;
     padding-bottom: 1em;
+    text-align: center;
     @include grid-column(12);
+    padding-right: 2.5rem; // No overlapping with the close button in smaller screens
     @include ie8{
       padding-left: 0.9375em;
-      padding-right: 0.9375em;
+      padding-right: 2.5rem;
     }
 }
 


### PR DESCRIPTION
## Relevant issue(s)
Working on another ticket I noticed the markup for the `popup` and realised that there is a close button, however is not visible enough(opacity and size) and the clickable area is also quite small.

<img width="1915" alt="Screenshot 2024-09-23 at 07 28 22" src="https://github.com/user-attachments/assets/62646d29-5fa4-41d1-b95b-49ad0e75ae77">


## What does this do?

- Increases the size of the button
- Get rids of the opacity
- It also positions the close button vertically in the middle, specially on smaller screen it think it looks nicer.
- The content has being centred. For this type of one liner messages it looks a bit nicer and for having a different alignment than the rest of the page it pops up a bit more, but happy if we want to keep it the left aligned.

## Why was this needed?

## Implementation notes

## Screenshots

https://github.com/user-attachments/assets/ee75629d-91f0-40be-baa7-57748480a2a7


## Notes to reviewer

<hr>


[skip changelog]
