### PR TITLE
[#7293] Update Notable#all_notes

### DIFF
--- a/app/models/concerns/notable.rb
+++ b/app/models/concerns/notable.rb
@@ -23,6 +23,10 @@ module Notable
   private
 
   def notable_tags
-    tags.map(&:name_and_value)
+    tags.inject([]) do |arr, tag|
+      arr << tag.name
+      arr << tag.name_and_value if tag.value
+      arr
+    end
   end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Change notes so that records tagged with `name:value` will be associated with
+  notes tagged as `name` (Graeme Porteous)
 * Upgrade Stripe API version (Graeme Porteous)
 * Drop support for Azure storage (Graeme Porteous)
 * Add basic Citation searching in admin UI (Gareth Rees)

--- a/spec/models/concerns/notable_and_taggable.rb
+++ b/spec/models/concerns/notable_and_taggable.rb
@@ -4,12 +4,31 @@ RSpec.shared_examples 'concerns/notable_and_taggable' do |factory_opts|
   describe '#all_notes' do
     subject { record.all_notes }
 
-    before { record.tag_string = 'foo' }
-
     let!(:tagged_note) { FactoryBot.create(:note, notable_tag: 'foo') }
     let!(:other_tagged_note) { FactoryBot.create(:note, notable_tag: 'bar') }
 
-    it { is_expected.to include tagged_note }
-    it { is_expected.to_not include other_tagged_note }
+    let!(:tagged_note_with_value) do
+      FactoryBot.create(:note, notable_tag: 'foo:1')
+    end
+
+    let!(:tagged_note_with_other_value) do
+      FactoryBot.create(:note, notable_tag: 'foo:2')
+    end
+
+    context 'with name tag' do
+      before { record.tag_string = 'foo' }
+      it { is_expected.to include tagged_note }
+      it { is_expected.to_not include tagged_note_with_value }
+      it { is_expected.to_not include other_tagged_note }
+      it { is_expected.to_not include tagged_note_with_other_value }
+    end
+
+    context 'with name:value tag' do
+      before { record.tag_string = 'foo:1' }
+      it { is_expected.to include tagged_note }
+      it { is_expected.to include tagged_note_with_value }
+      it { is_expected.to_not include other_tagged_note }
+      it { is_expected.to_not include tagged_note_with_other_value }
+    end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7293

## What does this do?

Update Notable#all_notes

## Why was this needed?

Update the concern so that records tagged with `name:value` will be associated with notes tagged as `name`.
