### PR TITLE
Only send clarification notifications to recent requests

### DIFF
--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -425,6 +425,7 @@ class RequestMailer < ApplicationMailer
       alert_event_id = info_request.get_last_public_response_event_id
       last_response_message = info_request.get_last_public_response
       next if alert_event_id.nil?
+      next if last_response_message&.created_at < 3.months.ago
 
       # To the user who created the request
       sent_already = UserInfoRequestSentAlert.

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Only send clarification notifications to recent requests (Gareth Rees)
 * Improve citation form field width (Gareth Rees)
 * Add report link to user profile pages (Gareth Rees)
 * Only list users who have made requests in search (Gareth Rees)

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -1026,9 +1026,9 @@ RSpec.describe RequestMailer do
     end
 
     it "should send an alert" do
-      ir = info_requests(:fancy_dog_request)
-      ir.set_described_state('waiting_clarification')
-      force_updated_at_to_past(ir)
+      info_request = info_requests(:fancy_dog_request)
+      info_request.set_described_state('waiting_clarification')
+      force_updated_at_to_past(info_request)
 
       RequestMailer.alert_not_clarified_request
 
@@ -1042,17 +1042,17 @@ RSpec.describe RequestMailer do
 
       expect(mail_url).to match(
         new_request_incoming_followup_path(
-          ir.url_title,
-          incoming_message_id: ir.incoming_messages.last.id
+          info_request.url_title,
+          incoming_message_id: info_request.incoming_messages.last.id
         )
       )
     end
 
     it "skips requests that don't have a public last response" do
-      ir = info_requests(:fancy_dog_request)
-      ir.set_described_state('waiting_clarification')
+      info_request = info_requests(:fancy_dog_request)
+      info_request.set_described_state('waiting_clarification')
 
-      im = ir.incoming_messages.last
+      im = info_request.incoming_messages.last
       old_prominence = im.prominence
       im.update(prominence: 'hidden')
       im.info_request.log_event(
@@ -1065,20 +1065,20 @@ RSpec.describe RequestMailer do
         prominence_reason: 'test'
       )
 
-      force_updated_at_to_past(ir)
+      force_updated_at_to_past(info_request)
       RequestMailer.alert_not_clarified_request
 
       expect(ActionMailer::Base.deliveries.size).to eq(0)
     end
 
     it "should not send an alert to banned users" do
-      ir = info_requests(:fancy_dog_request)
-      ir.set_described_state('waiting_clarification')
+      info_request = info_requests(:fancy_dog_request)
+      info_request.set_described_state('waiting_clarification')
 
-      ir.user.ban_text = 'Banned'
-      ir.user.save!
+      info_request.user.ban_text = 'Banned'
+      info_request.user.save!
 
-      force_updated_at_to_past(ir)
+      force_updated_at_to_past(info_request)
 
       RequestMailer.alert_not_clarified_request
 

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -1049,6 +1049,23 @@ RSpec.describe RequestMailer do
       end
     end
 
+    context "when request has needed clarification for over 3 months ago" do
+      let(:info_request) do
+        FactoryBot.create(:info_request, :with_incoming, :waiting_clarification)
+      end
+
+      before do
+        last_incoming_message.update(created_at: 3.months.ago)
+      end
+
+      it "should not send an alert" do
+        RequestMailer.alert_not_clarified_request
+
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(0)
+      end
+    end
+
     context "when request doesn't have a public last response" do
       let(:info_request) do
         FactoryBot.create(:info_request, :with_incoming, :waiting_clarification)

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -1017,20 +1017,19 @@ RSpec.describe RequestMailer do
   end
 
   describe "clarification required alerts" do
-    before(:each) do
-      load_raw_emails_data
-    end
+    let(:info_request) { FactoryBot.create(:info_request) }
 
-    def force_updated_at_to_past(request)
-      request.update_column(:updated_at, Time.zone.now - 5.days)
+    before do
+      load_raw_emails_data
+      info_request.update_column(:updated_at, Time.zone.now - 5.days)
     end
 
     context "when request needs clarification" do
-      it "should send an alert" do
-        info_request = FactoryBot.create(:info_request, :with_incoming,
-                                         :waiting_clarification)
-        force_updated_at_to_past(info_request)
+      let(:info_request) do
+        FactoryBot.create(:info_request, :with_incoming, :waiting_clarification)
+      end
 
+      it "should send an alert" do
         RequestMailer.alert_not_clarified_request
 
         deliveries = ActionMailer::Base.deliveries
@@ -1051,11 +1050,11 @@ RSpec.describe RequestMailer do
     end
 
     context "when request doesn't have a public last response" do
-      it "should not send an alert" do
-        info_request = FactoryBot.create(:info_request, :with_incoming,
-                                         :waiting_clarification)
-        force_updated_at_to_past(info_request)
+      let(:info_request) do
+        FactoryBot.create(:info_request, :with_incoming, :waiting_clarification)
+      end
 
+      it "should not send an alert" do
         im = info_request.incoming_messages.last
         old_prominence = im.prominence
         im.update(prominence: 'hidden')
@@ -1076,11 +1075,12 @@ RSpec.describe RequestMailer do
     end
 
     context "when requester is banned" do
-      it "should not send an alert" do
-        info_request = FactoryBot.create(:info_request, :waiting_clarification,
-                                         user: FactoryBot.build(:user, :banned))
-        force_updated_at_to_past(info_request)
+      let(:info_request) do
+        FactoryBot.create(:info_request, :waiting_clarification,
+                          user: FactoryBot.build(:user, :banned))
+      end
 
+      it "should not send an alert" do
         RequestMailer.alert_not_clarified_request
 
         deliveries = ActionMailer::Base.deliveries
@@ -1089,11 +1089,11 @@ RSpec.describe RequestMailer do
     end
 
     context "when request is embargoed" do
-      it "should send alert" do
-        info_request = FactoryBot.create(:embargoed_request,
-                                         :waiting_clarification)
-        force_updated_at_to_past(info_request)
+      let(:info_request) do
+        FactoryBot.create(:embargoed_request, :waiting_clarification)
+      end
 
+      it "should send alert" do
         RequestMailer.alert_not_clarified_request
 
         deliveries = ActionMailer::Base.deliveries
@@ -1105,11 +1105,11 @@ RSpec.describe RequestMailer do
     end
 
     context 'when request has use_notifications enabled' do
-      it "should not send an alert" do
-        info_request = FactoryBot.create(:use_notifications_request,
-                                         :waiting_clarification)
-        force_updated_at_to_past(info_request)
+      let(:info_request) do
+        FactoryBot.create(:use_notifications_request, :waiting_clarification)
+      end
 
+      it "should not send an alert" do
         RequestMailer.alert_not_clarified_request
 
         deliveries = ActionMailer::Base.deliveries


### PR DESCRIPTION
If someone classifies an old request as needing clarification through the request game, the request author will get notified. After this period most authorities will have closed the case so clarification is not the best route.

