### PR TITLE
Add report link on user profile page

### DIFF
--- a/app/views/user/show/_show_profile.html.erb
+++ b/app/views/user/show/_show_profile.html.erb
@@ -12,6 +12,10 @@
       <% if feature_enabled?(:annotations) %>
         <br><a href="#annotations"><%= _('Annotations') %></a>
       <% end %>
+
+      <hr style="margin:1em 0;">
+
+      <%= link_to _('Report inappropriate content'), help_contact_path %>
     <% end %>
   </div>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add report link to user profile pages (Gareth Rees)
 * Only list users who have made requests in search (Gareth Rees)
 * Collect cancellation reasons when Pro users cancel their subscriptions (Graeme
   Porteous)


### PR DESCRIPTION
Fixes https://github.com/mysociety/sysadmin/issues/2042.

The UK Online Safety Act requires good content reporting capabilities.

We have report links attached to most user generated content, but not here. This is a quick fix to add a report link to user profile pages, which goes to the general contact form.

In future it would be good to have this direct to a more structured form, but this works for now as we consider user profiles more generally.

Visitor

<img width="1364" alt="Screenshot 2025-03-18 at 09 29 20" src="https://github.com/user-attachments/assets/5c94231a-cff0-4f02-8a83-a85001d8b11d" />

Signed in

<img width="1364" alt="Screenshot 2025-03-18 at 09 29 32" src="https://github.com/user-attachments/assets/d45b44f7-b2c0-42d5-8c22-4e3a71324f86" />
