### PR TITLE
Drop azure-storage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -169,7 +169,6 @@ gem 'alaveteli_features', path: 'gems/alaveteli_features'
 
 # Storage backends
 gem 'aws-sdk-s3', require: false
-gem 'azure-storage', require: false
 gem 'google-cloud-storage', '~> 1.47', require: false
 
 # Storage content analyzers

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,15 +148,6 @@ GEM
       aws-sigv4 (~> 1.5)
     aws-sigv4 (1.10.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    azure-core (0.1.15)
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.10)
-      nokogiri (~> 1.6)
-    azure-storage (0.15.0.preview)
-      azure-core (~> 0.1)
-      faraday (~> 0.9)
-      faraday_middleware (~> 0.10)
-      nokogiri (~> 1.6, >= 1.6.8)
     base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.8)
@@ -214,8 +205,6 @@ GEM
       railties (>= 3.1.0)
     faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.14.0)
-      faraday (>= 0.7.4, < 1.0)
     fast_gettext (3.1.0)
       prime
     fivemat (1.3.7)
@@ -592,7 +581,6 @@ DEPENDENCIES
   alaveteli_features!
   annotate (< 3.2.1)
   aws-sdk-s3
-  azure-storage
   bcrypt (~> 3.1.20)
   bootstrap-sass (~> 2.3.2.2)
   bullet (~> 7.2.0)

--- a/config/storage.yml-example
+++ b/config/storage.yml-example
@@ -8,12 +8,6 @@
 #   region: ''
 #   bucket: ''
 #
-# azure:
-#   service: AzureStorage
-#   storage_account_name: ''
-#   storage_access_key: ''
-#   container: ''
-#
 # google:
 #   service: GCS
 #   credentials:

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Drop support for Azure storage (Graeme Porteous)
 * Add basic Citation searching in admin UI (Gareth Rees)
 * Improve citations admin to allow title and description updates (Graeme
   Porteous)
@@ -108,6 +109,13 @@
   for Puma. You can generate this by running `rake config_files:convert_daemon
   DAEMON=puma.service`. For detailed instructions, refer to [the
   documentation](https://alaveteli.org/docs/installing/cron_and_daemons/#puma).
+
+* _Required:_ This release drops support for Azure storage. This is because the
+  Azure gem hasn't been updated in a long time and is preventing upgrades and
+  feature development. If you depend on this gem for storage please migrate to
+  a different storage backend before upgrading. We're not expecting other sites
+  to have used this gem but if you do please reach out if you need assistance
+  migrating.
 
 * _Optional:_ Bodies with not many requests will automatically get tagged
   `not_many_requests` as they are updated. If you want to automatically tag them


### PR DESCRIPTION
As far as I'm aware this gem isn't used by any Alaveteli site.

It hasn't been updated since 2017 and is preventing installation of
other gems due to restrictive dependencies versions requirements such as
`faraday ~> 0.9` which prevents installation of other gems.