### PR TITLE
[#8624] Attachment locking - main body masking

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -142,6 +142,11 @@ body.admin {
     border-color: #771414;
   }
 
+  i.icon-foi-attachment--locked {
+    @include prominence_icon;
+    @extend .icon-lock;
+  }
+
   body.admin blockquote p {
     font-size: 13px;
     display: inline;

--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -15,7 +15,14 @@ class Admin::FoiAttachmentsController < AdminController
       )
       @foi_attachment.expire
 
-      flash[:notice] = 'Attachment successfully updated.'
+      if @foi_attachment.locked? && !@foi_attachment.masked?
+        flash[:notice] = <<~TXT.squish
+          Attachment successfully updated and locked. Please wait for masking to
+          complete before adding additional censor rules.
+        TXT
+      else
+        flash[:notice] = 'Attachment successfully updated.'
+      end
       redirect_to edit_admin_incoming_message_path(@incoming_message)
 
     else
@@ -26,7 +33,9 @@ class Admin::FoiAttachmentsController < AdminController
   private
 
   def foi_attachment_params
-    params.require(:foi_attachment).permit(:prominence, :prominence_reason)
+    params.require(:foi_attachment).permit(
+      :locked, :prominence, :prominence_reason
+    )
   end
 
   def set_foi_attachment

--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -34,7 +34,10 @@ class Admin::FoiAttachmentsController < AdminController
 
   def foi_attachment_params
     params.require(:foi_attachment).permit(
-      :locked, :prominence, :prominence_reason
+      :locked,
+      :replacement_body, :replacement_file,
+      :replaced_filename, :replaced_reason,
+      :prominence, :prominence_reason
     )
   end
 

--- a/app/helpers/admin/locked_helper.rb
+++ b/app/helpers/admin/locked_helper.rb
@@ -1,0 +1,11 @@
+##
+# Helpers for handling locked status of incoming messages or attachments in the
+# admin interface
+#
+module Admin::LockedHelper
+  def locked_icon(resource)
+    return unless resource.locked?
+
+    tag.i class: 'icon-foi-attachment--locked', title: 'locked'
+  end
+end

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -50,6 +50,8 @@ class FoiAttachment < ApplicationRecord
   before_destroy :delete_cached_file!
 
   scope :binary, -> { where.not(content_type: AlaveteliTextMasker::TextMask) }
+  scope :locked, -> { where(locked: true) }
+  scope :unlocked, -> { where(locked: false) }
 
   delegate :expire, :log_event, to: :info_request
   delegate :metadata, to: :file_blob, allow_nil: true

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20230717201410
+# Schema version: 20250304205550
 #
 # Table name: foi_attachments
 #
@@ -17,6 +17,7 @@
 #  prominence            :string           default("normal")
 #  prominence_reason     :text
 #  masked_at             :datetime
+#  locked                :boolean          default(FALSE)
 #
 
 # models/foi_attachment.rb:

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20250304205550
+# Schema version: 20250408105243
 #
 # Table name: foi_attachments
 #
@@ -18,6 +18,8 @@
 #  prominence_reason     :text
 #  masked_at             :datetime
 #  locked                :boolean          default(FALSE)
+#  replaced_at           :datetime
+#  replaced_reason       :string
 #
 
 # models/foi_attachment.rb:
@@ -36,6 +38,10 @@ class FoiAttachment < ApplicationRecord
 
   MissingAttachment = Class.new(StandardError)
 
+  attribute :replacement_file
+  attribute :replacement_body, :string
+  attribute :replaced_filename, :string
+
   belongs_to :incoming_message, inverse_of: :foi_attachments, optional: true
   has_one :info_request, through: :incoming_message, source: :info_request
   has_one :raw_email, through: :incoming_message, source: :raw_email
@@ -45,9 +51,13 @@ class FoiAttachment < ApplicationRecord
   validates_presence_of :content_type
   validates_presence_of :filename
   validates_presence_of :display_size
+  validates :replaced_filename, absence: true, unless: :replacing_or_replaced?
+  validates :replaced_reason, absence: true, unless: :replacing_or_replaced?
+  validates :replaced_reason, presence: true, if: :replacing_or_replaced?
 
   before_validation :ensure_filename!, only: [:filename]
   before_save :handle_locked
+  before_save :handle_replacements
   before_destroy :delete_cached_file!
 
   scope :binary, -> { where.not(content_type: AlaveteliTextMasker::TextMask) }
@@ -272,12 +282,20 @@ class FoiAttachment < ApplicationRecord
   def update_and_log_event(event: {}, **params)
     return false unless update(params)
 
+    replaced = locked? && (
+               replacement_body_previously_changed? ||
+               replacement_file_previously_changed?)
+
     log_event(
       'edit_attachment',
       event.merge(
         attachment_id: id,
         old_locked: locked_previously_was,
         locked: locked,
+        replaced: replaced,
+        replaced_at: replaced ? replaced_at : nil,
+        replaced_filename: replaced ? filename : nil,
+        replaced_reason: replaced ? replaced_reason : nil,
         old_prominence: prominence_previously_was,
         prominence: prominence,
         old_prominence_reason: prominence_reason_previously_was,
@@ -292,6 +310,33 @@ class FoiAttachment < ApplicationRecord
 
   def unlocking?
     !locked? && locked_changed?
+  end
+
+  def replacing?
+    !unlocking? && (replacement_file_changed? || replacement_body_changed?)
+  end
+
+  def replaced?
+    replaced_at.present?
+  end
+
+  def replacing_or_replaced?
+    replacing? || replaced?
+  end
+
+  def replaced_filename
+    return filename if replaced? && !replaced_filename_changed?
+
+    super
+  end
+
+  def replacement_body
+    super || body
+  end
+
+  def replacement_body=(new_replacement_body)
+    super unless normalize_line_endings(new_replacement_body) ==
+                 normalize_line_endings(body)
   end
 
   private
@@ -334,12 +379,50 @@ class FoiAttachment < ApplicationRecord
   end
 
   def handle_locked
+    if unlocking? && replaced?
+      file_blob.upload(StringIO.new(unmasked_body), identify: false)
+      file_blob.save
+
+      self.replaced_at = nil
+      self.replaced_reason = nil
+    end
+
     if unlocking?
       self.masked_at = nil
+      self.filename = mail_attributes[:filename]
+      ensure_filename!
     end
 
     if locking? || unlocking?
       FoiAttachmentMaskJob.perform_later(self) unless masked_at
+    end
+
+    true
+  end
+
+  def handle_replacements
+    if replacing? || (replaced? && replaced_filename_changed?)
+      self.filename = replaced_filename.presence ||
+                      replacement_file&.original_filename ||
+                      mail_attributes[:filename]
+      ensure_filename!
+    end
+
+    if replacing?
+      self.replaced_at = Time.zone.now
+      self.masked_at = Time.zone.now
+      self.locked = true
+
+      if replacement_file_changed?
+        file.attach(
+          io: replacement_file,
+          filename: filename,
+          content_type: content_type
+        )
+      elsif replacement_body_changed?
+        file_blob.upload(StringIO.new(replacement_body), identify: false)
+        file_blob.save
+      end
     end
 
     true

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -556,7 +556,6 @@ class IncomingMessage < ApplicationRecord
   # Returns text version of attachment text
   def get_attachment_text_full
     text = _get_attachment_text_internal
-    text = apply_masks(text, 'text/html')
 
     # This can be useful for memory debugging
     #STDOUT.puts 'xxx '+ MySociety::DebugHelpers::allocated_string_size_around_gc
@@ -592,6 +591,7 @@ class IncomingMessage < ApplicationRecord
         attachment.content_type, attachment.default_body, attachment.charset
       )
       text = convert_string_to_utf8(text, 'UTF-8').string
+      text = apply_masks(text, 'text/html')
 
       memo += text
     }

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -473,17 +473,17 @@ class IncomingMessage < ApplicationRecord
 
     # Purge old public attachments that will be rebuilt with a new hexdigest
     old_attachments = (foi_attachments - attachments)
-    hidden_old_attachments = old_attachments.reject { _1.is_public? }
 
-    if hidden_old_attachments.any?
-      # if there are hidden attachments error as we don't want to re-build and
-      # lose the prominence as this will make them public
+    non_public_old_attachments = old_attachments.reject(&:is_public?)
+    if non_public_old_attachments.any?
+      # if there are non public attachments error as we don't want to re-build
+      # and lose the prominence as this will make them public
       raise UnableToExtractAttachments, "unable to extract attachments due " \
         "to prominence of attachments " \
-        "(ID=#{hidden_old_attachments.map(&:id).join(', ')})"
-    else
-      old_attachments.each(&:mark_for_destruction)
+        "(ID=#{non_public_old_attachments.map(&:id).join(', ')})"
     end
+
+    old_attachments.each(&:mark_for_destruction)
   end
 
   # Returns body text as HTML with quotes flattened, and emails removed.

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -653,6 +653,10 @@ class IncomingMessage < ApplicationRecord
     refusals.any?
   end
 
+  def locked?
+    foi_attachments.locked.any?
+  end
+
   private
 
   def legislation_references

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -310,7 +310,7 @@ class IncomingMessage < ApplicationRecord
     end
 
     # apply masks for this message
-    text = apply_masks(text, 'text/html')
+    text = apply_masks(text, 'text/html') unless get_main_body_text_part&.locked?
 
     # Remove existing quoted sections
     folded_quoted_text = remove_lotus_quoting(text, 'FOLDED_QUOTED_SECTION')
@@ -591,7 +591,7 @@ class IncomingMessage < ApplicationRecord
         attachment.content_type, attachment.default_body, attachment.charset
       )
       text = convert_string_to_utf8(text, 'UTF-8').string
