### PR TITLE
Tweaks to `.gitignore` to better ignore some deployment artefacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,10 @@
 !/lib/themes/.keep
-!/log/.keep
 /.bundle/
 /.ruby-version
 /.sass-cache/
 /.vagrant.yml
 /.vagrant/
-/cache/
+/cache
 /config/*.deployed
 /config/aliases
 /config/config.tmp
@@ -28,12 +27,12 @@
 /files/
 /lib/themes/*
 /locale/model_attributes.rb
-/log/*
+/log
 /old-cache/
 /public/*theme/
 /public/alavetelitheme
 /public/asktheeu-theme
-/public/assets/
+/public/assets
 /public/down.current.html
 /public/down.html
 /public/download/
@@ -41,7 +40,7 @@
 /public/foi-user-use.png
 /public/google*.html
 /public/wordpress
-/storage/
+/storage
 /tmp/
-/vendor/bundle/
+/vendor/bundle
 /vendor/data/


### PR DESCRIPTION
## What does this do?

Slightly widens the scope of a few `.gitignore` lines to include parent directories in particular. These get created by our deployment automation and as it stands are visible to git.

## Why was this needed?

To prevent build/deployment working copies being cluttered with uncommitted changes. Came up during some internal work looking at our deployment/build systems.

## Notes to reviewer

I don't think any of these directories ever need to be in version control, so I don't think this should be a problem unless there's something I have missed.

I don't think a changelog entry is needed for this, either.

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
