### PR TITLE
Improve citation form field width

### DIFF
--- a/app/views/admin/citations/edit.html.erb
+++ b/app/views/admin/citations/edit.html.erb
@@ -10,14 +10,14 @@
   <div class="control-group">
     <%= f.label :source_url %>
     <div class="controls">
-      <%= f.text_field :source_url, class: 'form-control' %>
+      <%= f.text_field :source_url, class: 'form-control span12' %>
     </div>
   </div>
 
   <div class="control-group">
     <%= f.label :title %>
     <div class="controls">
-      <%= f.text_field :title, class: 'form-control' %>
+      <%= f.text_field :title, class: 'form-control span12' %>
     </div>
   </div>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Improve citation form field width (Gareth Rees)
 * Add report link to user profile pages (Gareth Rees)
 * Only list users who have made requests in search (Gareth Rees)
 * Collect cancellation reasons when Pro users cancel their subscriptions (Graeme


### PR DESCRIPTION
URLs tend to be quite long, so editing them is difficult within a short input field. Used the same for title to balance the form.

BEFORE

<img width="980" alt="Screenshot 2025-04-04 at 16 11 41" src="https://github.com/user-attachments/assets/d0abb130-2c91-4396-b952-e2c1b6b1ef39" />

AFTER

<img width="968" alt="Screenshot 2025-04-04 at 16 15 28" src="https://github.com/user-attachments/assets/c0504c5c-8dbf-49ee-b6db-5569215362c0" />
