### PR TITLE
[#8532] Update crontab log level

### DIFF
--- a/config/crontab-example
+++ b/config/crontab-example
@@ -11,6 +11,7 @@ PATH=/home/<%= user %>/.gem/ruby/<%= ruby_version %>/bin:/usr/local/bin:/usr/bin
 <% end %>
 
 MAILTO=<%= mailto %>
+RAILS_LOG_LEVEL=warn
 
 # Every 5 minutes
 */5 * * * * <%= user %> <%= vhost_dir %>/<%= vcspath %>/commonlib/bin/run-with-lockfile.sh -n <%= vhost_dir %>/change-xapian-database.lock "<%= vhost_dir %>/<%= vcspath %>/script/update-xapian-index verbose=true" >> <%= vhost_dir %>/<%= vcspath %>/log/update-xapian-index.log || echo "stalled?"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -81,9 +81,9 @@ Rails.application.configure do
     Rails.root.join('spec', 'mailers', 'previews')
   ]
 
-  # Set LOG_LEVEL in the environment to a valid log level to temporarily run the
-  # application with a non-default setting.
-  config.log_level = ENV.fetch('LOG_LEVEL', :debug)
+  # Set RAILS_LOG_LEVEL in the environment to a valid log level to temporarily
+  # run the application with a non-default setting.
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', :debug)
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -8,9 +8,9 @@ Rails.application.configure do
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new
 
-  # Set LOG_LEVEL in the environment to a valid log level to temporarily run the
-  # application with a non-default setting.
-  config.log_level = ENV.fetch('LOG_LEVEL', :info)
+  # Set RAILS_LOG_LEVEL in the environment to a valid log level to temporarily
+  # run the application with a non-default setting.
+  config.log_level = ENV.fetch('RAILS_LOG_LEVEL', :info)
 
   # Full error reports are disabled and caching is turned on
   config.action_controller.consider_all_requests_local = false


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8532

## What does this do?

Update crontab log level from "info" to "warn".

## Why was this needed?

Crontab emails including "info" messages.

[skip changelog]
