### PR TITLE
Stripe Prices fixes

### DIFF
--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -70,7 +70,7 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
 
   def invoice_payment_failed
     account = pro_account_from_stripe_event(@stripe_event)
-    return unless account
+    return unless account&.subscription?
 
     AlaveteliPro::SubscriptionMailer.payment_failed(account.user).deliver_now
   end

--- a/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
+++ b/app/controllers/alaveteli_pro/stripe_webhooks_controller.rb
@@ -53,26 +53,26 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   def invoice_payment_succeeded
     charge_id = @stripe_event.data.object.charge
 
-    if charge_id
-      charge = Stripe::Charge.retrieve(charge_id)
+    return unless charge_id
 
-      subscription_id = @stripe_event.data.object.subscription
-      subscription = Stripe::Subscription.retrieve(
-        id: subscription_id, expand: ['plan.product']
-      )
-      plan_name = subscription.plan.product.name
+    charge = Stripe::Charge.retrieve(charge_id)
 
-      Stripe::Charge.update(
-        charge.id, description: "#{pro_site_name}: #{plan_name}"
-      )
-    end
+    subscription_id = @stripe_event.data.object.subscription
+    subscription = Stripe::Subscription.retrieve(
+      id: subscription_id, expand: ['plan.product']
+    )
+    plan_name = subscription.plan.product.name
+
+    Stripe::Charge.update(
+      charge.id, description: "#{pro_site_name}: #{plan_name}"
+    )
   end
 
   def invoice_payment_failed
     account = pro_account_from_stripe_event(@stripe_event)
-    if account
-      AlaveteliPro::SubscriptionMailer.payment_failed(account.user).deliver_now
-    end
+    return unless account
+
+    AlaveteliPro::SubscriptionMailer.payment_failed(account.user).deliver_now
   end
 
   def store_unhandled_webhook
@@ -96,10 +96,10 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   end
 
   def check_for_event_type
-    unless @stripe_event.respond_to?(:type)
-      msg = "undefined method `type' for #{ @stripe_event.inspect }"
-      raise MissingTypeStripeWebhookError, msg
-    end
+    return if @stripe_event.respond_to?(:type)
+
+    msg = "undefined method `type' for #{ @stripe_event.inspect }"
+    raise MissingTypeStripeWebhookError, msg
   end
 
   def notify_exception(error)
@@ -125,8 +125,8 @@ class AlaveteliPro::StripeWebhooksController < ApplicationController
   end
 
   def plan_matches_namespace?(plan_id)
