### PR TITLE
Post rails 8.0 upgrade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -731,4 +731,4 @@ DEPENDENCIES
   zip_tricks (~> 5.6.0)
 
 BUNDLED WITH
-   2.4.19
+   2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,7 +454,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.2.1)
-    rdoc (6.10.0)
+    rdoc (6.11.0)
       psych (>= 4.0.0)
     recaptcha (5.18.0)
     redcarpet (3.6.0)

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -8,8 +8,6 @@
 #  user_id    :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  title      :string
-#  content    :text
 #
 
 class Announcement < ApplicationRecord

--- a/app/models/blog/post.rb
+++ b/app/models/blog/post.rb
@@ -3,13 +3,14 @@
 #
 # Table name: blog_posts
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
 #  title      :string
 #  url        :string
 #  data       :jsonb
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+
 class Blog::Post < ApplicationRecord
   include Taggable
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,12 +3,10 @@
 #
 # Table name: categories
 #
-#  id           :bigint           not null, primary key
+#  id           :integer          not null, primary key
 #  category_tag :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  title        :string
-#  description  :string
 #
 
 ##

--- a/app/models/category_relationship.rb
+++ b/app/models/category_relationship.rb
@@ -3,7 +3,7 @@
 #
 # Table name: category_relationships
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
 #  parent_id  :integer          not null
 #  child_id   :integer          not null
 #  position   :integer

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -3,10 +3,10 @@
 #
 # Table name: citations
 #
-#  id           :bigint           not null, primary key
-#  user_id      :bigint
+#  id           :integer          not null, primary key
+#  user_id      :integer
 #  citable_type :string
-#  citable_id   :bigint
+#  citable_id   :integer
 #  source_url   :string
 #  type         :string
 #  created_at   :datetime         not null

--- a/app/models/dataset/key_set.rb
+++ b/app/models/dataset/key_set.rb
@@ -3,9 +3,9 @@
 #
 # Table name: dataset_key_sets
 #
-#  id            :bigint           not null, primary key
+#  id            :integer          not null, primary key
 #  resource_type :string
-#  resource_id   :bigint
+#  resource_id   :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/app/models/dataset/value.rb
+++ b/app/models/dataset/value.rb
@@ -3,9 +3,9 @@
 #
 # Table name: dataset_values
 #
-#  id                   :bigint           not null, primary key
-#  dataset_value_set_id :bigint
-#  dataset_key_id       :bigint
+#  id                   :integer          not null, primary key
+#  dataset_value_set_id :integer
+#  dataset_key_id       :integer
 #  value                :string
 #  notes                :string
 #  created_at           :datetime         not null

--- a/app/models/dataset/value_set.rb
+++ b/app/models/dataset/value_set.rb
@@ -3,10 +3,10 @@
 #
 # Table name: dataset_value_sets
 #
-#  id                 :bigint           not null, primary key
+#  id                 :integer          not null, primary key
 #  resource_type      :string
-#  resource_id        :bigint
-#  dataset_key_set_id :bigint
+#  resource_id        :integer
+#  dataset_key_set_id :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/app/models/outgoing_message/snippet.rb
+++ b/app/models/outgoing_message/snippet.rb
@@ -3,11 +3,9 @@
 #
 # Table name: outgoing_message_snippets
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  name       :string
-#  body       :text
 #
 
 ##

--- a/app/models/project/membership.rb
+++ b/app/models/project/membership.rb
@@ -3,10 +3,10 @@
 #
 # Table name: project_memberships
 #
-#  id         :bigint           not null, primary key
-#  project_id :bigint
-#  user_id    :bigint
-#  role_id    :bigint
+#  id         :integer          not null, primary key
+#  project_id :integer
+#  user_id    :integer
+#  role_id    :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/app/models/project/resource.rb
+++ b/app/models/project/resource.rb
@@ -3,10 +3,10 @@
 #
 # Table name: project_resources
 #