-      text = apply_masks(text, 'text/html')
+      text = apply_masks(text, 'text/html') unless attachment.locked?
 
       memo += text
     }

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -483,6 +483,15 @@ class IncomingMessage < ApplicationRecord
         "(ID=#{non_public_old_attachments.map(&:id).join(', ')})"
     end
 
+    locked_old_attachments = old_attachments.select(&:locked?)
+    if locked_old_attachments.any?
+      # if there are locked attachments error as we don't want to re-build and
+      # lose any changes made outside Alaveteli
+      raise UnableToExtractAttachments, "unable to extract attachments due " \
+        "to locked attachments " \
+        "(ID=#{locked_old_attachments.map(&:id).join(', ')})"
+    end
+
     old_attachments.each(&:mark_for_destruction)
   end
 

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -583,19 +583,18 @@ class IncomingMessage < ApplicationRecord
     cached_attachment_text_clipped
   end
 
-  def _extract_text
+  def _get_attachment_text_internal
     # Extract text from each attachment
     get_attachments_for_display.reduce('') { |memo, attachment|
       return memo if Ability.guest.cannot?(:read, attachment)
 
-      memo += MailHandler.get_attachment_text_one_file(attachment.content_type,
-                                                       attachment.default_body,
-                                                       attachment.charset)
-    }
-  end
+      text = MailHandler.get_attachment_text_one_file(
+        attachment.content_type, attachment.default_body, attachment.charset
+      )
+      text = convert_string_to_utf8(text, 'UTF-8').string
 
