### PR TITLE
Fix JS warnings when logged in as admin

### DIFF
--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -13,7 +13,7 @@
           <% else %>
 
           <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Summary<span class="caret"></span></a>
+            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Summary<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Summary', admin_general_index_path %></li>
               <li><%= link_to 'Timeline', admin_timeline_path %></li>
@@ -23,7 +23,7 @@
           </li>
 
           <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Requests<span class="caret"></span></a>
+            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Requests<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Requests', admin_requests_path %></li>
               <li><%= link_to 'Comments', admin_comments_path %></li>
@@ -35,7 +35,7 @@
           </li>
 
           <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Authorities<span class="caret"></span></a>
+            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Authorities<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Authorities', admin_bodies_path %></li>
               <li><%= link_to 'Categories', admin_categories_path(model_type: 'PublicBody') %></li>
@@ -44,7 +44,7 @@
           </li>
 
           <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Users<span class="caret"></span></a>
+            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Users<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Users', admin_users_path %></li>
               <li><%= link_to 'Tracks', admin_tracks_path %></li>
@@ -52,7 +52,7 @@
           </li>
 
           <li class="dropdown">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Tools<span class="caret"></span></a>
+            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Tools<span class="caret"></span></a>
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Announcements', admin_announcements_path %></li>
               <li><%= link_to 'Blog Posts', admin_blog_posts_path %></li>


### PR DESCRIPTION
With the admin navbar showing we see `Empty string passed to getElementById().` warnings due to bootstrap dropdown menus.

Removing the blank href on dropdown toggles fixes this.

<hr>

[skip changelog]