### PR TITLE
[#8545] Fix citation JSON exception

### DIFF
--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -72,7 +72,7 @@ class Citation < ApplicationRecord
     citable.is_a?(InfoRequestBatch)
   end
 
-  def as_json(_options)
+  def as_json
     citable_path = case citable
                    when InfoRequest
                      request_path(citable)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8545

## What does this do?

Fix citation JSON exception

## Why was this needed?

Update method declaration. This is called from the controller/view to render to citations as JSON. Rails used to pass an options argument but now doesn't.

[skip changelog]
