### PR TITLE
Update info request not embargoed query

### DIFF
--- a/app/models/info_request/prominence/not_embargoed_query.rb
+++ b/app/models/info_request/prominence/not_embargoed_query.rb
@@ -9,11 +9,10 @@ class InfoRequest
         # Specify an outer join as the default inner join
         # will not retrieve NULL records which is what we want here
         @relation
-          .select("info_requests.*")
-            .joins('LEFT OUTER JOIN embargoes
-                    ON embargoes.info_request_id = info_requests.id')
-              .where('embargoes.id IS NULL')
-                .references(:embargoes)
+          .joins('LEFT OUTER JOIN embargoes
+                  ON embargoes.info_request_id = info_requests.id')
+            .where('embargoes.id IS NULL')
+              .references(:embargoes)
       end
     end
   end

--- a/app/models/info_request/prominence/not_embargoed_query.rb
+++ b/app/models/info_request/prominence/not_embargoed_query.rb
@@ -6,13 +6,7 @@ class InfoRequest
       end
 
       def call
-        # Specify an outer join as the default inner join
-        # will not retrieve NULL records which is what we want here
-        @relation
-          .joins('LEFT OUTER JOIN embargoes
-                  ON embargoes.info_request_id = info_requests.id')
-            .where('embargoes.id IS NULL')
-              .references(:embargoes)
+        @relation.left_joins(:embargo).where(embargoes: { id: nil })
       end
     end
   end

--- a/app/models/statistics/leaderboard.rb
+++ b/app/models/statistics/leaderboard.rb
@@ -6,7 +6,7 @@ module Statistics
                   joins(:user).
                   merge(User.active).
                   group(:user).
-                  order(count_info_requests_all: :desc).
+                  order(count_all: :desc).
                   limit(10).
                   count
     end
@@ -18,7 +18,7 @@ module Statistics
                   joins(:user).
                   merge(User.active).
                   group(:user).
-                  order(count_info_requests_all: :desc).
+                  order(count_all: :desc).
                   limit(10).
                   count
     end


### PR DESCRIPTION
## What does this do?

Update info request not embargoed query:

1. Remove the SQL select prefix as this will allow the query to be used in join queries
2. Refactor query

<hr>

[skip changelog]