### PR TITLE
Add spacing between citations

### DIFF
--- a/app/assets/stylesheets/responsive/_sidebar_style.scss
+++ b/app/assets/stylesheets/responsive/_sidebar_style.scss
@@ -114,6 +114,10 @@
     padding: 0;
   }
 
+  .citations-list__citation--compact {
+    margin-bottom: 0.5em;
+  }
+
   .citations-new {
     font-size: 0.875rem
   }


### PR DESCRIPTION
The compact list is a bit too compact. It's difficult to tell where one citation ends and the next begins, especially when some citations are broken over multiple lines.

BEFORE

<img width="256" alt="Screenshot 2025-04-01 at 16 11 51" src="https://github.com/user-attachments/assets/a5d8ce37-cdbf-43c8-9176-7d6f5acaa883" />


AFTER

<img width="256" alt="Screenshot 2025-04-01 at 16 20 05" src="https://github.com/user-attachments/assets/97a76265-7064-468b-9eab-42db84414eec" />


[skip changelog]
