### PR TITLE
[#8546] Fix exception with rake task

### DIFF
--- a/lib/tasks/config_files.rake
+++ b/lib/tasks/config_files.rake
@@ -186,9 +186,9 @@ namespace :config_files do
     check_for_env_vars(%w[REJECTED_THRESHOLD AGE_IN_MONTHS], example)
     dryrun = ENV['DRYRUN'] != '0'
     STDERR.puts "Only a dry run; info_requests will not be updated" if dryrun
-    options = { rejection_threshold: ENV['REJECTED_THRESHOLD'],
-               age_in_months: ENV['AGE_IN_MONTHS'],
-               dryrun: dryrun }
+    options = { rejection_threshold: ENV['REJECTED_THRESHOLD'].to_i,
+                age_in_months: ENV['AGE_IN_MONTHS'].to_i,
+                dryrun: dryrun }
 
     updated_count = InfoRequest.reject_incoming_at_mta(options) do |ids|
       puts "Info Request\tRejected incoming count\tLast updated"


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8546

## What does this do?

Fix exception with rake task

## Why was this needed?

Update options passed into `InfoRequest.reject_incoming_at_mta` to ensure they are cast to integer correct as the method expects. Tests only pass in integers so we should here too.

[skip changelog]