### PR TITLE
Fix error handling in script/mailin

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Fix script/mailin when multiple EXCEPTION_NOTIFICATIONS_TO addresses are
+  specified (Graeme Porteous)
 * Add example logrotate configuration (Graeme Porteous)
 * Switch application server from Thin to Puma (Graeme Porteous)
 * Fix rendering invoices page when there are discounted Pro subscription (Graeme

--- a/script/mailin
+++ b/script/mailin
@@ -22,7 +22,10 @@ then
     SUBJ="Mail import error for $(bin/config DOMAIN)"
     BODY="There was an error code $ERROR_CODE returned by the RequestMailer.receive command in script/mailin. See attached for details. This might be quite serious, such as the database was down, or might be an email with corrupt headers that Rails is choking on. We returned the email with an exit code 75, which for Exim at least instructs the MTA to try again later. A well configured installation of this code will separately have had Exim make a backup copy of the email in a separate mailbox, just in case."
     FROM="$(bin/config BLACKHOLE_PREFIX)@$(bin/config INCOMING_EMAIL_DOMAIN)"
-    /usr/bin/mutt -e "set use_envelope_from" -e "set envelope_from_address=$FROM" -s "$SUBJ" -a "$OUTPUT" "$INPUT" -- "$(bin/config EXCEPTION_NOTIFICATIONS_TO)" <<<"$BODY"
+
+    for TO in $(bin/config EXCEPTION_NOTIFICATIONS_TO); do
+        /usr/bin/mutt -e "set use_envelope_from" -e "set envelope_from_address=$FROM" -s "$SUBJ" -a "$OUTPUT" "$INPUT" -- "$TO" <<<"$BODY"
+    done
 
     # tell exim error was temporary, so try again later (no point bouncing message to authority)
     rm -f "$INPUT" "$OUTPUT"


### PR DESCRIPTION
Support multiple exception notifications addresses when handling errors
running script/mailin.