-  def _get_attachment_text_internal
-    convert_string_to_utf8(_extract_text, 'UTF-8').string
+      memo += text
+    }
   end
 
   # Returns text for indexing

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -845,7 +845,7 @@ class InfoRequest < ApplicationRecord
   end
 
   def clear_attachment_masks!
-    foi_attachments.update_all(masked_at: nil)
+    foi_attachments.unlocked.update_all(masked_at: nil)
   end
 
   # Removes anything cached about the object in the database, and saves

--- a/app/views/admin/foi_attachments/edit.html.erb
+++ b/app/views/admin/foi_attachments/edit.html.erb
@@ -19,29 +19,29 @@
   </tbody>
 </table>
 
-<%= form_tag admin_foi_attachment_path(@foi_attachment), method: 'put', class: 'form form-inline' do %>
+<%= form_for [:admin, @foi_attachment], class: 'form form-inline' do |f| %>
   <fieldset class="form-horizontal">
     <legend>Prominence</legend>
 
     <div class="control-group">
-      <label class="control-label" for="foi_attachment_prominence">Prominence</label>
+      <%= f.label :prominence, class: 'control-label' %>
 
       <div class="controls">
-        <%= select 'foi_attachment', 'prominence', FoiAttachment.prominence_states %>
+        <%= f.select :prominence, FoiAttachment.prominence_states %>
       </div>
     </div>
 
     <div class="control-group">
