### PR TITLE
[#2366] Remove broken Google Chart

### DIFF
--- a/app/views/request_game/play.html.erb
+++ b/app/views/request_game/play.html.erb
@@ -2,15 +2,12 @@
 
 <div id="game_sidebar" class="game_sidebar">
   <p style="text-align: center">
-    <%= image_tag "https://chart.googleapis.com/chart?chs=250x125&cht=gom&chd=t:#{@percentage}",
-          :size => "250x125",
-          :alt => "A chart showing #{@percentage}% of requests have been categorised",
-          :title => "#{@percentage}% of requests have been categorised" %>
-    <br><%= n_("{{number_of_requests}} request left to categorise / {{total_number_of_requests}} total",
-               "{{number_of_requests}} requests left to categorise / {{total_number_of_requests}} total",
-               @missing,
-               :number_of_requests => number_with_delimiter(@missing),
-               :total_number_of_requests => number_with_delimiter(@total)) %>
+    <br />
+    <%= n_('{{number_of_requests}} request left to categorise / {{total_number_of_requests}} total',
+           '{{number_of_requests}} requests left to categorise / {{total_number_of_requests}} total',
+           @missing,
+           number_of_requests: number_with_delimiter(@missing),
+           total_number_of_requests: number_with_delimiter(@total)) %>
   </p>
 
   <h2><%= _("Top recent players") %></h2>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Remove deprecated Google Chart from request game (Gareth Rees)
 * Migrated from Stripe Plans to Stripe Prices (Graeme Porteous)
 * Change notes so that records tagged with `name:value` will be associated with
   notes tagged as `name` (Graeme Porteous)


### PR DESCRIPTION
Has been deprecated since 2012 and they've actually removed it over the last year. Would be nice to replace with something else, but for now this just removes the broken element.

Fixes https://github.com/mysociety/alaveteli/issues/2366

![Screenshot 2024-11-22 at 12 35 21](https://github.com/user-attachments/assets/d29ad7e6-7117-4018-950d-51f0d2c24049)


