### PR TITLE
[#8622] Add attachment locking

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -50,6 +50,8 @@ class FoiAttachment < ApplicationRecord
   before_destroy :delete_cached_file!
 
   scope :binary, -> { where.not(content_type: AlaveteliTextMasker::TextMask) }
+  scope :locked, -> { where(locked: true) }
+  scope :unlocked, -> { where(locked: false) }
 
   delegate :expire, :log_event, to: :info_request
   delegate :metadata, to: :file_blob, allow_nil: true

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20230717201410
+# Schema version: 20250304205550
 #
 # Table name: foi_attachments
 #
@@ -17,6 +17,7 @@
 #  prominence            :string           default("normal")
 #  prominence_reason     :text
 #  masked_at             :datetime
+#  locked                :boolean          default(FALSE)
 #
 
 # models/foi_attachment.rb:

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -473,17 +473,17 @@ class IncomingMessage < ApplicationRecord
 
     # Purge old public attachments that will be rebuilt with a new hexdigest
     old_attachments = (foi_attachments - attachments)
-    hidden_old_attachments = old_attachments.reject { _1.is_public? }
 
-    if hidden_old_attachments.any?
-      # if there are hidden attachments error as we don't want to re-build and
-      # lose the prominence as this will make them public
+    non_public_old_attachments = old_attachments.reject(&:is_public?)
+    if non_public_old_attachments.any?
+      # if there are non public attachments error as we don't want to re-build
+      # and lose the prominence as this will make them public
       raise UnableToExtractAttachments, "unable to extract attachments due " \
         "to prominence of attachments " \
-        "(ID=#{hidden_old_attachments.map(&:id).join(', ')})"
-    else
-      old_attachments.each(&:mark_for_destruction)
+        "(ID=#{non_public_old_attachments.map(&:id).join(', ')})"
     end
+
+    old_attachments.each(&:mark_for_destruction)
   end
 
   # Returns body text as HTML with quotes flattened, and emails removed.

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -483,6 +483,15 @@ class IncomingMessage < ApplicationRecord
         "(ID=#{non_public_old_attachments.map(&:id).join(', ')})"
     end
 
+    locked_old_attachments = old_attachments.select(&:locked?)
+    if locked_old_attachments.any?
+      # if there are locked attachments error as we don't want to re-build and
+      # lose any changes made outside Alaveteli
+      raise UnableToExtractAttachments, "unable to extract attachments due " \
+        "to locked attachments " \
+        "(ID=#{locked_old_attachments.map(&:id).join(', ')})"
+    end
+
     old_attachments.each(&:mark_for_destruction)
   end
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -845,7 +845,7 @@ class InfoRequest < ApplicationRecord
   end
 
   def clear_attachment_masks!
-    foi_attachments.update_all(masked_at: nil)
+    foi_attachments.unlocked.update_all(masked_at: nil)
   end
 
   # Removes anything cached about the object in the database, and saves

--- a/db/migrate/20250304205550_add_locked_to_foi_attachments.rb
+++ b/db/migrate/20250304205550_add_locked_to_foi_attachments.rb
@@ -1,0 +1,5 @@
+class AddLockedToFoiAttachments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :foi_attachments, :locked, :boolean, default: false
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add attachment locking (Graeme Porteous)
 * Improve citation form field width (Gareth Rees)
 * Add report link to user profile pages (Gareth Rees)
 * Only list users who have made requests in search (Gareth Rees)
@@ -13,6 +14,10 @@
 * Add additional InfoRequest embargo scopes (Graeme Porteous)
 
 ## Upgrade Notes
+
+* _Required:_ There are some database structure updates so remember to run:
+
+      bin/rails db:migrate
 
 * _Recommended:_ This release limits user indexing to users who've made requests
 to prevent users stumbling across spam user profiles via the on-site search.

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe FoiAttachment do
     it { is_expected.to match_array(binary_attachments) }
   end
 
+  describe '.locked' do
+    subject { described_class.locked }
+
+    let!(:unlocked_attachment) { FactoryBot.create(:body_text) }
+    let!(:locked_attachment) { FactoryBot.create(:body_text, locked: true) }
+
+    it { is_expected.to include(locked_attachment) }
+    it { is_expected.to_not include(unlocked_attachment) }
+  end
+
+  describe '.unlocked' do
+    subject { described_class.unlocked }
+
+    let!(:unlocked_attachment) { FactoryBot.create(:body_text) }
+    let!(:locked_attachment) { FactoryBot.create(:body_text, locked: true) }
+
+    it { is_expected.to_not include(locked_attachment) }
+    it { is_expected.to include(unlocked_attachment) }
+  end
+
   describe '.cached_urls' do
     it 'includes the correct paths' do
       att = FactoryBot.create(:jpeg_attachment)

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20230717201410
+# Schema version: 20250304205550
 #
 # Table name: foi_attachments
 #
@@ -17,6 +17,7 @@
 #  prominence            :string           default("normal")
 #  prominence_reason     :text
 #  masked_at             :datetime
+#  locked                :boolean          default(FALSE)
 #
 
 require 'spec_helper'

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -1089,6 +1089,16 @@ RSpec.describe IncomingMessage, "when extracting attachments" do
       IncomingMessage::UnableToExtractAttachments
     )
   end
+
+  it 'raises error if existing locked attachment will be deleted' do
+    incoming_message = FactoryBot.create(:incoming_message)
+    foi_attachment = incoming_message.foi_attachments.first
+    foi_attachment.update(locked: true, hexdigest: '123')
+
+    expect { incoming_message.extract_attachments! }.to raise_error(
+      IncomingMessage::UnableToExtractAttachments
+    )
+  end
 end
 
 RSpec.describe IncomingMessage, 'when getting the body of a message for html display' do

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1454,13 +1454,26 @@ RSpec.describe InfoRequest do
     let(:info_request) { FactoryBot.create(:info_request_with_plain_incoming) }
     let(:attachment) { info_request.foi_attachments.first }
 
-    before { attachment.update(masked_at: Time.zone.now) }
+    context 'attachment unlocked' do
+      before { attachment.update(locked: false, masked_at: Time.zone.now) }
 
-    it 'sets attachments masked_at to nil' do
-      expect { info_request.clear_attachment_masks! }.to change {
-        attachment.reload
-        attachment.masked_at
-      }.from(Time).to(nil)
+      it 'sets attachments masked_at to nil' do
+        expect { info_request.clear_attachment_masks! }.to change {
+          attachment.reload
+          attachment.masked_at
+        }.from(Time).to(nil)
+      end
+    end
+
+    context 'attachment locked' do
+      before { attachment.update(locked: true, masked_at: Time.zone.now) }
+
+      it 'does not set attachments masked_at to nil' do
+        expect { info_request.clear_attachment_masks! }.to_not change {
+          attachment.reload
+          attachment.masked_at
+        }.from(Time)
+      end
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8622

## What does this do?

Add attachment locking

## Why was this needed?

Easier admin and better compliance with GDPR requests. This will open the door to allow us to delete raw emails so we can fully remove PII.