-      <label class="control-label" for="foi_attachment_prominence_reason">Reason for prominence</label>
+      <%= f.label :prominence_reason, 'Reason for prominence', class: 'control-label' %>
 
       <div class="controls">
-        <%= text_area 'foi_attachment', 'prominence_reason', rows: 5, class: 'span6' %>
+        <%= f.text_area :prominence_reason, rows: 5, class: 'span6' %>
       </div>
     </div>
   </fieldset>
 
   <div class="form-actions">
-    <%= submit_tag 'Save', class: 'btn btn-success' %>
+    <%= f.submit 'Save', class: 'btn btn-success' %>
   </div>
 <% end %>
 

--- a/app/views/admin/foi_attachments/edit.html.erb
+++ b/app/views/admin/foi_attachments/edit.html.erb
@@ -53,8 +53,11 @@
 
         <strong>When unlocking an attachment:</strong>
         <ol>
+          <li>Replaced attachment will revert back to the original copy</li>
           <li>All applicable censor rules will be applied</li>
         </ol>
+
+        <strong>When replacing the attachment locking will be enabled.</strong>
       </p>
     </div>
 
@@ -63,6 +66,43 @@
 
       <div class="controls">
         <%= f.check_box :locked %>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <%= f.label :replacement_file, class: 'control-label' %>
+
+      <div class="controls">
+        <%= f.file_field :replacement_file %>
+      </div>
+    </div>
+
+    <% if @foi_attachment.main_body_part? %>
+      <div class="control-group">
+        <%= f.label :replacement_body, class: 'control-label' %>
+
+        <div class="controls">
+          <%= f.text_area :replacement_body, rows: 5, class: 'span6' %>
+        </div>
+      </div>
+    <% else %>
+      <div class="control-group">
+        <%= f.label :replaced_filename, class: 'control-label' %>
+
+        <div class="controls">
+          <%= f.text_field :replaced_filename %>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="control-group">
+      <%= f.label :replaced_reason, class: 'control-label' %>
+
+      <div class="controls">
+        <%= f.text_field :replaced_reason %>
+        <span class="help-inline">
+          Private reason why attachment as been replaced, such as GDPR case reference
+        </span>
       </div>
     </div>
   </fieldset>

--- a/app/views/admin/foi_attachments/edit.html.erb
+++ b/app/views/admin/foi_attachments/edit.html.erb
@@ -40,6 +40,33 @@
     </div>
   </fieldset>
 
+  <fieldset class="form-horizontal">
+    <legend>Locking and replacement</legend>
+
+    <div class="controls">
+      <p class="help-block">
+        <strong>When locking an attachment:</strong>
+        <ol>
+          <li>Attachment will be preserved with current applicable censor rules applied</li>
+          <li>New censor rules will not be applied</li>
+        </ol>
+
+        <strong>When unlocking an attachment:</strong>
+        <ol>
+          <li>All applicable censor rules will be applied</li>
+        </ol>
+      </p>
+    </div>
+
+    <div class="control-group">
+      <%= f.label :locked, class: 'control-label' %>
+
+      <div class="controls">
+        <%= f.check_box :locked %>
+      </div>
+    </div>
+  </fieldset>
+
   <div class="form-actions">
     <%= f.submit 'Save', class: 'btn btn-success' %>
   </div>

--- a/app/views/admin_incoming_message/_foi_attachments.html.erb
+++ b/app/views/admin_incoming_message/_foi_attachments.html.erb
@@ -16,6 +16,7 @@
           <tr>
             <td>
               <%= both_links attachment %>
+              <%= locked_icon attachment %>
 
               <% if attachment.main_body_part? %>
                 <span class="label">Main Body</span>

--- a/app/views/admin_incoming_message/_foi_attachments.html.erb
+++ b/app/views/admin_incoming_message/_foi_attachments.html.erb
@@ -21,6 +21,9 @@
               <% if attachment.main_body_part? %>
                 <span class="label">Main Body</span>
               <% end %>
+              <% if attachment.replaced? %>
+                <span class="label">Replaced</span>
+              <% end %>
             </td>
             <td><tt><%= attachment.content_type %></tt></td>
             <td><tt><%= attachment.hexdigest %></tt></td>

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -334,6 +334,7 @@
         <a href="#incoming_<%=incoming_message.id%>" data-toggle="collapse" data-parent="#incoming_messages"><%= chevron_right %></a>
         <%= check_box_tag "message_id_#{incoming_message.id}", incoming_message.id, false, :class => "delete-checkbox" %>
         <%= both_links(incoming_message) %>
