### PR TITLE
Move dataset download button

### DIFF
--- a/app/views/projects/dataset/show.html.erb
+++ b/app/views/projects/dataset/show.html.erb
@@ -20,6 +20,18 @@
     </div>
 
     <div class="row">
+      <p>
+        <% if can? :read, @project %>
+          <%= link_to _('Back to project'),
+                project_path(@project),
+                class: 'button-secondary' %>
+        <% end %>
+
+        <%= link_to _('Download'),
+              project_dataset_path(@project, format: :csv),
+              class: 'button' %>
+      </p>
+
       <table class="dataset">
         <% @export.data_for_web.each_with_index do |data, index| %>
           <% if index == 0 %>
@@ -36,17 +48,6 @@
           </tr>
         <% end %>
       </table>
-      <p>
-        <% if can? :read, @project %>
-          <%= link_to _('Back to project'),
-                project_path(@project),
-                class: 'button-secondary' %>
-        <% end %>
-
-        <%= link_to _('Download'),
-              project_dataset_path(@project, format: :csv),
-              class: 'button' %>
-      </p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Moves the project dataset download button above the table. Projects can include hundreds of requests, which results in a very long table. This makes it easy to miss that you can download the dataset as a CSV, or if you do know, makes for a very long scroll to get there.

**BEFORE**

<img width="1140" alt="Screenshot 2025-03-20 at 16 43 38" src="https://github.com/user-attachments/assets/7d527df4-7aef-44c4-b2fc-956431432d9b" />

**AFTER**

<img width="1146" alt="Screenshot 2025-03-20 at 16 43 12" src="https://github.com/user-attachments/assets/903d60d3-bbfb-4413-83b6-94dd3f716a50" />

[skip changelog]
