### PR TITLE
Limit user profile indexing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -621,7 +621,7 @@ class User < ApplicationRecord
   end
 
   def indexed_by_search?
-    email_confirmed && active?
+    email_confirmed && active? && info_requests.any?
   end
 
   # Notify a user about an info_request_event, allowing the user's preferences

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,12 +2,32 @@
 
 ## Highlighted Features
 
+* Only list users who have made requests in search (Gareth Rees)
 * Collect cancellation reasons when Pro users cancel their subscriptions (Graeme
   Porteous)
 * Removed `old_unclassified_updated` email (Graeme Porteous)
 * Add Pro upsell on the user rate limited page (Graeme Porteous)
 * Update Stripe payment description after Pro payments (Graeme Porteous)
 * Add additional InfoRequest embargo scopes (Graeme Porteous)
+
+## Upgrade Notes
+
+* _Recommended:_ This release limits user indexing to users who've made requests
+to prevent users stumbling across spam user profiles via the on-site search.
+
+You can wait for this change to eventually percolate as account records
+are updated, or manually update the search index with the following:
+
+    bin/rails runner "User.where(info_requests_count: 0).in_batches.each_record(&:xapian_mark_needs_index)"
+
+Depending on the number of affected records and compute resources, you
+may wish to throttle the reindexing by running a similar version of this
+in the rails console:
+
+    User.where(info_requests_count: 0).in_batches do |users|
+      users.each(&:xapian_mark_needs_index)
+      sleep(360) # Throttle the reindexing
+    end
 
 # 0.45.3.1
 

--- a/spec/controllers/general_controller_spec.rb
+++ b/spec/controllers/general_controller_spec.rb
@@ -336,17 +336,6 @@ RSpec.describe GeneralController, 'when using xapian search' do
     expect(assigns[:xapian_users].results.map { |x|x[:model] }).to eq([])
   end
 
-  it "should show newly-confirmed users" do
-    u = users(:unconfirmed_user)
-    u.email_confirmed = true
-    u.save!
-    update_xapian_index
-
-    get :search, params: { combined: "unconfirmed/users" }
-    expect(response).to render_template('search')
-    expect(assigns[:xapian_users].results.map { |x|x[:model] }).to eq([u])
-  end
-
   it "should show tracking links for requests-only searches" do
     get :search, params: { combined: "bob/requests" }
     expect(response.body).to include('Track this search')

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1649,8 +1649,13 @@ RSpec.describe User do
       expect(user.indexed_by_search?).to eq(false)
     end
 
-    it 'is true if the user is confirmed and not banned' do
+    it 'is false if the user has no requests' do
       user = User.new(email_confirmed: true, ban_text: '')
+      expect(user.indexed_by_search?).to eq(false)
+    end
+
+    it 'is true if the user is active and has requests' do
+      user = FactoryBot.create(:info_request).user
       expect(user.indexed_by_search?).to eq(true)
     end
   end

--- a/spec/models/xapian_spec.rb
+++ b/spec/models/xapian_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe User, " when indexing users with Xapian" do
   end
 
   it "should search by name" do
-    xapian_object = ActsAsXapian::Search.new([User], "Silly", limit: 100)
+    xapian_object = ActsAsXapian::Search.new([User], "Bob", limit: 100)
     expect(xapian_object.results.size).to eq(1)
-    expect(xapian_object.results[0][:model]).to eq(users(:silly_name_user))
+    expect(xapian_object.results[0][:model]).to eq(users(:bob_smith_user))
   end
 
   it "should search by 'about me' text" do


### PR DESCRIPTION
Limit user indexing to users who've made requests to prevent users stumbling across spam user profiles via the on-site search.

You can wait for this change to eventually percolate as account records are updated, or manually update the search index with the following:

    bin/rails runner "User.where(info_requests_count: 0).in_batches.each_record(&:xapian_mark_needs_index)"

Depending on the number of affected records and compute resources, you may wish to throttle the reindexing by running a similar version of this in the rails console:

    User.where(info_requests_count: 0).in_batches do |users|
      users.each(&:xapian_mark_needs_index)
      sleep(360) # Throttle the reindexing
    end