+        <%= locked_icon(incoming_message) %>
 
         <span class="muted">
           --

--- a/db/migrate/20250304205550_add_locked_to_foi_attachments.rb
+++ b/db/migrate/20250304205550_add_locked_to_foi_attachments.rb
@@ -1,0 +1,5 @@
+class AddLockedToFoiAttachments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :foi_attachments, :locked, :boolean, default: false
+  end
+end

--- a/db/migrate/20250408105243_add_replaced_at_and_replaced_reason_to_foi_attachments.rb
+++ b/db/migrate/20250408105243_add_replaced_at_and_replaced_reason_to_foi_attachments.rb
@@ -1,0 +1,6 @@
+class AddReplacedAtAndReplacedReasonToFoiAttachments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :foi_attachments, :replaced_at, :datetime
+    add_column :foi_attachments, :replaced_reason, :string
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Highlighted Features
 
-* Add attachment locking (Graeme Porteous)
+* Add attachment locking and replacement (Graeme Porteous)
 * Improve citation form field width (Gareth Rees)
 * Add report link to user profile pages (Gareth Rees)
 * Only list users who have made requests in search (Gareth Rees)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add attachment locking (Graeme Porteous)
 * Improve citation form field width (Gareth Rees)
 * Add report link to user profile pages (Gareth Rees)
 * Only list users who have made requests in search (Gareth Rees)
@@ -13,6 +14,10 @@
 * Add additional InfoRequest embargo scopes (Graeme Porteous)
 
 ## Upgrade Notes
+
+* _Required:_ There are some database structure updates so remember to run:
+
+      bin/rails db:migrate
 
 * _Recommended:_ This release limits user indexing to users who've made requests
 to prevent users stumbling across spam user profiles via the on-site search.

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -393,15 +393,15 @@ module MailHandler
         end
       end
 
-      def attachment_body_for_hexdigest(mail, hexdigest:)
+      def attachment_attributes_for_hexdigest(mail, hexdigest:)
         attributes = get_attachment_attributes(mail).find do |attrs|
           attrs[:hexdigest] == hexdigest
         end
 
-        return attributes.fetch(:body) if attributes
-
-        raise MismatchedAttachmentHexdigest,
+        attributes || raise(
+          MismatchedAttachmentHexdigest,
           "can't find attachment matching hexdigest: #{hexdigest}"
+        )
       end
 
       def attempt_to_find_original_attachment_attributes(mail, body:, nested: false)

--- a/lib/normalize_string.rb
+++ b/lib/normalize_string.rb
@@ -4,6 +4,10 @@ require "net/imap"
 class EncodingNormalizationError < StandardError
 end
 
+def normalize_line_endings(text)
+  text.gsub(/\r\n?/, "\n") # Converts Windows line endings to Unix line endings
+end
+
 def normalize_string_to_utf8(s, suggested_character_encoding=nil)
   # Make a list of encodings to try:
   to_try = []

--- a/spec/factories/foi_attchments.rb
+++ b/spec/factories/foi_attchments.rb
@@ -24,6 +24,14 @@ FactoryBot.define do
       masked_at { nil }
     end
 
+    trait :locked do
+      locked { true }
+    end
+
+    trait :unlocked do
+      locked { false }
+    end
+
     factory :body_text do
       content_type { 'text/plain' }
       body { 'hereisthetext' }

--- a/spec/factories/foi_attchments.rb
+++ b/spec/factories/foi_attchments.rb
@@ -32,6 +32,25 @@ FactoryBot.define do
       locked { false }
     end
 
+    trait :replaced do
+      locked { true }
+      masked_at { 12.hours.ago }
+      replaced_at { 12.hours.ago }
+      replaced_reason { 'GDPR case' }
+
+      transient do
+        replacement_body { 'Replacement body' }
+      end
+
+      after(:build) do |foi_attachment, evaluator|
+        foi_attachment.file.attach(
+          io: StringIO.new(evaluator.replacement_body),
+          filename: foi_attachment.filename,
+          content_type: foi_attachment.content_type
+        )
+      end
+    end
+
     factory :body_text do
       content_type { 'text/plain' }
       body { 'hereisthetext' }

