### PR TITLE
Bump sprockets from `f4d3dae` to `3.7.5`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,7 +157,7 @@ gem 'mime-types', '< 4.0.0', require: false
 gem 'bootstrap-sass', '~> 2.3.2.2'
 gem 'mini_racer', '~> 0.16.0'
 gem 'sass-rails', '~> 5.0.8'
-gem 'sprockets', git: 'https://github.com/rails/sprockets', ref: '3.x'
+gem 'sprockets', '~> 3.7.5'
 gem 'uglifier', '~> 4.2.1'
 # Modern Assets
 gem 'importmap-rails', '~> 2.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,15 +24,6 @@ GIT
       activemodel (>= 3.0, < 8.0)
 
 GIT
-  remote: https://github.com/rails/sprockets
-  revision: f4d3dae71ef29c44b75a49cfbf8032cce07b423a
-  ref: 3.x
-  specs:
-    sprockets (3.7.2)
-      concurrent-ruby (~> 1.0)
-      rack (> 1, < 3)
-
-GIT
   remote: https://github.com/stripe-ruby-mock/stripe-ruby-mock
   revision: 6ceea9679bb573cb8bc6830f1bdf670b220a9859
   ref: 6ceea96
@@ -166,6 +157,7 @@ GEM
       faraday (~> 0.9)
       faraday_middleware (~> 0.10)
       nokogiri (~> 1.6, >= 1.6.8)
+    base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.8)
     bindex (0.8.1)
@@ -525,6 +517,10 @@ GEM
     simplecov-lcov (0.7.0)
     simplecov_json_formatter (0.1.4)
     singleton (0.2.0)
+    sprockets (3.7.5)
+      base64
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
     sprockets-rails (3.4.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -664,7 +660,7 @@ DEPENDENCIES
   sidekiq-limit_fetch (~> 4.4.1)
   simplecov (~> 0.22.0)
   simplecov-lcov (~> 0.7.0)
-  sprockets!
+  sprockets (~> 3.7.5)
   statistics2 (~> 0.54)
   stimulus-rails (~> 1.3.4)
   strip_attributes!


### PR DESCRIPTION
## What does this do?

Unpin the gem version. Change to suppress ERB warning has been released.

<hr>

[skip changelog]