-#  id            :bigint           not null, primary key
-#  project_id    :bigint
+#  id            :integer          not null, primary key
+#  project_id    :integer
 #  resource_type :string
-#  resource_id   :bigint
+#  resource_id   :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/app/models/project/submission.rb
+++ b/app/models/project/submission.rb
@@ -3,14 +3,14 @@
 #
 # Table name: project_submissions
 #
-#  id              :bigint           not null, primary key
-#  project_id      :bigint
-#  user_id         :bigint
+#  id              :integer          not null, primary key
+#  project_id      :integer
+#  user_id         :integer
 #  resource_type   :string
-#  resource_id     :bigint
+#  resource_id     :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  info_request_id :bigint
+#  info_request_id :integer
 #
 
 ##

--- a/app/models/public_body_category.rb
+++ b/app/models/public_body_category.rb
@@ -7,8 +7,6 @@
 #  category_tag :text             not null
 #  created_at   :datetime
 #  updated_at   :datetime
-#  title        :text
-#  description  :text
 #
 
 class PublicBodyCategory < ApplicationRecord

--- a/app/models/public_body_heading.rb
+++ b/app/models/public_body_heading.rb
@@ -7,7 +7,6 @@
 #  display_order :integer
 #  created_at    :datetime
 #  updated_at    :datetime
-#  name          :text
 #
 
 class PublicBodyHeading < ApplicationRecord

--- a/app/models/user/sign_in.rb
+++ b/app/models/user/sign_in.rb
@@ -3,8 +3,8 @@
 #
 # Table name: user_sign_ins
 #
-#  id         :bigint           not null, primary key
-#  user_id    :bigint
+#  id         :integer          not null, primary key
+#  user_id    :integer
 #  ip         :inet
 #  created_at :datetime         not null
 #  updated_at :datetime         not null

--- a/app/models/user_message.rb
+++ b/app/models/user_message.rb
@@ -3,11 +3,12 @@
 #
 # Table name: user_messages
 #
-#  id         :bigint           not null, primary key
-#  user_id    :bigint
+#  id         :integer          not null, primary key
+#  user_id    :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+
 class UserMessage < ApplicationRecord
   belongs_to :user,
              inverse_of: :user_messages,

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
-  config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  # config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")

--- a/spec/factories/announcements.rb
+++ b/spec/factories/announcements.rb
@@ -8,8 +8,6 @@
 #  user_id    :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  title      :string
-#  content    :text
 #
 
 FactoryBot.define do

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -3,12 +3,10 @@
 #
 # Table name: categories
 #
-#  id           :bigint           not null, primary key
+#  id           :integer          not null, primary key
 #  category_tag :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  title        :string
-#  description  :string
 #
 
 FactoryBot.define do

--- a/spec/factories/category_relationships.rb
+++ b/spec/factories/category_relationships.rb
@@ -3,7 +3,7 @@
 #
 # Table name: category_relationships
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
 #  parent_id  :integer          not null
 #  child_id   :integer          not null
 #  position   :integer

--- a/spec/factories/citations.rb
+++ b/spec/factories/citations.rb
@@ -3,10 +3,10 @@
 #
 # Table name: citations
 #
-#  id           :bigint           not null, primary key
-#  user_id      :bigint
+#  id           :integer          not null, primary key
+#  user_id      :integer
 #  citable_type :string
-#  citable_id   :bigint
+#  citable_id   :integer
 #  source_url   :string
 #  type         :string
 #  created_at   :datetime         not null

--- a/spec/factories/dataset_key_sets.rb
+++ b/spec/factories/dataset_key_sets.rb
@@ -3,9 +3,9 @@
 #
 # Table name: dataset_key_sets
 #
-#  id            :bigint           not null, primary key
+#  id            :integer          not null, primary key
 #  resource_type :string