--- a/spec/factories/incoming_messages.rb
+++ b/spec/factories/incoming_messages.rb
@@ -57,6 +57,10 @@ FactoryBot.define do
       prominence { 'hidden' }
     end
 
+    trait :with_text_attachment do
+      foi_attachments_factories { [[:body_text]] }
+    end
+
     trait :with_html_attachment do
       foi_attachments_factories { [[:html_attachment]] }
     end

--- a/spec/helpers/admin/locked_helper_spec.rb
+++ b/spec/helpers/admin/locked_helper_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe Admin::LockedHelper do
+  describe '#locked_icon' do
+    subject { helper.locked_icon(resource) }
+
+    context 'the resource is unsupported' do
+      let(:resource) { User.new }
+
+      it 'raises an NoMethodError' do
+        expect { subject }.to raise_error(NoMethodError)
+      end
+    end
+
+    context 'with an locked IncomingMessage' do
+      let(:resource) { FactoryBot.create(:incoming_message) }
+      before { allow(resource).to receive(:locked?).and_return(true) }
+      it { is_expected.to include('icon-foi-attachment--locked') }
+    end
+
+    context 'with an unlocked IncomingMessage' do
+      let(:resource) { FactoryBot.create(:incoming_message) }
+      it { is_expected.to be_nil }
+    end
+
+    context 'with an locked FoiAttachment' do
+      let(:resource) { FactoryBot.create(:body_text, locked: true) }
+      it { is_expected.to include('icon-foi-attachment--locked') }
+    end
+
+    context 'with an unlocked FoiAttachment' do
+      let(:resource) { FactoryBot.create(:body_text, locked: false) }
+      it { is_expected.to be_nil }
+    end
+  end
+end

