### PR TITLE
[#8543] Update Attachment masking job setup

### DIFF
--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -9,6 +9,8 @@ class FoiAttachmentMaskJob < ApplicationJob
   queue_as :default
   unique :until_and_while_executing, on_conflict: :log
 
+  around_perform :set_regexp_timeout
+
   attr_reader :attachment
 
   delegate :incoming_message, to: :attachment
@@ -61,5 +63,12 @@ class FoiAttachmentMaskJob < ApplicationJob
       censor_rules: info_request.applicable_censor_rules,
       masks: info_request.masks
     }
+  end
+
+  def set_regexp_timeout
+    current_timeout = Regexp.timeout
+    Regexp.timeout = 60.0
+    yield
+    Regexp.timeout = current_timeout
   end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+Increase regular expression timeout for attachment masking (Graeme Porteous)
 Add additional InfoRequest embargo scopes (Graeme Porteous)
 
 # 0.45.3.0


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8543

See: https://github.com/rails/rails/pull/53490

## What does this do?

Update Attachment masking job setup

## Why was this needed?

This change increase the `Regexp.timeout` from 1 sec to 60 secs.

This is needed since Rails 8.0 now defaults to 1 sec to stop possible DoS attacks. Since this is in a background job the timeout duration is less of a concern.

