### PR TITLE
Bump flipper-active_record from 0.28.3 to 1.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,8 +27,8 @@ PATH
   remote: gems/alaveteli_features
   specs:
     alaveteli_features (0.0.1)
-      flipper (~> 0.10)
-      flipper-active_record (~> 0.10)
+      flipper (~> 1.3.2)
+      flipper-active_record (~> 1.3.2)
       mime-types (< 4.0.0)
       rails (>= 7.0.4, < 8.1.0)
 
@@ -202,11 +202,11 @@ GEM
     fast_gettext (3.1.0)
       prime
     fivemat (1.3.7)
-    flipper (0.28.3)
+    flipper (1.3.2)
       concurrent-ruby (< 2)
-    flipper-active_record (0.28.3)
-      activerecord (>= 4.2, < 8)
-      flipper (~> 0.28.3)
+    flipper-active_record (1.3.2)
+      activerecord (>= 4.2, < 9)
+      flipper (~> 1.3.2)
     forwardable (1.3.3)
     friendly_id (5.5.1)
       activerecord (>= 4.0.0)

--- a/db/migrate/20250110145844_change_flipper_gates_value_to_text.rb
+++ b/db/migrate/20250110145844_change_flipper_gates_value_to_text.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ChangeFlipperGatesValueToText < ActiveRecord::Migration[7.0]
+  def up
+    # Ensure this incremental update migration is idempotent
+    return unless connection.column_exists? :flipper_gates, :value, :string
+
+    if index_exists? :flipper_gates, [:feature_key, :key, :value]
+      remove_index :flipper_gates, [:feature_key, :key, :value]
+    end
+    change_column :flipper_gates, :value, :text
+    add_index :flipper_gates, [:feature_key, :key, :value], unique: true, length: { value: 255 }
+  end
+
+  def down
+    change_column :flipper_gates, :value, :string
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -1,3 +1,11 @@
+# develop
+
+## Upgrade Notes
+
+* _Required:_ There are some database structure updates so remember to run:
+
+      bin/rails db:migrate
+
 # 0.45.0.0
 
 ## Highlighted Features

--- a/gems/alaveteli_features/alaveteli_features.gemspec
+++ b/gems/alaveteli_features/alaveteli_features.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", ">= 7.0.4", "< 8.1.0"
-  spec.add_dependency "flipper", "~> 0.10"
-  spec.add_dependency "flipper-active_record", "~> 0.10"
+  spec.add_dependency "flipper", "~> 1.3.2"
+  spec.add_dependency "flipper-active_record", "~> 1.3.2"
   # Mime types 3 needs Ruby 2.0.0 or greater, but we need to support 1.9.3 so
   # force a lower version
   spec.add_dependency "mime-types", "< 4.0.0"


### PR DESCRIPTION
Required for Rails 8 compatibility. Including database migration.

[skip changelog]