### PR TITLE
[#8204] Remove "Previously known as"

### DIFF
--- a/app/views/user/show/_show_profile.html.erb
+++ b/app/views/user/show/_show_profile.html.erb
@@ -47,13 +47,6 @@
       <p><%= link_to _('Change your name'), edit_users_name_path %></p>
     <% end %>
 
-    <% if @display_user.active? && @display_user.safe_previous_names.any? %>
-      <p>
-        <%= _('Previously known as:') %>
-        <%= @display_user.safe_previous_names.to_sentence %>
-      </p>
-    <% end %>
-
     <p class="subtitle">
       <%= _('Joined {{site_name}} in {{year}}',
             :site_name => site_name,

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Remove "Previously known as" from profile pages due to performance issues
+  (Gareth Rees)
 * Allow censor rules to ignore diacritics (Gareth Rees)
 * Allow censor rules to be case insensitive (Gareth Rees)
 * Add Content Security Policy with nonce-based script protection (Graeme


### PR DESCRIPTION
Causes slow profile page loads. More we can clean up around this, but this fixes the immediate user-facing issue.

Fixes https://github.com/mysociety/alaveteli/issues/8204

