### PR TITLE
[#4160] Update InfoRequest.find_existing

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -351,7 +351,7 @@ class InfoRequest < ApplicationRecord
   # TODO: this *should* also check outgoing message joined to is an initial
   # request (rather than follow up)
   def self.find_existing(title, public_body_id, body)
-    conditions = { title: title&.strip, public_body_id: public_body_id }
+    conditions = { title: title&.squish, public_body_id: public_body_id }
 
     InfoRequest.
       includes(:outgoing_messages).

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1511,6 +1511,22 @@ RSpec.describe InfoRequest do
                                        "Some information please")).
         to eq(info_request)
     end
+
+    it 'compress whitespace within the title when considering duplicates' do
+      info_request = FactoryBot.create(:info_request, title: 'Foo bar')
+      expect(InfoRequest.find_existing('Foo  bar',
+                                       info_request.public_body_id,
+                                       'Some information please')).
+        to eq(info_request)
+    end
+
+    it 'compress newlines within the title when considering duplicates' do
+      info_request = FactoryBot.create(:info_request, title: 'Foo bar')
+      expect(InfoRequest.find_existing("Foo\r\nbar",
+                                       info_request.public_body_id,
+                                       'Some information please')).
+        to eq(info_request)
+    end
   end
 
   describe '#find_existing_outgoing_message' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #4160

## What does this do?

Update InfoRequest.find_existing

## Why was this needed?

Squish extra whitespace and newlines within the title attribute so that it matches request titles stored in the database.

<hr>

[skip changelog]