### PR TITLE
Bump activejob-uniqueness from 0.2.5 to 0.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,7 @@ gem 'addressable', '~> 2.8.7'
 gem 'acts_as_versioned', git: 'https://github.com/mysociety/acts_as_versioned.git',
                          ref: '13e928b'
 gem 'active_model_otp'
-gem 'activejob-uniqueness', '~> 0.2.5'
+gem 'activejob-uniqueness', '~> 0.4.0'
 gem 'bcrypt', '~> 3.1.20'
 gem 'cancancan', '~> 3.6.1'
 gem 'charlock_holmes', '~> 0.7.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,9 +96,9 @@ GEM
     activejob (7.0.8.7)
       activesupport (= 7.0.8.7)
       globalid (>= 0.3.6)
-    activejob-uniqueness (0.2.5)
-      activejob (>= 4.2, < 7.1)
-      redlock (>= 1.2, < 2)
+    activejob-uniqueness (0.4.0)
+      activejob (>= 4.2, < 8.1)
+      redlock (>= 2.0, < 3)
     activemodel (7.0.8.7)
       activesupport (= 7.0.8.7)
     activerecord (7.0.8.7)
@@ -424,8 +424,10 @@ GEM
     recaptcha (5.18.0)
     redcarpet (3.6.0)
     redis (4.8.1)
-    redlock (1.3.2)
-      redis (>= 3.0.0, < 6.0)
+    redis-client (0.23.0)
+      connection_pool
+    redlock (2.0.6)
+      redis-client (>= 0.14.1, < 1.0.0)
     regexp_parser (2.10.0)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -582,7 +584,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_otp
-  activejob-uniqueness (~> 0.2.5)
+  activejob-uniqueness (~> 0.4.0)
   acts_as_versioned!
   addressable (~> 2.8.7)
   alaveteli_features!

--- a/config/initializers/active_job_uniqueness.rb
+++ b/config/initializers/active_job_uniqueness.rb
@@ -1,5 +1,5 @@
 require 'redis_connection'
 
 ActiveJob::Uniqueness.configure do |config|
-  config.redlock_servers = [RedisConnection.instance]
+  config.redlock_servers = [RedisConnection.client]
 end

--- a/lib/redis_connection.rb
+++ b/lib/redis_connection.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../config/load_env.rb', __dir__)
+require 'redis-client'
 
 ##
 # Module to parse Redis ENV variables into usable configuration for Sidekiq and
@@ -7,6 +8,14 @@ require File.expand_path('../config/load_env.rb', __dir__)
 module RedisConnection
   def self.instance
     Redis.new(configuration)
+  end
+
+  def self.client
+    if configuration.key?(:sentinels)
+      RedisClient.sentinel(**configuration).new_client
+    else
+      RedisClient.config(**configuration).new_client
+    end
   end
 
   def self.configuration


### PR DESCRIPTION
## Relevant issue(s)

Required for #8090

## What does this do?

Bump activejob-uniqueness from 0.2.5 to 0.4.0

## Why was this needed?

Need to upgrade this gem due to a dependency on ActiveJob which is preventing upgrade to Rails 7.1+

## Implementation notes

Dependabot attempted to upgrade this but I closed this PR with [this comment](https://github.com/mysociety/alaveteli/pull/8111#issuecomment-1914420012). This doesn't seem to be an issue anymore.

<hr>

[skip changelog]