-#  resource_id   :bigint
+#  resource_id   :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/spec/factories/dataset_value_sets.rb
+++ b/spec/factories/dataset_value_sets.rb
@@ -3,10 +3,10 @@
 #
 # Table name: dataset_value_sets
 #
-#  id                 :bigint           not null, primary key
+#  id                 :integer          not null, primary key
 #  resource_type      :string
-#  resource_id        :bigint
-#  dataset_key_set_id :bigint
+#  resource_id        :integer
+#  dataset_key_set_id :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/spec/factories/dataset_values.rb
+++ b/spec/factories/dataset_values.rb
@@ -3,9 +3,9 @@
 #
 # Table name: dataset_values
 #
-#  id                   :bigint           not null, primary key
-#  dataset_value_set_id :bigint
-#  dataset_key_id       :bigint
+#  id                   :integer          not null, primary key
+#  dataset_value_set_id :integer
+#  dataset_key_id       :integer
 #  value                :string
 #  notes                :string
 #  created_at           :datetime         not null

--- a/spec/factories/outgoing_message_snippets.rb
+++ b/spec/factories/outgoing_message_snippets.rb
@@ -3,11 +3,9 @@
 #
 # Table name: outgoing_message_snippets
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  name       :string
-#  body       :text
 #
 
 FactoryBot.define do

--- a/spec/factories/project_memberships.rb
+++ b/spec/factories/project_memberships.rb
@@ -3,10 +3,10 @@
 #
 # Table name: project_memberships
 #
-#  id         :bigint           not null, primary key
-#  project_id :bigint
-#  user_id    :bigint
-#  role_id    :bigint
+#  id         :integer          not null, primary key
+#  project_id :integer
+#  user_id    :integer
+#  role_id    :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/spec/factories/project_resources.rb
+++ b/spec/factories/project_resources.rb
@@ -3,10 +3,10 @@
 #
 # Table name: project_resources
 #
-#  id            :bigint           not null, primary key
-#  project_id    :bigint
+#  id            :integer          not null, primary key
+#  project_id    :integer
 #  resource_type :string
-#  resource_id   :bigint
+#  resource_id   :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/spec/factories/project_submissions.rb
+++ b/spec/factories/project_submissions.rb
@@ -3,14 +3,14 @@
 #
 # Table name: project_submissions
 #
-#  id              :bigint           not null, primary key
-#  project_id      :bigint
-#  user_id         :bigint
+#  id              :integer          not null, primary key
+#  project_id      :integer
+#  user_id         :integer
 #  resource_type   :string
-#  resource_id     :bigint
+#  resource_id     :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  info_request_id :bigint
+#  info_request_id :integer
 #
 
 FactoryBot.define do

--- a/spec/factories/public_body_categories.rb
+++ b/spec/factories/public_body_categories.rb
@@ -7,8 +7,6 @@
 #  category_tag :text             not null
 #  created_at   :datetime
 #  updated_at   :datetime
-#  title        :text
-#  description  :text
 #
 
 FactoryBot.define do

--- a/spec/factories/public_body_headings.rb
+++ b/spec/factories/public_body_headings.rb
@@ -7,7 +7,6 @@
 #  display_order :integer
 #  created_at    :datetime
 #  updated_at    :datetime
-#  name          :text
 #
 
 FactoryBot.define do

--- a/spec/factories/user_messages.rb
+++ b/spec/factories/user_messages.rb
@@ -3,11 +3,12 @@
 #
 # Table name: user_messages
 #
-#  id         :bigint           not null, primary key
-#  user_id    :bigint
+#  id         :integer          not null, primary key
+#  user_id    :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+
 FactoryBot.define do
   factory :user_message do
     user

--- a/spec/fixtures/categories.yml
+++ b/spec/fixtures/categories.yml
@@ -3,12 +3,10 @@
 #
 # Table name: categories
 #
-#  id           :bigint           not null, primary key
+#  id           :integer          not null, primary key
 #  category_tag :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  title        :string
