### PR TITLE
Fix Stripe customer creation in development

### DIFF
--- a/app/models/pro_account.rb
+++ b/app/models/pro_account.rb
@@ -51,8 +51,11 @@ class ProAccount < ApplicationRecord
     @subscriptions = nil unless stripe_customer
 
     attributes = {}
-    attributes[:email] = user.email if stripe_customer.try(:email) != user.email
     attributes[:source] = @token.id if @token
+
+    if stripe_customer&.email != user.email && user.email !~ /@localhost$/
+      attributes[:email] = user.email
+    end
 
     @stripe_customer = (
       if attributes.empty?
@@ -64,7 +67,7 @@ class ProAccount < ApplicationRecord
       end
     )
 
-    update(stripe_customer_id: @stripe_customer.id)
+    update(stripe_customer_id: @stripe_customer&.id)
   end
 
   private

--- a/spec/models/pro_account_spec.rb
+++ b/spec/models/pro_account_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe ProAccount, feature: :pro_pricing do
       ).from(old_source)
     end
 
+    context 'when user uses localhost development email' do
+      before { user.update(email: 'user@localhost') }
+
+      it 'does not create Stripe customer' do
+        expect(Stripe::Customer).to_not receive(:create)
+        pro_account.update_stripe_customer
+      end
+    end
+
     context 'with pro_pricing disabled' do
       it 'does not store Stripe customer ID' do
         with_feature_disabled(:pro_pricing) do


### PR DESCRIPTION

## What does this do?

Fix Stripe customer creation in development

## Why was this needed?

We use `@localhost` email addresses for our development example users. We can't create Stripe customers with these email address as they aren't valid.

This change will allow our pro example users to login and allow non-pro example users to sign up without needing to change their email address.


<hr>

[skip changelog]