### PR TITLE
[#8663] Update FoiAttachment default replacement body

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -331,7 +331,7 @@ class FoiAttachment < ApplicationRecord
   end
 
   def replacement_body
-    super || body
+    super || normalize_string_to_utf8(body)
   end
 
   def replacement_body=(new_replacement_body)

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -730,6 +730,31 @@ RSpec.describe FoiAttachment do
     end
   end
 
+  describe '#replacement_body' do
+    let(:foi_attachment) { FactoryBot.create(:body_text) }
+
+    before do
+      allow(foi_attachment).to receive(:body).and_return('hello'.b)
+    end
+
+    context 'when set' do
+      it 'returns the set value' do
+        foi_attachment.replacement_body = 'goodbye'
+        expect(foi_attachment.replacement_body).to eq('goodbye')
+      end
+    end
+
+    context 'when unset' do
+      it 'returns the original body' do
+        expect(foi_attachment.replacement_body).to eq('hello')
+      end
+
+      it 'returns a UTF-8 string of the original body' do
+        expect(foi_attachment.replacement_body.is_utf8?).to eq(true)
+      end
+    end
+  end
+
   describe '#replacement_body=' do
     let(:foi_attachment) { FactoryBot.create(:body_text) }
     let(:original_body) { "Original content\n" }


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8663

## What does this do?

Update FoiAttachment default replacement body

## Why was this needed?

This should always be a UTF-8 string. Without this exceptions were being
raised on the admin attachment edit view as we were rendering both
binary and UTF-8 strings.

<hr>

[skip changelog]