-#  description  :string
 #
 
 public_body_root_category:

--- a/spec/fixtures/category_relationships.yml
+++ b/spec/fixtures/category_relationships.yml
@@ -3,13 +3,12 @@
 #
 # Table name: category_relationships
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
 #  parent_id  :integer          not null
 #  child_id   :integer          not null
 #  position   :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#
 #
 
 useless_and_lonely_category_rel:

--- a/spec/fixtures/public_body_categories.yml
+++ b/spec/fixtures/public_body_categories.yml
@@ -7,8 +7,6 @@
 #  category_tag :text             not null
 #  created_at   :datetime
 #  updated_at   :datetime
-#  title        :text
-#  description  :text
 #
 
 useless_category:

--- a/spec/fixtures/public_body_headings.yml
+++ b/spec/fixtures/public_body_headings.yml
@@ -7,7 +7,6 @@
 #  display_order :integer
 #  created_at    :datetime
 #  updated_at    :datetime
-#  name          :text
 #
 
 useless_lonely_heading:

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -8,8 +8,6 @@
 #  user_id    :integer          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  title      :string
-#  content    :text
 #
 
 require 'spec_helper'

--- a/spec/models/blog/post_spec.rb
+++ b/spec/models/blog/post_spec.rb
@@ -3,13 +3,14 @@
 #
 # Table name: blog_posts
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
 #  title      :string
 #  url        :string
 #  data       :jsonb
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+
 require 'spec_helper'
 require 'models/concerns/taggable'
 

--- a/spec/models/category_relationship_spec.rb
+++ b/spec/models/category_relationship_spec.rb
@@ -3,7 +3,7 @@
 #
 # Table name: category_relationships
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
 #  parent_id  :integer          not null
 #  child_id   :integer          not null
 #  position   :integer

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,12 +3,10 @@
 #
 # Table name: categories
 #
-#  id           :bigint           not null, primary key
+#  id           :integer          not null, primary key
 #  category_tag :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  title        :string
-#  description  :string
 #
 
 require 'spec_helper'

--- a/spec/models/citation_spec.rb
+++ b/spec/models/citation_spec.rb
@@ -3,10 +3,10 @@
 #
 # Table name: citations
 #
-#  id           :bigint           not null, primary key
-#  user_id      :bigint
+#  id           :integer          not null, primary key
+#  user_id      :integer
 #  citable_type :string
-#  citable_id   :bigint
+#  citable_id   :integer
 #  source_url   :string
 #  type         :string
 #  created_at   :datetime         not null

--- a/spec/models/dataset/key_set_spec.rb
+++ b/spec/models/dataset/key_set_spec.rb
@@ -3,9 +3,9 @@
 #
 # Table name: dataset_key_sets
 #
-#  id            :bigint           not null, primary key
+#  id            :integer          not null, primary key
 #  resource_type :string
-#  resource_id   :bigint
+#  resource_id   :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/spec/models/dataset/value_set_spec.rb
+++ b/spec/models/dataset/value_set_spec.rb
@@ -3,10 +3,10 @@
 #
 # Table name: dataset_value_sets
 #
-#  id                 :bigint           not null, primary key
+#  id                 :integer          not null, primary key
 #  resource_type      :string
-#  resource_id        :bigint
-#  dataset_key_set_id :bigint
+#  resource_id        :integer
+#  dataset_key_set_id :integer
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/spec/models/dataset/value_spec.rb
+++ b/spec/models/dataset/value_spec.rb
@@ -3,9 +3,9 @@
 #
 # Table name: dataset_values
 #
-#  id                   :bigint           not null, primary key
-#  dataset_value_set_id :bigint
-#  dataset_key_id       :bigint
+#  id                   :integer          not null, primary key
+#  dataset_value_set_id :integer
+#  dataset_key_id       :integer
 #  value                :string
 #  notes                :string
 #  created_at           :datetime         not null

