### PR TITLE
[#2733/#8331] Prevent request classification notifications

### DIFF
--- a/app/controllers/concerns/classifiable.rb
+++ b/app/controllers/concerns/classifiable.rb
@@ -66,7 +66,7 @@ module Classifiable
     )
   end
 
-  def set_described_state
+  def set_described_state(default_log_params = {})
     described_state = classification_params[:described_state]
     message = classification_params[:message]
 
@@ -74,7 +74,7 @@ module Classifiable
       user_id: current_user.id,
       old_described_state: @info_request.described_state,
       described_state: described_state
-    }
+    }.merge(default_log_params)
 
     log_params[:message] = message if message
 

--- a/app/controllers/projects/classifications_controller.rb
+++ b/app/controllers/projects/classifications_controller.rb
@@ -33,7 +33,7 @@ class Projects::ClassificationsController < Projects::BaseController
     {
       user: current_user,
       info_request: @info_request,
-      resource: set_described_state
+      resource: set_described_state(project: @project)
     }
   end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -20,6 +20,9 @@ class ApplicationMailer < ActionMailer::Base
   # Site-wide access to configuration settings
   include ConfigHelper
 
+  # Check user can receive the emails by wrapping `mail_user`.
+  prepend CheckMailerAbility
+
   # This really should be the default - otherwise you lose any information
   # about the errors, and have to do error checking on return codes.
   self.raise_delivery_errors = true

--- a/app/mailers/concerns/check_mailer_ability.rb
+++ b/app/mailers/concerns/check_mailer_ability.rb
@@ -1,0 +1,44 @@
+##
+# This module provides email sending ability control for mailers. It allows
+# mailers to check whether email delivery is permitted based on user
+# permissions or other criteria.
+#
+# Key functionality:
+# - Wraps mail sending with permission checking
+# - Extracts mailer name and action for permission lookup
+# - Builds ability instance with mailer context variables
+#
+module CheckMailerAbility
+  extend ActiveSupport::Concern
+
+  def mail_user(user, **headers)
+    @user = user
+
+    mail = super
+    mail.perform_deliveries = can_send?
+    mail
+  end
+
+  def can_send?
+    ability.can?(:receive, name)
+  end
+
+  def name
+    [mailer_name.underscore, action_name].join('#')
+  end
+
+  def ability
+    @ability ||= MailerAbility.new(@user, **variables)
+  end
+
+  private
+
+  def variables
+    instance_variables.inject({}) do |hash, var|
+      next hash if var.to_s.starts_with?('@_')
+
+      hash[var.to_s.delete('@').to_sym] = instance_variable_get(var)
+      hash
+    end
+  end
+end

--- a/app/mailers/mailer_ability.rb
+++ b/app/mailers/mailer_ability.rb
@@ -15,6 +15,13 @@ class MailerAbility
     cannot :receive, 'request_mailer#old_unclassified_updated' do
       info_request.created_at <= 6.months.ago
     end
+
+    cannot :receive, 'request_mailer#old_unclassified_updated' do
+      last_status_update = info_request.info_request_events.
+        where(event_type: 'status_update').
+        last
+      last_status_update.params[:project] if last_status_update
+    end
   end
 
   private

--- a/app/mailers/mailer_ability.rb
+++ b/app/mailers/mailer_ability.rb
@@ -1,0 +1,15 @@
+##
+# This ability model enforces permission rules for mailer functions.
+#
+class MailerAbility
+  include CanCan::Ability
+
+  attr_reader :user, :params
+
+  def initialize(user, **params)
+    @user = user
+    @params = params
+
+    can :receive, :all
+  end
+end

--- a/app/mailers/mailer_ability.rb
+++ b/app/mailers/mailer_ability.rb
@@ -11,5 +11,15 @@ class MailerAbility
     @params = params
 
     can :receive, :all
+
+    cannot :receive, 'request_mailer#old_unclassified_updated' do
+      info_request.created_at <= 6.months.ago
+    end
+  end
+
+  private
+
+  def info_request
+    params[:info_request]
   end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Highlighted Features
 
-* Prevent request classification notifications from being set if request is
+* Prevent request classification notifications from being sent if request is
   older than 6 months (Graeme Porteous)
 * Add additional InfoRequest embargo scopes (Graeme Porteous)
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Prevent project classification notifications from being sent (Graeme Porteous)
 * Prevent request classification notifications from being sent if request is
   older than 6 months (Graeme Porteous)
 * Add additional InfoRequest embargo scopes (Graeme Porteous)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,7 +2,9 @@
 
 ## Highlighted Features
 
-Add additional InfoRequest embargo scopes (Graeme Porteous)
+* Prevent request classification notifications from being set if request is
+  older than 6 months (Graeme Porteous)
+* Add additional InfoRequest embargo scopes (Graeme Porteous)
 
 # 0.45.3.1
 

