### PR TITLE
Alert email subject in the receivers language

### DIFF
--- a/app/mailers/alaveteli_pro/embargo_mailer.rb
+++ b/app/mailers/alaveteli_pro/embargo_mailer.rb
@@ -68,27 +68,31 @@ module AlaveteliPro
     def expiring_alert(user, info_requests)
       @user = user
       @info_requests = info_requests
-      subject = n_(
-        "{{count}} request will be made public on {{site_name}} this week",
-        "{{count}} requests will be made public on {{site_name}} this week",
-        info_requests.count,
-        site_name: site_name.html_safe,
-        count: info_requests.count
+      mail_user(
+        @user,
+        subject: -> { n_(
+          "{{count}} request will be made public on {{site_name}} this week",
+          "{{count}} requests will be made public on {{site_name}} this week",
+          info_requests.count,
+          site_name: site_name.html_safe,
+          count: info_requests.count
+        ) }
       )
-      mail_user(@user, subject: subject)
     end
 
     def expired_alert(user, info_requests)
       @user = user
       @info_requests = info_requests
-      subject = n_(
-        "{{count}} request has been made public on {{site_name}}",
-        "{{count}} requests have been made public on {{site_name}}",
-        info_requests.count,
-        site_name: site_name.html_safe,
-        count: info_requests.count
+      mail_user(
+        @user,
+        subject: -> { n_(
+          "{{count}} request has been made public on {{site_name}}",
+          "{{count}} requests have been made public on {{site_name}}",
+          info_requests.count,
+          site_name: site_name.html_safe,
+          count: info_requests.count
+        ) }
       )
-      mail_user(@user, subject: subject)
     end
   end
 end

--- a/app/mailers/alaveteli_pro/subscription_mailer.rb
+++ b/app/mailers/alaveteli_pro/subscription_mailer.rb
@@ -3,13 +3,16 @@ class AlaveteliPro::SubscriptionMailer < ApplicationMailer
   def payment_failed(user)
     auto_generated_headers(user)
 
-    subject = _('Action Required: Payment failed on {{pro_site_name}}',
-                pro_site_name: pro_site_name)
-
     @user_name = user.name
     @pro_site_name = pro_site_name.html_safe
     @subscriptions_url = subscriptions_url
-    mail_user(user, subject: subject)
+    mail_user(
+      user,
+      subject: -> { _(
+        'Action Required: Payment failed on {{pro_site_name}}',
+        pro_site_name: pro_site_name
+      ) }
+    )
   end
 
   private

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -24,8 +24,10 @@ class ApplicationMailer < ActionMailer::Base
   # about the errors, and have to do error checking on return codes.
   self.raise_delivery_errors = true
 
+  # The subject: arg must be a proc, it is localized with the user's locale.
   def mail_user(user, subject:, **opts)
     if user.is_a?(User)
+      locale = user.locale
       opts[:to] = user.name_and_email
     else
       opts[:to] = user
@@ -36,7 +38,6 @@ class ApplicationMailer < ActionMailer::Base
       opts[:from] = MailHandler.address_from_name_and_email(
         opts[:from].name, blackhole_email
       )
-
     else
       set_reply_to_headers
       opts[:from] ||= blackhole_email
@@ -45,7 +46,7 @@ class ApplicationMailer < ActionMailer::Base
     set_auto_generated_headers
 
     default_opts = {
-      subject: subject
+      subject: AlaveteliLocalization.with_locale(locale) { subject.call }
     }
     default_opts.merge!(opts)
     mail(default_opts)

--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -34,7 +34,7 @@ class ContactMailer < ApplicationMailer
     mail_user(
       recipient_user,
       from: from_user,
-      subject: subject
+      subject: -> { subject }
     )
   end
 
@@ -53,7 +53,7 @@ class ContactMailer < ApplicationMailer
       to_address,
       from: from_address,
       bcc: AlaveteliConfiguration.contact_email,
-      subject: subject
+      subject: -> { subject }
     )
   end
 end

--- a/app/mailers/info_request_batch_mailer.rb
+++ b/app/mailers/info_request_batch_mailer.rb
@@ -12,8 +12,10 @@ class InfoRequestBatchMailer < ApplicationMailer
 
     mail_user(
       user,
-      subject: _("Your batch request \"{{title}}\" has been sent",
-                 title: info_request_batch.title.html_safe)
+      subject: -> { _(
+        "Your batch request \"{{title}}\" has been sent",
+        title: info_request_batch.title.html_safe
+      ) }
     )
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -84,8 +84,10 @@ class NotificationMailer < ApplicationMailer
 
     mail_user(
       user,
-      subject: _("Your daily request summary from {{pro_site_name}}",
-                 pro_site_name: pro_site_name)
+      subject: -> {
+        _("Your daily request summary from {{pro_site_name}}",
+          pro_site_name: pro_site_name)
+      }
     )
   end
 
@@ -99,11 +101,12 @@ class NotificationMailer < ApplicationMailer
     @info_request = notification.info_request_event.info_request
     @incoming_message = notification.info_request_event.incoming_message
 
-    subject = _("New response to your FOI request - {{request_title}}",
-                request_title: @info_request.title.html_safe)
     mail_user(
       @info_request.user,
-      subject: subject,
+      subject: -> {
+        _("New response to your FOI request - {{request_title}}",
+          request_title: @info_request.title.html_safe)
+      },
       template_name: 'response_notification'
     )
   end
@@ -111,16 +114,14 @@ class NotificationMailer < ApplicationMailer
   def embargo_expiring_notification(notification)
     @info_request = notification.info_request_event.info_request
 
-    subject = _(
-      "Your FOI request - {{request_title}} will be made public on " \
-      "{{site_name}} this week",
-      request_title: @info_request.title.html_safe,
-      site_name: site_name.html_safe
-    )
-
     mail_user(
       @info_request.user,
-      subject: subject,
+      subject: -> { _(
+        "Your FOI request - {{request_title}} will be made public on " \
+        "{{site_name}} this week",
+        request_title: @info_request.title.html_safe,
+        site_name: site_name.html_safe
+      ) },
       template_name: 'embargo_expiring_notification'
     )
   end
@@ -128,16 +129,14 @@ class NotificationMailer < ApplicationMailer
   def expire_embargo_notification(notification)
     @info_request = notification.info_request_event.info_request
 
-    subject = _(
-      "Your FOI request - {{request_title}} has been made public on " \
-      "{{site_name}}",
-      request_title: @info_request.title.html_safe,
-      site_name: site_name.html_safe
-    )
-
     mail_user(
       @info_request.user,
-      subject: subject,
+      subject: -> { _(
+        "Your FOI request - {{request_title}} has been made public on " \
+        "{{site_name}}",
+        request_title: @info_request.title.html_safe,
+        site_name: site_name.html_safe
+      ) },
       template_name: 'expire_embargo_notification'
     )
   end
@@ -146,12 +145,12 @@ class NotificationMailer < ApplicationMailer
     @info_request = notification.info_request_event.info_request
     @url = signin_url(r: respond_to_last_path(@info_request))
 
-    subject = _("Delayed response to your FOI request - {{request_title}}",
-                request_title: @info_request.title.html_safe)
-
     mail_user(
       @info_request.user,
-      subject: subject,
+      subject: -> { _(
+        "Delayed response to your FOI request - {{request_title}}",
+        request_title: @info_request.title.html_safe
+      ) },
       template_name: 'overdue_notification'
     )
   end
@@ -160,13 +159,13 @@ class NotificationMailer < ApplicationMailer
     @info_request = notification.info_request_event.info_request
     @url = signin_url(r: respond_to_last_path(@info_request))
 
-    subject = _("You're long overdue a response to your FOI request " \
-                "- {{request_title}}",
-                request_title: @info_request.title.html_safe)
-
     mail_user(
       @info_request.user,
-      subject: subject,
+      subject: -> { _(
+        "You're long overdue a response to your FOI request " \
+        "- {{request_title}}",
+        request_title: @info_request.title.html_safe
+      ) },
       template_name: 'very_overdue_notification'
     )
   end

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -90,8 +90,10 @@ class RequestMailer < ApplicationMailer
 
     mail_user(
       info_request.user,
-      subject: _("New response to your FOI request - {{request_title}}",
-                 request_title: info_request.title.html_safe),
+      subject: -> {
+        _("New response to your FOI request - {{request_title}}",
+          request_title: info_request.title.html_safe)
+      },
       charset: "UTF-8"
     )
   end
@@ -103,8 +105,10 @@ class RequestMailer < ApplicationMailer
 
     mail_user(
       user,
-      subject: _("Delayed response to your FOI request - {{request_title}}",
-                 request_title: info_request.title.html_safe)
+      subject: -> { _(
+        "Delayed response to your FOI request - {{request_title}}",
+        request_title: info_request.title.html_safe
+      ) }
     )
   end
 
@@ -115,9 +119,11 @@ class RequestMailer < ApplicationMailer
 
     mail_user(
       user,
-      subject: _("You're long overdue a response to your FOI request - " \
-                 "{{request_title}}",
-                 request_title: info_request.title.html_safe)
+      subject: -> { _(
+        "You're long overdue a response to your FOI request - " \
+        "{{request_title}}",
+        request_title: info_request.title.html_safe
+      ) }
     )
   end
 
@@ -133,8 +139,10 @@ class RequestMailer < ApplicationMailer
 
     mail_user(
       info_request.user,
-      subject: _("Please update the status of your request - {{request_title}}",
-                 request_title: info_request.title.html_safe)
+      subject: -> { _(
+        "Please update the status of your request - {{request_title}}",
+        request_title: info_request.title.html_safe
+      ) }
     )
   end
 
@@ -145,7 +153,7 @@ class RequestMailer < ApplicationMailer
 
     mail_user(
       info_request.user,
-      subject: _("Someone has updated the status of your request")
+      subject: -> { _("Someone has updated the status of your request") }
     )
   end
 
@@ -162,8 +170,10 @@ class RequestMailer < ApplicationMailer
 
     mail_user(
       info_request.user,
-      subject: _("Clarify your FOI request - {{request_title}}",
-                 request_title: info_request.title.html_safe)
+      subject: -> { _(
+        "Clarify your FOI request - {{request_title}}",
+        request_title: info_request.title.html_safe
+      ) }
     )
   end
 
@@ -175,8 +185,10 @@ class RequestMailer < ApplicationMailer
 
     mail_user(
       info_request.user,
-      subject: _("Somebody added a note to your FOI request - {{request_title}}",
-                 request_title: info_request.title.html_safe)
+      subject: -> { _(
+        "Somebody added a note to your FOI request - {{request_title}}",
+        request_title: info_request.title.html_safe
+      ) }
     )
   end
 
@@ -189,8 +201,10 @@ class RequestMailer < ApplicationMailer
 
     mail_user(
       info_request.user,
-      subject: _("Some notes have been added to your FOI request - {{request_title}}",
-                 request_title: info_request.title.html_safe)
+      subject: -> { _(
+        "Some notes have been added to your FOI request - {{request_title}}",
+        request_title: info_request.title.html_safe
+      ) }
     )
   end
 

--- a/app/mailers/survey_mailer.rb
+++ b/app/mailers/survey_mailer.rb
@@ -24,7 +24,9 @@ class SurveyMailer < ApplicationMailer
 
     mail_user(
       @user,
-      subject: _('A survey about your recent Freedom of Information request')
+      subject: -> { _(
+        'A survey about your recent Freedom of Information request'
+      ) }
     )
   end
 

--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -31,8 +31,10 @@ class TrackMailer < ApplicationMailer
 
     mail_user(
       user,
-      subject: _("Your {{site_name}} email alert",
-                 site_name: site_name.html_safe)
+      subject: -> { _(
+        "Your {{site_name}} email alert",
+        site_name: site_name.html_safe
+      ) }
     )
   end
 

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,7 +10,7 @@ class UserMailer < ApplicationMailer
     @name = user.name
     @url = url
 
-    mail_user(user, subject: reasons[:email_subject])
+    mail_user(user, subject: -> { reasons[:email_subject] })
   end
 
   def already_registered(user, reasons, url)
@@ -18,7 +18,7 @@ class UserMailer < ApplicationMailer
     @name = user.name
     @url = url
 
-    mail_user(user, subject: reasons[:email_subject])
+    mail_user(user, subject: -> { reasons[:email_subject] })
   end
 
   def changeemail_confirm(user, new_email, url)
@@ -27,11 +27,13 @@ class UserMailer < ApplicationMailer
     @old_email = user.email
     @new_email = new_email
 
-    mail_user(
-      new_email,
-      subject: _("Confirm your new email address on {{site_name}}",
-                 site_name: site_name)
+    # Cannot send the user to mail_user - that would send to old_email.
+    # No problem if the current locale is the user's.
+    subject = _(
+      "Confirm your new email address on {{site_name}}",
+      site_name: site_name
     )
+    mail_user(new_email, subject: -> { subject })
   end
 
   def changeemail_already_used(old_email, new_email)
@@ -39,10 +41,12 @@ class UserMailer < ApplicationMailer
     @new_email = new_email
     user = User.find_by_email(@old_email)
 
-    mail_user(
-      new_email,
-      subject: _("Unable to change email address on {{site_name}}",
-                 site_name: site_name)
+    # Cannot send the user to mail_user - that would send to old_email.
+    # No problem if the current locale is the user's.
+    subject = _(
+      "Unable to change email address on {{site_name}}",
+      site_name: site_name
     )
+    mail_user(new_email, subject: -> { subject })
   end
 end

--- a/spec/fixtures/locale/es/app.po
+++ b/spec/fixtures/locale/es/app.po
@@ -931,8 +931,8 @@ msgid "Dear {{public_body_name}},"
 msgstr "Estimado {{public_body_name}},"
 
 #: app/models/request_mailer.rb:87
-msgid "Delayed response to your FOI request - "
-msgstr "Respuesta retrasada a tu solicitud de acceso a información - "
+msgid "Delayed response to your FOI request - {{request_title}}"
+msgstr "Respuesta retrasada a tu solicitud de acceso a información - {{request_title}}"
 
 #: app/models/info_request.rb:783
 msgid "Delayed."
@@ -1772,9 +1772,9 @@ msgstr "Nueva contraseña:"
 msgid "New password: (again)"
 msgstr "Nueva contraseña: (otra vez)"
 
-#: app/models/request_mailer.rb:68
-msgid "New response to your FOI request - "
-msgstr "Nueva respuesta a tu solicitud de información - "
+#: app/mailers/request_mailer.rb:92
+msgid "New response to your FOI request - {{request_title}}"
+msgstr "Nueva respuesta a tu solicitud de información - {{request_title}}"
 
 #: app/views/request/show_response.rhtml:60
 msgid "New response to your request"
@@ -2601,9 +2601,9 @@ msgstr "Solicitudes similares"
 msgid "Simple search"
 msgstr "Búsqueda básica"
 
-#: app/models/request_mailer.rb:178
-msgid "Some notes have been added to your FOI request - "
-msgstr "Nuevos comentarios en tu solicitud de acceso a información - "
+#: app/mailers/request_mailer.rb:205
+msgid "Some notes have been added to your FOI request - {{request_title}}"
+msgstr "Nuevos comentarios en tu solicitud de acceso a información - {{request_title}}"
 
 #: app/views/general/_advanced_search_tips.rhtml:29
 msgid "Some of the information requested has been received"
@@ -2617,9 +2617,9 @@ msgid ""
 "information has been provided. Everyone'll be exceedingly grateful."
 msgstr "Algunas personas que hicieron solicitudes no nos han hecho saber si tuvieron\néxito o no. Necesitamos <strong>tu</strong> ayuda &ndash;\nelije una de las solicitudes, léela, y háznos saber si se ha obtenido o no\nla información. Todos te estaremos agradecidos."
 
-#: app/models/request_mailer.rb:169
-msgid "Somebody added a note to your FOI request - "
-msgstr "Nuevo comentario en tu solicitud de acceso a información - "
+#: app/models/request_mailer.rb:189
+msgid "Somebody added a note to your FOI request - {{request_title}}"
+msgstr "Nuevo comentario en tu solicitud de acceso a información - {{request_title}}"
 
 #: app/views/user_mailer/changeemail_already_used.rhtml:1
 msgid ""
@@ -3883,8 +3883,8 @@ msgid ""
 msgstr "Sólo recibirás una respuesta a tu solicitud si continúas\ncon la aclaración."
 
 #: app/models/request_mailer.rb:106
-msgid "You're long overdue a response to your FOI request - "
-msgstr "La respuesta a tu solicitud de información está muy retrasada - "
+msgid "You're long overdue a response to your FOI request - {{request_title}}"
+msgstr "La respuesta a tu solicitud de información está muy retrasada - {{request_title}}"
 
 #: app/controllers/user_controller.rb:476
 msgid "You've now cleared your profile photo"
@@ -4519,6 +4519,44 @@ msgstr "{{user}} (<a href=\"{{user_admin_url}}\">admin</a>) hizo esta solicitud 
 #: app/views/request/show.rhtml:44
 msgid "{{user}} made this {{law_used_full}} request"
 msgstr "{{user}} hizo esta solicitud de {{law_used_full}}"
+
+#: app/mailers/notification_mailer.rb:88
+msgid "Your daily request summary from {{pro_site_name}}"
+msgstr "*** Spanish missing *** {{pro_site_name}}"
+
+msgid "Your FOI request - {{request_title}} will be made public on {{site_name}} this week"
+msgstr "*** Spanish missing *** {{request_title}} *** {{site_name}}"
+
+msgid "Your FOI request - {{request_title}} has been made public on {{site_name}}"
+msgstr "*** Spanish missing *** {{request_title}} *** {{site_name}}"
+
+msgid "{{count}} request will be made public on {{site_name}} this week"
+msgid_plural "{{count}} requests will be made public on {{site_name}} this week"
+msgstr[0] "*** Spanish missing *** {{count}} *** {{site_name}}"
+msgstr[1] "*** Spanish missings *** {{count}} *** {{site_name}}"
+
+msgid "{{count}} request has been made public on {{site_name}}"
+msgid_plural "{{count}} requests have been made public on {{site_name}}"
+msgstr[0] "*** Spanish missing *** {{count}} *** {{site_name}}"
+msgstr[1] "*** Spanish missings *** {{count}} *** {{site_name}}"
+
+msgid "Action Required: Payment failed on {{pro_site_name}}"
+msgstr "*** Spanish missing *** {{pro_site_name}}"
+
+msgid "Your batch request \"{{title}}\" has been sent"
+msgstr "Tu solicitud en lote \"{{title}}\" ha sido enviada"
+
+msgid "Someone has updated the status of your request"
+msgstr "Alguien ha actualizado el estado de tu solicitud"
+
+msgid "Clarify your FOI request - {{request_title}}"
+msgstr "Clarifica tu solicitud de información - {{request_title}}"
+
+msgid "A survey about your recent Freedom of Information request"
+msgstr "*** Spanish missing ***"
+
+msgid "Please update the status of your request - {{request_title}}",
+msgstr "*** Spanish missing *** {{request_title}}"
 
 msgid "sent"
 msgstr "expedido"

--- a/spec/mailers/alaveteli_pro/embargo_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/embargo_mailer_spec.rb
@@ -121,6 +121,21 @@ RSpec.describe AlaveteliPro::EmbargoMailer do
         expect(@message.subject).to eq expected_subject
       end
 
+      context "when the user does not use default locale" do
+        before do
+          pro_user.locale = 'es'
+          @message = AlaveteliPro::EmbargoMailer.
+            expiring_alert(pro_user, [expiring_1]).
+            message
+        end
+
+        it "translates the subject" do
+          expect(@message.subject). to eq(
+            "*** Spanish missing *** 1 *** Alaveteli"
+          )
+        end
+      end
+
       it "sends the email to the user" do
         expect(@message.to).to eq [pro_user.email]
       end
@@ -140,6 +155,21 @@ RSpec.describe AlaveteliPro::EmbargoMailer do
       it 'sets the subject correctly' do
         expected_subject = '2 requests will be made public on Alaveteli this week'
         expect(@message.subject).to eq expected_subject
+      end
+
+      context "when the user does not use default locale" do
+        before do
+          pro_user.locale = 'es'
+          @message = AlaveteliPro::EmbargoMailer.
+            expiring_alert(pro_user, [expiring_1, expiring_2]).
+            message
+        end
+
+        it "translates the subject" do
+          expect(@message.subject). to eq(
+            "*** Spanish missings *** 2 *** Alaveteli"
+          )
+        end
       end
 
       it "sends the email to the user" do
@@ -245,6 +275,21 @@ RSpec.describe AlaveteliPro::EmbargoMailer do
         expect(@message.subject).to eq expected
       end
 
+      context "when the user does not use default locale" do
+        before do
+          pro_user.locale = 'es'
+          @message = AlaveteliPro::EmbargoMailer.
+            expired_alert(pro_user, [expired_1]).
+            message
+        end
+
+        it "translates the subject" do
+          expect(@message.subject). to eq(
+            "*** Spanish missing *** 1 *** Alaveteli"
+          )
+        end
+      end
+
       it "sends the email to the user" do
         expect(@message.to).to eq [pro_user.email]
       end
@@ -264,6 +309,21 @@ RSpec.describe AlaveteliPro::EmbargoMailer do
       it 'sets the subject correctly' do
         expected = '2 requests have been made public on Alaveteli'
         expect(@message.subject).to eq expected
+      end
+
+      context "when the user does not use default locale" do
+        before do
+          pro_user.locale = 'es'
+          @message = AlaveteliPro::EmbargoMailer.
+            expired_alert(pro_user, [expired_1, expired_2]).
+            message
+        end
+
+        it "translates the subject" do
+          expect(@message.subject). to eq(
+            "*** Spanish missings *** 2 *** Alaveteli"
+          )
+        end
       end
 
       it "sends the email to the user" do

--- a/spec/mailers/alaveteli_pro/subscription_mailer_spec.rb
+++ b/spec/mailers/alaveteli_pro/subscription_mailer_spec.rb
@@ -31,5 +31,16 @@ RSpec.describe AlaveteliPro::SubscriptionMailer, feature: [:alaveteli_pro] do
         expect(subject.body.to_s).not_to match(/&amp;laveteli Pro/)
       end
     end
+
+    context "when the user does not use default locale" do
+      before do
+        user.locale = 'es'
+      end
+
+      it "translates the subject" do
+        expect(subject.subject).
+          to eq "*** Spanish missing *** Alaveteli Professional"
+      end
+    end
   end
 end

--- a/spec/mailers/info_request_batch_mailer_spec.rb
+++ b/spec/mailers/info_request_batch_mailer_spec.rb
@@ -23,6 +23,22 @@ RSpec.describe InfoRequestBatchMailer do
         to eq('Your batch request "Apostrophe\'s" has been sent')
     end
 
+    context "when the user does not use default locale" do
+      before do
+        @user.locale = 'es'
+        @mail = InfoRequestBatchMailer.batch_sent(
+          @info_request_batch,
+          @unrequestable,
+          @user
+        )
+      end
+
+      it "translates the subject" do
+        expect(@mail.subject).
+          to eq "Tu solicitud en lote \"Example title\" ha sido enviada"
+      end
+    end
+
     it 'renders the receiver email' do
       expect(@mail.to).to eq([@user.email])
     end

--- a/spec/mailers/notification_mailer_spec.rb
+++ b/spec/mailers/notification_mailer_spec.rb
@@ -383,6 +383,18 @@ RSpec.describe NotificationMailer do
         to eq("Your daily request summary from Alaveteli Professional")
     end
 
+    context "when the user does not use default locale" do
+      before do
+        user.locale = 'es'
+      end
+
+      it "translates the subject" do
+        mail = NotificationMailer.daily_summary(user, all_notifications)
+        expect(mail.subject).
+          to eq("*** Spanish missing *** Alaveteli Professional")
+      end
+    end
+
     it "matches the expected message" do
       mail = NotificationMailer.daily_summary(user, all_notifications)
       expected_message = load_file_fixture(
@@ -452,6 +464,20 @@ RSpec.describe NotificationMailer do
         mail = NotificationMailer.response_notification(notification)
         expected = "New response to your FOI request - Here's a request"
         expect(mail.subject).to eq expected
+      end
+    end
+
+    context "when the user does not use default locale" do
+      before do
+        info_request.title = "A request"
+        info_request.user.locale = 'es'
+      end
+
+      it "translates the subject" do
+        mail = NotificationMailer.response_notification(notification)
+        expect(mail.subject).to eq(
+          "Nueva respuesta a tu solicitud de información - A request"
+        )
       end
     end
 
@@ -542,6 +568,19 @@ RSpec.describe NotificationMailer do
       end
     end
 
+    context "when the user does not use default locale" do
+      before do
+        info_request.title = "A request"
+        info_request.user.locale = 'es'
+      end
+
+      it "translates the subject" do
+        mail = NotificationMailer.embargo_expiring_notification(notification)
+        expect(mail.subject).
+          to eq("*** Spanish missing *** A request *** Alaveteli")
+      end
+    end
+
     it "sends the message to the right user" do
       mail = NotificationMailer.embargo_expiring_notification(notification)
       expect(mail.to).to eq [info_request.user.email]
@@ -612,6 +651,19 @@ RSpec.describe NotificationMailer do
       end
     end
 
+    context "when the user does not use default locale" do
+      before do
+        info_request.title = "A request"
+        info_request.user.locale = 'es'
+      end
+
+      it "translates the subject" do
+        mail = NotificationMailer.expire_embargo_notification(notification)
+        expect(mail.subject).
+          to eq("*** Spanish missing *** A request *** Alaveteli")
+      end
+    end
+
     it 'sends the message to the right user' do
       mail = NotificationMailer.expire_embargo_notification(notification)
       expect(mail.to).to eq [info_request.user.email]
@@ -675,6 +727,21 @@ RSpec.describe NotificationMailer do
         mail = NotificationMailer.overdue_notification(notification)
         expected = "Delayed response to your FOI request - Here's a request"
         expect(mail.subject).to eq expected
+      end
+    end
+
+    context "when the user does not use default locale" do
+      before do
+        info_request.title = "A request"
+        info_request.user.locale = 'es'
+      end
+
+      it "translates the subject" do
+        mail = NotificationMailer.overdue_notification(notification)
+        expect(mail.subject). to eq(
+          "Respuesta retrasada a tu solicitud de acceso a información - "\
+          "A request"
+        )
       end
     end
 
@@ -743,6 +810,21 @@ RSpec.describe NotificationMailer do
         expected = "You're long overdue a response to your FOI request " \
                    "- Here's a request"
         expect(mail.subject).to eq expected
+      end
+    end
+
+    context "when the user does not use default locale" do
+      before do
+        info_request.title = "A request"
+        info_request.user.locale = 'es'
+      end
+
+      it "translates the subject" do
+        mail = NotificationMailer.very_overdue_notification(notification)
+        expect(mail.subject). to eq(
+          "La respuesta a tu solicitud de información está muy retrasada - "\
+          "A request"
+        )
       end
     end
 

--- a/spec/mailers/survey_mailer_spec.rb
+++ b/spec/mailers/survey_mailer_spec.rb
@@ -26,11 +26,36 @@ RSpec.describe SurveyMailer do
         expect(ActionMailer::Base.deliveries.size).to eq(1)
       end
 
+      it "sends a mail with correct subject" do
+        info_request = get_surveyable_request
+        SurveyMailer.alert_survey
+        mail = ActionMailer::Base.deliveries.first
+        expect(mail.subject). to eq(
+          "A survey about your recent Freedom of Information request"
+        )
+      end
+
       it 'records the sending of the alert' do
         info_request = get_surveyable_request
         SurveyMailer.alert_survey
         expect(info_request.user.user_info_request_sent_alerts.size).
           to eq(1)
+      end
+
+      context "when the user does not use default locale" do
+        before do
+          @info_request = get_surveyable_request(
+            FactoryBot.create(:user, locale: 'es')
+          )
+          SurveyMailer.alert_survey
+        end
+
+        it "translates the subject" do
+          mail = ActionMailer::Base.deliveries.first
+          expect(mail.subject). to eq(
+            "*** Spanish missing ***"
+          )
+        end
       end
     end
 

--- a/spec/mailers/track_mailer_spec.rb
+++ b/spec/mailers/track_mailer_spec.rb
@@ -189,7 +189,8 @@ RSpec.describe TrackMailer do
       ActionMailer::Base.deliveries = []
       @user = mock_model(User,
                          name_and_email: MailHandler.address_from_name_and_email('Tippy Test', 'tippy@localhost'),
-                         url_name: 'tippy_test'
+                         url_name: 'tippy_test',
+                         locale: 'es'
                          )
       TrackMailer.event_digest(@user, []).deliver_now # no items in it email for minimal test
     end
@@ -216,8 +217,14 @@ RSpec.describe TrackMailer do
       deliveries = ActionMailer::Base.deliveries
       expect(deliveries.size).to eq(1)
       mail = deliveries[0]
+      expect(mail.subject).to eq "Tu alerta en L'information"
+    end
 
-      expect(mail.subject).to eq "Your L'information email alert"
+    it "translates the subject for a user with non-default locale" do
+      # Yes, this is indeed just the same test as above. We simply give the
+      # user a non-default locale in the "before". Use let bindings instead?
+      expect(ActionMailer::Base.deliveries[0].subject).
+        to eq "Tu alerta en L'information"
     end
 
     it "does not alert about embargoed requests" do


### PR DESCRIPTION
Issue #5164 PR candidate

## Relevant issue(s)

Fixes #5164.

## What does this do?

Automatic email alerts are sent with the subject localized with the receiving user's locale.

## Why was this needed?

Needed to ensure that the receiving user understands the subject line.

## Implementation notes

User mails are sent with `ApplicationMailer#mail_user`. The change consists of requiring the `subject:` arg to `mail_user` to be a `proc`, and running the `proc` using the locale of the `user` arg.

All other changes are straightforward rewrites of the 26 other methods that call `mail_user`, and corresponding tests.

## Notes to reviewer

Below is a list of the affected methods, where the corresponding tests are, and why some tests are not changed.
```
app/mailers/alaveteli_pro/embargo_mailer.rb
  expiring_alert(user, info_requests)
    test: spec/mailers/alaveteli_pro/embargo_mailer_spec.rb:124/160
  expired_alert(user, info_requests)
    test: spec/mailers/alaveteli_pro/embargo_mailer_spec.rb:278/314
app/mailers/alaveteli_pro/subscription_mailer.rb
  payment_failed(user)
    test: spec/mailers/alaveteli_pro/subscription_mailer_spec.rb:35
app/mailers/contact_mailer.rb
  user_message(from_user, recipient_user, from_user_url, subject, message)
    No new functionality to test
  from_admin_message(recipient_name, recipient_email, subject, message)
    No new functionality to test
app/mailers/info_request_batch_mailer.rb
  batch_sent(info_request_batch, unrequestable, user)
    test: spec/mailers/info_request_batch_mailer_spec.rb:26
app/mailers/notification_mailer.rb
  daily_summary(user, notifications)
    test: spec/mailers/notification_mailer_spec.rb:386
  response_notification(notification)
    test: spec/mailers/notification_mailer_spec.rb:470
  embargo_expiring_notification(notification)
    test: spec/mailers/notification_mailer_spec.rb:571
  expire_embargo_notification(notification)
    test: spec/mailers/notification_mailer_spec.rb:654
  overdue_notification(notification)
    test: spec/mailers/notification_mailer_spec.rb:733
  very_overdue_notification(notification)
    test: spec/mailers/notification_mailer_spec.rb:816
app/mailers/request_mailer.rb
  new_response(info_request, incoming_message)
    test: spec/mailers/request_mailer_spec.rb:618
  overdue_alert(info_request, user)
    test: spec/mailers/request_mailer_spec.rb:792
  very_overdue_alert(info_request, user)
    test: spec/mailers/request_mailer_spec.rb:921
  new_response_reminder_alert(info_request, incoming_message)
    test: spec/mailers/request_mailer_spec.rb:672/691
  old_unclassified_updated(info_request)
    test: spec/mailers/request_mailer_spec.rb:545
  not_clarified_alert(info_request, incoming_message)
    test: spec/mailers/request_mailer_spec.rb:995
  comment_on_alert(info_request, comment)
    test: spec/mailers/request_mailer_spec.rb:1019
  comment_on_alert_plural(info_request, count, earliest_unalerted_comment)
    test: spec/mailers/request_mailer_spec.rb:1044
app/mailers/survey_mailer.rb
  survey_alert(info_request)
    test: spec/mailers/survey_mailer_spec.rb:29/45
app/mailers/track_mailer.rb
  event_digest(user, email_about_things)
    test: spec/mailers/track_mailer_spec.rb:193/220/223
app/mailers/user_mailer.rb
  confirm_login(user, reasons, url)
    No new functionality to test
  already_registered(user, reasons, url)
    No new functionality to test
  changeemail_confirm(user, new_email, url)
    No new functionality to test
  changeemail_already_used(old_email, new_email)
    No new functionality to test
```
