### PR TITLE
[#8600] Index users once they've made their first request

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -194,7 +194,7 @@ class InfoRequest < ApplicationRecord
   before_create :set_use_notifications
   before_validation :compute_idhash
   before_validation :set_law_used, on: :create
-  after_create :notify_public_body
+  after_create :notify_associations
   after_save :update_counter_cache
   after_update :reindex_request_events, if: :reindexable_attribute_changed?
   before_destroy :expire
@@ -1962,7 +1962,7 @@ class InfoRequest < ApplicationRecord
     end
   end
 
-  def notify_public_body
+  def notify_associations
     public_body.request_created
   end
 end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1964,5 +1964,6 @@ class InfoRequest < ApplicationRecord
 
   def notify_associations
     public_body.info_request_count_changed
+    user&.info_request_count_changed
   end
 end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -198,7 +198,7 @@ class InfoRequest < ApplicationRecord
   after_save :update_counter_cache
   after_update :reindex_request_events, if: :reindexable_attribute_changed?
   before_destroy :expire
-  after_destroy :update_counter_cache
+  after_destroy :notify_associations, :update_counter_cache
 
   # Return info request corresponding to an incoming email address, or nil if
   # none found. Checks the hash to ensure the email came from the public body -
@@ -1963,6 +1963,6 @@ class InfoRequest < ApplicationRecord
   end
 
   def notify_associations
-    public_body.request_created
+    public_body.info_request_count_changed
   end
 end

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -922,7 +922,7 @@ class PublicBody < ApplicationRecord
     ]
   end
 
-  def request_created
+  def info_request_count_changed
     update_not_many_requests_tag
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -680,6 +680,10 @@ class User < ApplicationRecord
     ]
   end
 
+  def info_request_count_changed
+    xapian_mark_needs_index
+  end
+
   private
 
   def email_and_name_are_valid

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -6,7 +6,8 @@
 * Only send clarification notifications to recent requests (Gareth Rees)
 * Improve citation form field width (Gareth Rees)
 * Add report link to user profile pages (Gareth Rees)
-* Only list users who have made requests in search (Gareth Rees)
+* Only list users who have made requests in search results (Gareth Rees, Graeme
+  Porteous)
 * Collect cancellation reasons when Pro users cancel their subscriptions (Graeme
   Porteous)
 * Removed `old_unclassified_updated` email (Graeme Porteous)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1408,6 +1408,11 @@ RSpec.describe InfoRequest do
       expect { info_request.destroy }.
         to change(AlaveteliPro::Embargo, :count).by(-1)
     end
+
+    it 'notifies the public body' do
+      expect(info_request.public_body).to receive(:info_request_count_changed)
+      info_request.destroy
+    end
   end
 
   describe '#expire' do
@@ -3568,13 +3573,14 @@ RSpec.describe InfoRequest do
     end
 
     it 'notifies the public body when created' do
-      expect(info_request.public_body).to receive(:request_created)
+      expect(info_request.public_body).to receive(:info_request_count_changed)
       info_request.save!
     end
 
     it 'does not notify the public body when updated' do
       info_request.save!
-      expect(info_request.public_body).not_to receive(:request_created)
+      expect(info_request.public_body).
+        not_to receive(:info_request_count_changed)
       info_request.save!
     end
   end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1409,8 +1409,9 @@ RSpec.describe InfoRequest do
         to change(AlaveteliPro::Embargo, :count).by(-1)
     end
 
-    it 'notifies the public body' do
+    it 'notifies the associations' do
       expect(info_request.public_body).to receive(:info_request_count_changed)
+      expect(info_request.user).to receive(:info_request_count_changed)
       info_request.destroy
     end
   end
@@ -3572,15 +3573,17 @@ RSpec.describe InfoRequest do
       info_request.save!
     end
 
-    it 'notifies the public body when created' do
+    it 'notifies the associations when created' do
       expect(info_request.public_body).to receive(:info_request_count_changed)
+      expect(info_request.user).to receive(:info_request_count_changed)
       info_request.save!
     end
 
-    it 'does not notify the public body when updated' do
+    it 'does not notify the associations when updated' do
       info_request.save!
       expect(info_request.public_body).
         not_to receive(:info_request_count_changed)
+      expect(info_request.user).not_to receive(:info_request_count_changed)
       info_request.save!
     end
   end

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -2314,8 +2314,8 @@ RSpec.describe PublicBody do
     end
   end
 
-  describe '#request_created' do
-    subject { public_body.request_created }
+  describe '#info_request_count_changed' do
+    subject { public_body.info_request_count_changed }
 
     context 'when there are not many public requests' do
       let!(:public_body) { FactoryBot.create(:public_body) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2231,4 +2231,13 @@ RSpec.describe User do
       end
     end
   end
+
+  describe '#info_request_count_changed' do
+    let(:user) { FactoryBot.create(:user) }
+
+    it 'mark as needed to be indexed' do
+      expect(user).to receive(:xapian_mark_needs_index)
+      user.info_request_count_changed
+    end
+  end
 end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8600

## What does this do?

Index user profiles once they've made their first request. If their only request is then destroyed de-index the profile.

## Why was this needed?

Follow on from #8599 to ensure profiles are indexed/de-indexed promptly.