### PR TITLE
 Bump strip_attributes from 1.12.0 to 1.14.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,7 +125,7 @@ gem 'secure_headers', '~> 7.0.0'
 gem 'sidekiq', '~> 6.5.12'
 gem 'sidekiq-limit_fetch', '~> 4.4.1'
 gem 'statistics2', '~> 0.54'
-gem 'strip_attributes', git: 'https://github.com/mysociety/strip_attributes.git', branch: 'globalize3-rails7'
+gem 'strip_attributes', git: 'https://github.com/mysociety/strip_attributes.git', branch: 'globalize3-rails8'
 gem 'stripe', '~> 11.7.0'
 gem 'syck', '~> 1.4.1', require: false
 gem 'syslog_protocol', '~> 0.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,11 +17,11 @@ GIT
 
 GIT
   remote: https://github.com/mysociety/strip_attributes.git
-  revision: 842a889258a897692296dff8445bb9dc12e676f8
-  branch: globalize3-rails7
+  revision: 75f12bd5c68d4099142cb659a176748df0847488
+  branch: globalize3-rails8
   specs:
-    strip_attributes (1.12.0)
-      activemodel (>= 3.0, < 8.0)
+    strip_attributes (1.14.1)
+      activemodel (>= 3.0, < 9.0)
 
 PATH
   remote: gems/alaveteli_features


### PR DESCRIPTION
Required for Rails 8 compatibility.

[skip changelog]