--- a/spec/models/outgoing_message/snippet_spec.rb
+++ b/spec/models/outgoing_message/snippet_spec.rb
@@ -3,11 +3,9 @@
 #
 # Table name: outgoing_message_snippets
 #
-#  id         :bigint           not null, primary key
+#  id         :integer          not null, primary key
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  name       :string
-#  body       :text
 #
 
 require 'spec_helper'

--- a/spec/models/project/membership_spec.rb
+++ b/spec/models/project/membership_spec.rb
@@ -3,10 +3,10 @@
 #
 # Table name: project_memberships
 #
-#  id         :bigint           not null, primary key
-#  project_id :bigint
-#  user_id    :bigint
-#  role_id    :bigint
+#  id         :integer          not null, primary key
+#  project_id :integer
+#  user_id    :integer
+#  role_id    :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #

--- a/spec/models/project/resource_spec.rb
+++ b/spec/models/project/resource_spec.rb
@@ -3,10 +3,10 @@
 #
 # Table name: project_resources
 #
-#  id            :bigint           not null, primary key
-#  project_id    :bigint
+#  id            :integer          not null, primary key
+#  project_id    :integer
 #  resource_type :string
-#  resource_id   :bigint
+#  resource_id   :integer
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
 #

--- a/spec/models/project/submission_spec.rb
+++ b/spec/models/project/submission_spec.rb
@@ -3,14 +3,14 @@
 #
 # Table name: project_submissions
 #
-#  id              :bigint           not null, primary key
-#  project_id      :bigint
-#  user_id         :bigint
+#  id              :integer          not null, primary key
+#  project_id      :integer
+#  user_id         :integer
 #  resource_type   :string
-#  resource_id     :bigint
+#  resource_id     :integer
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
-#  info_request_id :bigint
+#  info_request_id :integer
 #
 
 require 'spec_helper'

--- a/spec/models/public_body_category_spec.rb
+++ b/spec/models/public_body_category_spec.rb
@@ -7,8 +7,6 @@
 #  category_tag :text             not null
 #  created_at   :datetime
 #  updated_at   :datetime
-#  title        :text
-#  description  :text
 #
 
 require 'spec_helper'

--- a/spec/models/public_body_heading_spec.rb
+++ b/spec/models/public_body_heading_spec.rb
@@ -7,7 +7,6 @@
 #  display_order :integer
 #  created_at    :datetime
 #  updated_at    :datetime
-#  name          :text
 #
 
 require 'spec_helper'

--- a/spec/models/user/sign_in_spec.rb
+++ b/spec/models/user/sign_in_spec.rb
@@ -3,13 +3,14 @@
 #
 # Table name: user_sign_ins
 #
-#  id         :bigint           not null, primary key
-#  user_id    :bigint
+#  id         :integer          not null, primary key
+#  user_id    :integer
 #  ip         :inet
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  country    :string
 #
+
 require 'spec_helper'
 
 RSpec.describe User::SignIn, type: :model do

--- a/spec/models/user_message_spec.rb
+++ b/spec/models/user_message_spec.rb
@@ -3,11 +3,12 @@
 #
 # Table name: user_messages
 #
-#  id         :bigint           not null, primary key
-#  user_id    :bigint
+#  id         :integer          not null, primary key
+#  user_id    :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+
 require 'spec_helper'
 
 RSpec.describe UserMessage, type: :model do


### PR DESCRIPTION
## What does this do?

Minor fixes post Rails upgrade

## Why was this needed?

Few niggles noticed post Rails upgrade from 7.0 -> 8.0

1. Annotate models (`bigint`->`integer`) and seems the gem now removes globalized columns 🤷‍♂️ 
2. Minor Rdoc gem bump to prevent warnings in development - was loading two version of the gem and causing "Constant previously defined".
3. Updated bundler version
4. Restore production logging to `log/production.log`

[skip changelog]