--- a/spec/lib/basic_encoding_spec.rb
+++ b/spec/lib/basic_encoding_spec.rb
@@ -65,6 +65,35 @@ gb_18030_bytes = [ 0xb9, 0xf3, 0xb9, 0xab, 0xcb, 0xbe, 0xb8, 0xba, 0xd4, 0xf0,
 
 gb_18030_spam_string = bytes_to_binary_string gb_18030_bytes
 
+RSpec.describe '#normalize_line_endings' do
+  it 'converts Windows line endings (CRLF) to Unix line endings (LF)' do
+    windows_text = "Line 1\r\nLine 2\r\nLine 3"
+    expected_unix_text = "Line 1\nLine 2\nLine 3"
+
+    expect(normalize_line_endings(windows_text)).to eq(expected_unix_text)
+  end
+
+  it 'converts old Mac line endings (CR) to Unix line endings (LF)' do
+    old_mac_text = "Line 1\rLine 2\rLine 3"
+    expected_unix_text = "Line 1\nLine 2\nLine 3"
+
+    expect(normalize_line_endings(old_mac_text)).to eq(expected_unix_text)
+  end
+
+  it 'leaves Unix line endings unchanged' do
+    unix_text = "Line 1\nLine 2\nLine 3"
+
+    expect(normalize_line_endings(unix_text)).to eq(unix_text)
+  end
+
+  it 'handles mixed line endings' do
+    mixed_text = "Line 1\nLine 2\r\nLine 3\rLine 4"
+    expected_unix_text = "Line 1\nLine 2\nLine 3\nLine 4"
+
+    expect(normalize_line_endings(mixed_text)).to eq(expected_unix_text)
+  end
+end
+
 RSpec.describe "normalize_string_to_utf8" do
   describe "when passed uniterpretable character data" do
     it "should reject it as invalid" do

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -379,7 +379,7 @@ when it really should be application/pdf.\n
     end
   end
 
-  describe 'attachment_body_for_hexdigest' do
+  describe 'attachment_attributes_for_hexdigest' do
     let(:mail) do
       Mail.new do
         add_file filename: 'file.txt', content: 'hereisthetext'
@@ -387,19 +387,24 @@ when it really should be application/pdf.\n
     end
 
     context 'matching hexdigest' do
-      it 'returns the body of the attachment' do
-        body = attachment_body_for_hexdigest(
-          mail, hexdigest: Digest::MD5.hexdigest('hereisthetext')
+      it 'returns the attributes of the attachment' do
+        hexdigest = Digest::MD5.hexdigest('hereisthetext')
+        attributes = attachment_attributes_for_hexdigest(
+          mail, hexdigest: hexdigest
         )
 
-        expect(body).to eq('hereisthetext')
+        expect(attributes).to include(
+          body: 'hereisthetext',
+          filename: 'file.txt',
+          hexdigest: hexdigest
+        )
       end
     end
 
     context 'non-matching hexdigest' do
       it 'raises MismatchedAttachmentHexdigest error' do
         expect {
-          attachment_body_for_hexdigest(mail, hexdigest: 'incorrect')
+          attachment_attributes_for_hexdigest(mail, hexdigest: 'incorrect')
         }.to raise_error(MailHandler::MismatchedAttachmentHexdigest)
       end
     end

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -317,8 +317,8 @@ RSpec.describe FoiAttachment do
 
     context 'when mail handler finds original attachment by hexdigest' do
       before do
-        allow(MailHandler).to receive(:attachment_body_for_hexdigest).
-          and_return('hereistheunmaskedtext')
+        allow(MailHandler).to receive(:attachment_attributes_for_hexdigest).
+          and_return(body: 'hereistheunmaskedtext')
       end
 
       it 'returns the attachment body from the raw email' do

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe FoiAttachment do
     it { is_expected.to match_array(binary_attachments) }
   end
 
+  describe '.locked' do
+    subject { described_class.locked }
+
+    let!(:unlocked_attachment) { FactoryBot.create(:body_text) }
+    let!(:locked_attachment) { FactoryBot.create(:body_text, locked: true) }
+
+    it { is_expected.to include(locked_attachment) }
+    it { is_expected.to_not include(unlocked_attachment) }
+  end
+
+  describe '.unlocked' do
+    subject { described_class.unlocked }
+
+    let!(:unlocked_attachment) { FactoryBot.create(:body_text) }
+    let!(:locked_attachment) { FactoryBot.create(:body_text, locked: true) }
+
+    it { is_expected.to_not include(locked_attachment) }
+    it { is_expected.to include(unlocked_attachment) }
+  end
+
   describe '.cached_urls' do
     it 'includes the correct paths' do
       att = FactoryBot.create(:jpeg_attachment)

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20230717201410
+# Schema version: 20250304205550
 #
 # Table name: foi_attachments
 #
@@ -17,6 +17,7 @@
 #  prominence            :string           default("normal")
 #  prominence_reason     :text
 #  masked_at             :datetime
+#  locked                :boolean          default(FALSE)
 #
 
 require 'spec_helper'

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -479,6 +479,12 @@ RSpec.describe IncomingMessage do
         expect(message.get_attachment_text_full).to include('[REDACTED]')
         expect(message.get_attachment_text_full).not_to include('hide_me')
       end
+
+      it 'does not apply censor rules to the attachment text if locked' do
+        allow(message.foi_attachments.last).to receive(:locked?).and_return(true)
+        expect(message.get_attachment_text_full).not_to include('[REDACTED]')
+        expect(message.get_attachment_text_full).to include('hide_me')
+      end
     end
   end
 
@@ -518,6 +524,12 @@ RSpec.describe IncomingMessage do
       it 'applies censor rules to the attachment text' do
         expect(message.get_attachment_text_clipped).to include('[REDACTED]')
         expect(message.get_attachment_text_clipped).not_to include('hide_me')
+      end
+
+      it 'does not apply censor rules to the attachment text if locked' do
+        allow(message.foi_attachments.last).to receive(:locked?).and_return(true)
+        expect(message.get_attachment_text_full).not_to include('[REDACTED]')
+        expect(message.get_attachment_text_full).to include('hide_me')
       end
     end
   end
@@ -1252,6 +1264,12 @@ RSpec.describe IncomingMessage, 'when getting the main body text' do
     it 'applies censor rules to the main body text' do
       expect(message.get_main_body_text_unfolded).to include('[REDACTED]')
       expect(message.get_main_body_text_unfolded).not_to include('hide_me')
+    end
+
+    it 'does not apply censor rules to the main body text if locked' do
+      allow(message.get_main_body_text_part).to receive(:locked?).and_return(true)
+      expect(message.get_main_body_text_unfolded).not_to include('[REDACTED]')
+      expect(message.get_main_body_text_unfolded).to include('hide_me')
     end
   end
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -448,7 +448,7 @@ RSpec.describe IncomingMessage do
     end
   end
 
-  describe '#_extract_text' do
+  describe '#_get_attachment_text_internal' do
     it 'does not generate incompatible character encodings' do
       message = FactoryBot.create(:incoming_message)
       FactoryBot.create(:body_text,
@@ -461,7 +461,7 @@ RSpec.describe IncomingMessage do
                         url_part_number: 3)
       message.reload
 
-      expect { message._extract_text }.
+      expect { message._get_attachment_text_internal }.
         to_not raise_error
     end
   end
@@ -1084,8 +1084,9 @@ RSpec.describe IncomingMessage, "when extracting attachments" do
   end
 
   it 'makes invalid utf-8 encoded attachment text valid when string responds to encode' do
-    im = incoming_messages(:useless_incoming_message)
-    allow(im).to receive(:_extract_text).and_return("\xBF")
+    im = FactoryBot.create(:incoming_message, :with_text_attachment)
+    allow(im.foi_attachments.last).to receive(:default_body).
+      and_return("\xBF")
 
     expect(im._get_attachment_text_internal.valid_encoding?).to be true
   end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -534,6 +534,24 @@ RSpec.describe IncomingMessage do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe '#locked?' do
+    subject { message.locked? }
+
+    let(:message) { FactoryBot.build(:incoming_message) }
+
+    context 'if there are locked attachments' do
+      before do
+        FactoryBot.create(:body_text, incoming_message: message, locked: true)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'if there are no locked attachments' do
+      it { is_expected.to eq(false) }
+    end
+  end
 end
 
 RSpec.describe IncomingMessage, "when the prominence is changed" do

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -1089,6 +1089,16 @@ RSpec.describe IncomingMessage, "when extracting attachments" do
       IncomingMessage::UnableToExtractAttachments
     )
   end
+
+  it 'raises error if existing locked attachment will be deleted' do
+    incoming_message = FactoryBot.create(:incoming_message)
+    foi_attachment = incoming_message.foi_attachments.first
+    foi_attachment.update(locked: true, hexdigest: '123')
+
+    expect { incoming_message.extract_attachments! }.to raise_error(
+      IncomingMessage::UnableToExtractAttachments
+    )
+  end
 end
 
 RSpec.describe IncomingMessage, 'when getting the body of a message for html display' do

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -1085,7 +1085,7 @@ RSpec.describe IncomingMessage, "when extracting attachments" do
 
   it 'makes invalid utf-8 encoded attachment text valid when string responds to encode' do
     im = incoming_messages(:useless_incoming_message)
-    allow(im).to receive(:extract_text).and_return("\xBF")
+    allow(im).to receive(:_extract_text).and_return("\xBF")
 
     expect(im._get_attachment_text_internal.valid_encoding?).to be true
   end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1454,13 +1454,26 @@ RSpec.describe InfoRequest do
     let(:info_request) { FactoryBot.create(:info_request_with_plain_incoming) }
     let(:attachment) { info_request.foi_attachments.first }
 
-    before { attachment.update(masked_at: Time.zone.now) }
+    context 'attachment unlocked' do
+      before { attachment.update(locked: false, masked_at: Time.zone.now) }
 
-    it 'sets attachments masked_at to nil' do
-      expect { info_request.clear_attachment_masks! }.to change {
-        attachment.reload
-        attachment.masked_at
-      }.from(Time).to(nil)
+      it 'sets attachments masked_at to nil' do
+        expect { info_request.clear_attachment_masks! }.to change {
+          attachment.reload
+          attachment.masked_at
+        }.from(Time).to(nil)
+      end
+    end
+
+    context 'attachment locked' do
+      before { attachment.update(locked: true, masked_at: Time.zone.now) }
+
+      it 'does not set attachments masked_at to nil' do
+        expect { info_request.clear_attachment_masks! }.to_not change {
+          attachment.reload
+          attachment.masked_at
+        }.from(Time)
+      end
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8624

## What does this do?

Ensures locked attachments aren't masked when caching the main body part in the incoming message instance or when indexing attachments in Xapian.

## Why was this needed?

Easier admin and better compliance with GDPR requests. This will open the door to allow us to delete raw emails so we can fully remove PII.