### PR TITLE
Fix the arrow on the topic pages

### DIFF
--- a/app/views/request/_tabs.html.erb
+++ b/app/views/request/_tabs.html.erb
@@ -1,8 +1,8 @@
 <% content_for :subnav do %>
-  <li class="<%= 'selected' unless current_page?(requests_path) %>">
+  <li class="<%= 'selected' unless current_page?(requests_path) || @category %>">
     <%= link_to _('Search requests'), request_list_path %>
   </li>
-  <li class="<%= 'selected' if current_page?(requests_path) %>">
+  <li class="<%= 'selected' if current_page?(requests_path) || @category %>">
     <%= link_to _('Browse by category'), requests_path %>
   </li>
   <li>


### PR DESCRIPTION
This moves the arrow on the tab bar, which was annoying me.

## Relevant issue(s)
fixes #8431 
## What does this do?
Moves the arrow
## Why was this needed?
It makes more sense to point to the browse page
## Implementation notes
n/a
## Screenshots
<img width="1356" alt="Screenshot 2024-10-23 at 13 25 57" src="https://github.com/user-attachments/assets/84e03973-1601-4510-91dc-97a80326812c">

## Notes to reviewer
Hope this is ok! 
<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
