### PR TITLE
[#8694] Fix type of authority helper

### DIFF
--- a/app/helpers/public_body_helper.rb
+++ b/app/helpers/public_body_helper.rb
@@ -40,10 +40,14 @@ module PublicBodyHelper
     categories = PublicBody.category_list.
       where(category_tag: public_body.tag_string.split).order(:id)
 
-    types = categories.each_with_index.map do |category, index|
+    types = categories.each_with_index.inject([]) do |links, (category, index)|
       desc = category.description
+      next links if desc.empty?
+
       desc = desc.sub(/\S/, &:upcase) if index.zero?
-      link_to(desc, list_public_bodies_by_tag_path(category.category_tag))
+      links << link_to(
+        desc, list_public_bodies_by_tag_path(category.category_tag)
+      )
     end
 
     if types.any?

--- a/spec/helpers/public_body_helper_spec.rb
+++ b/spec/helpers/public_body_helper_spec.rb
@@ -82,6 +82,23 @@ RSpec.describe PublicBodyHelper do
       expect(type_of_authority(public_body)).to eq(expected)
     end
 
+    it 'ignores categories without descriptions' do
+      3.times do |i|
+        FactoryBot.create(
+          :category, :public_body,
+          category_tag: "spec_#{i}",
+          description: i.even? ? "spec category #{i}" : ""
+        )
+      end
+      public_body = FactoryBot.create(
+        :public_body,
+        tag_string: 'unknown spec_0 spec_1 spec_2'
+      )
+      expected = '<a href="/body/list/spec_0">Spec category 0</a> and ' \
+        '<a href="/body/list/spec_2">spec category 2</a>'
+      expect(type_of_authority(public_body)).to eq(expected)
+    end
+
     context 'when categories are descendents of non-root parents' do
       it 'returns the description wrapped in an anchor tag' do
         FactoryBot.create(


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8694

## What does this do?

Filter out categories with blank descriptions to improve rendering of the type of authority helper text.

[skip changelog]