--- a/spec/controllers/projects/classifications_controller_spec.rb
+++ b/spec/controllers/projects/classifications_controller_spec.rb
@@ -121,7 +121,8 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         expect(event.params[:described_state]).to eq 'successful'
         expect(event.params[:old_described_state]).to eq 'waiting_response'
         expect(event.params).to include(
-          user: { gid: info_request.user.to_global_id.to_s }
+          user: { gid: info_request.user.to_global_id.to_s },
+          project: { gid: project.to_global_id.to_s }
         )
       end
 
@@ -172,7 +173,8 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         expect(event.params[:old_described_state]).to eq 'waiting_response'
         expect(event.params[:message]).to eq 'A message'
         expect(event.params).to include(
-          user: { gid: info_request.user.to_global_id.to_s }
+          user: { gid: info_request.user.to_global_id.to_s },
+          project: { gid: project.to_global_id.to_s }
         )
       end
 
@@ -214,7 +216,8 @@ RSpec.describe Projects::ClassificationsController, spec_meta do
         expect(event.params[:old_described_state]).to eq 'waiting_response'
         expect(event.params[:message]).to eq 'A message'
         expect(event.params).to include(
-          user: { gid: info_request.user.to_global_id.to_s }
+          user: { gid: info_request.user.to_global_id.to_s },
+          project: { gid: project.to_global_id.to_s }
         )
       end
 

--- a/spec/mailers/mailer_ability_spec.rb
+++ b/spec/mailers/mailer_ability_spec.rb
@@ -90,12 +90,18 @@ RSpec.describe MailerAbility do
     let(:ability) { MailerAbility.new(user, info_request: info_request) }
 
     context 'when info request when sent less than 6 months ago' do
-      let(:info_request) { double(:InfoRequest, created_at: 6.months.ago + 1) }
+      let(:info_request) do
+        FactoryBot.build(:info_request, created_at: 6.months.ago + 1)
+      end
+
       it { expect(ability).to be_able_to(:receive, name) }
     end
 
     context 'when info request when sent more than 6 months ago' do
-      let(:info_request) { double(:InfoRequest, created_at: 6.months.ago) }
+      let(:info_request) do
+        FactoryBot.build(:info_request, created_at: 6.months.ago)
+      end
+
       it { expect(ability).not_to be_able_to(:receive, name) }
     end
   end

--- a/spec/mailers/mailer_ability_spec.rb
+++ b/spec/mailers/mailer_ability_spec.rb
@@ -87,7 +87,17 @@ RSpec.describe MailerAbility do
 
   describe 'RequestMailer#old_unclassified_updated' do
     let(:name) { 'request_mailer#old_unclassified_updated' }
-    it { expect(ability).to be_able_to(:receive, name) }
+    let(:ability) { MailerAbility.new(user, info_request: info_request) }
+
+    context 'when info request when sent less than 6 months ago' do
+      let(:info_request) { double(:InfoRequest, created_at: 6.months.ago + 1) }
+      it { expect(ability).to be_able_to(:receive, name) }
+    end
+
+    context 'when info request when sent more than 6 months ago' do
+      let(:info_request) { double(:InfoRequest, created_at: 6.months.ago) }
+      it { expect(ability).not_to be_able_to(:receive, name) }
+    end
   end
 
   describe 'RequestMailer#not_clarified_alert' do

