### PR TITLE
Add .well-known for FLOSS fund

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://alaveteli.org/funding.json


### PR DESCRIPTION
https://floss.fund/funding-manifest/

Not sure this one is strictly required but it's what others have done ([example](https://github.com/yiisoft/yii2/blob/master/.well-known/funding-manifest-urls))