-    (AlaveteliConfiguration.stripe_namespace == '' ||
-     plan_id =~ /^#{AlaveteliConfiguration.stripe_namespace}/)
+    AlaveteliConfiguration.stripe_namespace == '' ||
+      plan_id =~ /^#{AlaveteliConfiguration.stripe_namespace}/
   end
 
   def plan_ids(items)

--- a/app/models/alaveteli_pro/price.rb
+++ b/app/models/alaveteli_pro/price.rb
@@ -4,6 +4,8 @@
 class AlaveteliPro::Price < SimpleDelegator
   include Taxable
 
+  UnknownPrice = Class.new(StandardError)
+
   tax :unit_amount
 
   def self.list
@@ -12,15 +14,15 @@ class AlaveteliPro::Price < SimpleDelegator
     end
   end
 
-  def self.retrieve(id)
-    key = AlaveteliConfiguration.stripe_prices.key(id)
-    new(Stripe::Price.retrieve(key))
+  def self.retrieve(param)
+    id = AlaveteliConfiguration.stripe_prices.key(param)
+    new(Stripe::Price.retrieve(id))
   rescue Stripe::InvalidRequestError
     nil
   end
 
   def to_param
-    AlaveteliConfiguration.stripe_prices[id] || id
+    AlaveteliConfiguration.stripe_prices[id] || raise(UnknownPrice)
   end
 
   # product

--- a/app/models/alaveteli_pro/subscription.rb
+++ b/app/models/alaveteli_pro/subscription.rb
@@ -35,7 +35,7 @@ module AlaveteliPro
 
     def require_authorisation?
       invoice_open? && %w[
-        requires_source_action require_action
+        requires_source_action requires_action
       ].include?(payment_intent.status)
     end
 

--- a/app/models/alaveteli_pro/subscription.rb
+++ b/app/models/alaveteli_pro/subscription.rb
@@ -34,9 +34,7 @@ module AlaveteliPro
     end
 
     def require_authorisation?
-      invoice_open? && %w[
-        requires_source_action requires_action
-      ].include?(payment_intent.status)
+      invoice_open? && payment_intent.status == 'requires_action'
     end
 
     def update(attributes)

--- a/app/views/alaveteli_pro/plans/show.html.erb
+++ b/app/views/alaveteli_pro/plans/show.html.erb
@@ -65,7 +65,7 @@
         </div>
 
         <div class="settings__section">
-          <%= hidden_field_tag 'price_id', @price.id %>
+          <%= hidden_field_tag 'price_id', @price.to_param %>
           <%= submit_tag _('Subscribe'), id: 'js-stripe-submit', disabled: true, data: { disable_with: 'Processing...' } %>
           <%= link_to _('Cancel'), pro_plans_path, class: 'settings__cancel-button' %>
           <p id="card-errors"></p>

--- a/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/stripe_webhooks_controller_spec.rb
@@ -256,10 +256,10 @@ RSpec.describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro,
       end
 
       let!(:user) do
-        _user = FactoryBot.create(:pro_user)
-        _user.pro_account.stripe_customer_id = stripe_event.data.object.customer
-        _user.pro_account.save!
-        _user
+        user = FactoryBot.create(:pro_user)
+        user.pro_account.stripe_customer_id = stripe_event.data.object.customer
+        user.pro_account.save!
+        user
       end
 
       before do
@@ -324,10 +324,10 @@ RSpec.describe AlaveteliPro::StripeWebhooksController, feature: [:alaveteli_pro,
 
     describe 'a cancelled subscription is deleted at the end of the billing period' do
       let!(:user) do
-        _user = FactoryBot.create(:pro_user)
-        _user.pro_account.stripe_customer_id = stripe_event.data.object.customer
-        _user.pro_account.save!
-        _user
+        user = FactoryBot.create(:pro_user)
+        user.pro_account.stripe_customer_id = stripe_event.data.object.customer
+        user.pro_account.save!
+        user
       end
 
       it 'removes the pro role from the associated user' do

--- a/spec/models/alaveteli_pro/price_spec.rb
+++ b/spec/models/alaveteli_pro/price_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe AlaveteliPro::Price do
   end
 
   describe '.retrieve' do
-    it 'retrieves a price from Stripe' do
+    it 'retrieves a price for a given param from Stripe' do
       stripe_price = double('stripe_price')
       allow(Stripe::Price).to receive(:retrieve).with('pro').
         and_return(stripe_price)
@@ -43,6 +43,11 @@ RSpec.describe AlaveteliPro::Price do
       price = described_class.new(double('stripe_price', id: 'price_123'))
 
       expect(price.to_param).to eq('pro')
+    end
+
+    it 'raises UnknownPrice error if price is not defined' do
+      price = described_class.new(double('stripe_price', id: 'unknown'))
+      expect { price.to_param }.to raise_error(described_class::UnknownPrice)
     end
   end
 

--- a/spec/models/alaveteli_pro/subscription_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_spec.rb
@@ -111,9 +111,9 @@ RSpec.describe AlaveteliPro::Subscription do
         is_expected.to eq true
       end
 
-      it 'return true if payment intent status is require_action' do
+      it 'return true if payment intent status is requires_action' do
         allow(subscription).to receive(:payment_intent).and_return(
-          double('Stripe::PaymentIntent', status: 'require_action')
+          double('Stripe::PaymentIntent', status: 'requires_action')
         )
         is_expected.to eq true
       end

--- a/spec/models/alaveteli_pro/subscription_spec.rb
+++ b/spec/models/alaveteli_pro/subscription_spec.rb
@@ -104,13 +104,6 @@ RSpec.describe AlaveteliPro::Subscription do
         allow(subscription).to receive(:invoice_open?).and_return(true)
       end
 
-      it 'return true if payment intent status is requires_source_action' do
-        allow(subscription).to receive(:payment_intent).and_return(
-          double('Stripe::PaymentIntent', status: 'requires_source_action')
-        )
-        is_expected.to eq true
-      end
-
       it 'return true if payment intent status is requires_action' do
         allow(subscription).to receive(:payment_intent).and_return(
           double('Stripe::PaymentIntent', status: 'requires_action')

--- a/spec/views/alaveteli_pro/plans/index.html.erb_spec.rb
+++ b/spec/views/alaveteli_pro/plans/index.html.erb_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe 'alaveteli_pro/plans/index' do
   end
 
   before do
+    allow(AlaveteliConfiguration).to receive(:stripe_prices).
+        and_return('price_123' => 'pro')
     allow(AlaveteliConfiguration).to receive(:iso_currency_code).
         and_return('GBP')
     assign :prices, [price]


### PR DESCRIPTION
## What does this do?

Adds a couple of Stripe fixes for issues preventing signups.

- Change `Price.id` to `Price.to_param` so prices can be loaded
- Correct payment intent status (missing an `s`) should fix incomplete subscriptions
- Update payment failed email, don't send to users without current subscriptions - ie those who are attempting to sign up. 

## Why was this needed?

Getting payments working correctly.


<hr>

[skip changelog]