--- a/spec/mailers/mailer_ability_spec.rb
+++ b/spec/mailers/mailer_ability_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+require "cancan/matchers"
+
+RSpec.describe MailerAbility do
+  let(:user) { FactoryBot.build(:user) }
+  let(:ability) { MailerAbility.new(user) }
+
+  describe 'EmbargoMailer#expiring_alert' do
+    let(:name) { 'embargo_mailer#expiring_alert' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'EmbargoMailer#expired_alert' do
+    let(:name) { 'embargo_mailer#expired_alert' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'SubscriptionMailer#payment_failed' do
+    let(:name) { 'subscription_mailer#payment_failed' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'ContactMailer#user_message' do
+    let(:name) { 'contact_mailer#user_message' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'ContactMailer#from_admin_message' do
+    let(:name) { 'contact_mailer#from_admin_message' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'InfoRequestBatchMailer#batch_sent' do
+    let(:name) { 'info_request_batch_mailer#batch_sent' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'NotificationMailer#daily_summary' do
+    let(:name) { 'notification_mailer#daily_summary' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'NotificationMailer#response_notification' do
+    let(:name) { 'notification_mailer#response_notification' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'NotificationMailer#embargo_expiring_notification' do
+    let(:name) { 'notification_mailer#embargo_expiring_notification' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'NotificationMailer#expire_embargo_notification' do
+    let(:name) { 'notification_mailer#expire_embargo_notification' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'NotificationMailer#overdue_notification' do
+    let(:name) { 'notification_mailer#overdue_notification' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'NotificationMailer#very_overdue_notification' do
+    let(:name) { 'notification_mailer#very_overdue_notification' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'RequestMailer#new_response' do
+    let(:name) { 'request_mailer#new_response' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'RequestMailer#overdue_alert' do
+    let(:name) { 'request_mailer#overdue_alert' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'RequestMailer#very_overdue_alert' do
+    let(:name) { 'request_mailer#very_overdue_alert' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'RequestMailer#new_response_reminder_alert' do
+    let(:name) { 'request_mailer#new_response_reminder_alert' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'RequestMailer#old_unclassified_updated' do
+    let(:name) { 'request_mailer#old_unclassified_updated' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'RequestMailer#not_clarified_alert' do
+    let(:name) { 'request_mailer#not_clarified_alert' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'RequestMailer#comment_on_alert' do
+    let(:name) { 'request_mailer#comment_on_alert' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'RequestMailer#comment_on_alert_plural' do
+    let(:name) { 'request_mailer#comment_on_alert_plural' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'SurveyMailer#survey_alert' do
+    let(:name) { 'survey_mailer#survey_alert' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'TrackMailer#event_digest' do
+    let(:name) { 'track_mailer#event_digest' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'UserMailer#confirm_login' do
+    let(:name) { 'user_mailer#confirm_login' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'UserMailer#already_registered' do
+    let(:name) { 'user_mailer#already_registered' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'UserMailer#changeemail_confirm' do
+    let(:name) { 'user_mailer#changeemail_confirm' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+
+  describe 'UserMailer#changeemail_already_used' do
+    let(:name) { 'user_mailer#changeemail_already_used' }
+    it { expect(ability).to be_able_to(:receive, name) }
+  end
+end

--- a/spec/mailers/mailer_ability_spec.rb
+++ b/spec/mailers/mailer_ability_spec.rb
@@ -104,6 +104,23 @@ RSpec.describe MailerAbility do
 
       it { expect(ability).not_to be_able_to(:receive, name) }
     end
+
+    context 'when info request was classified by project contributor' do
+      let(:project) do
+        FactoryBot.create(:project, contributors_count: 1, requests_count: 1)
+      end
+
+      let(:info_request) { project.requests.first }
+      let(:contributor) { project.contributors.first }
+
+      before do
+        info_request.log_event(
+          'status_update', user_id: contributor.id, project: project
+        )
+      end
+
+      it { expect(ability).not_to be_able_to(:receive, name) }
+    end
   end
 
   describe 'RequestMailer#not_clarified_alert' do

--- a/spec/mailers/previews/request_mailer_preview.rb
+++ b/spec/mailers/previews/request_mailer_preview.rb
@@ -43,7 +43,8 @@ class RequestMailerPreview < ActionMailer::Preview
       url_title: 'a_request',
       user: User.first,
       public_body: PublicBody.first,
-      described_state: 'successful'
+      described_state: 'successful',
+      created_at: Time.now
     )
   end
 

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -542,6 +542,11 @@ RSpec.describe RequestMailer do
       expect(mail.subject).to eq('Someone has updated the status of your request')
     end
 
+    it 'delivers the email' do
+      mail.deliver_now
+      expect(ActionMailer::Base.deliveries).to_not be_empty
+    end
+
     context "when the user does not use default locale" do
       before do
         info_request.user.locale = 'es'
@@ -551,6 +556,21 @@ RSpec.describe RequestMailer do
         expect(mail.subject).to eq(
           'Alguien ha actualizado el estado de tu solicitud'
         )
+      end
+    end
+
+    context 'when the info request was created over 6 months ago' do
+      let(:info_request) do
+        FactoryBot.create(
+          :info_request,
+          user: user, title: "Test request", public_body: public_body,
+          url_title: "test_request", created_at: 6.months.ago
+        )
+      end
+
+      it 'does not deliver the email' do
+        mail.deliver_now
+        expect(ActionMailer::Base.deliveries).to be_empty
       end
     end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #2733
Fixes #8331

## What does this do?

1. Prevent request classification notifications for older requests (older than 6 months)
2. Prevent project classification notifications

## Why was this needed?

If a requester hasn't classified their request within 6 months then more than likely they don't care if their request has been classified.

Sometimes this years can go by before classification which can cause in the requester contacting us for support.

For projects classification, many notifications can be sent over a short period of time. These changes prevents them from being sent at all.

## Implementation notes

Build upon CanCan abilities so we can, in the future, offer fine grain permissions for users on which emails they'll receive.
