### PR TITLE
Update GitHub Action workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,13 @@ jobs:
         bundle exec rspec gems/*/spec --format Fivemat
 
     - name: Coveralls Parallel
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@v2
       continue-on-error: true
       with:
         github-token: ${{ secrets.github_token }}
         flag-name: run-${{ matrix.ruby }}-${{ matrix.gemfile || 'Gemfile' }}
         parallel: true
+        fail-on-error: false
 
   coveralls:
     name: Coveralls
@@ -143,7 +144,8 @@ jobs:
 
     steps:
       - name: Coveralls Finished
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.github_token }}
           parallel-finished: true
+          fail-on-error: false


### PR DESCRIPTION
Don't report errors if Coveralls fails for any reason. Their API seems to be having issues and as we don't really need the result of these checks lets ignore the errors.

Also pins Coveralls action to v2 just incase there are ever any braking changes on master.

<hr>

[skip changelog]
