### PR TITLE
[#8709] Fix admin text columns rendering

### DIFF
--- a/app/views/admin/info_request_batches/_admin_columns.html.erb
+++ b/app/views/admin/info_request_batches/_admin_columns.html.erb
@@ -12,9 +12,9 @@
 
         <td>
           <% if name == 'body' %>
-            <% truncated_value = truncate(h(value&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+            <% truncated_value = truncate(h(value&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Show more', class: 'toggle-hidden' } %>
             <%= simple_format(truncated_value) %>
-            <div style="display:none;"><%= simple_format(value) %></div>
+            <div style="display:none;"><%= simple_format(value&.truncate(1000)) %></div>
           <% else %>
             <%= admin_value(value) %>
           <% end %>

--- a/app/views/admin_incoming_message/_admin_columns.html.erb
+++ b/app/views/admin_incoming_message/_admin_columns.html.erb
@@ -8,9 +8,9 @@
 
         <td>
           <% if name =~ /^cached_.*?$/ %>
-            <% truncated_value = truncate(h(value&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+            <% truncated_value = truncate(h(value&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Show more', class: 'toggle-hidden' } %>
             <%= simple_format(truncated_value) %>
-            <div style="display:none;"><%= simple_format(value) %></div>
+            <div style="display:none;"><%= simple_format(value&.truncate(1000)) %></div>
           <% elsif name == 'prominence' %>
             <%= h highlight_prominence(value) %>
           <% else %>

--- a/app/views/admin_outgoing_message/_admin_columns.html.erb
+++ b/app/views/admin_outgoing_message/_admin_columns.html.erb
@@ -8,9 +8,9 @@
 
         <td>
           <% if name == 'body' %>
-            <% truncated_value = truncate(h(value&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+            <% truncated_value = truncate(h(value&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Show more', class: 'toggle-hidden' } %>
             <%= simple_format(truncated_value) %>
-            <div style="display:none;"><%= simple_format(value) %></div>
+            <div style="display:none;"><%= simple_format(value&.truncate(1000)) %></div>
           <% elsif name == 'prominence' %>
             <%= h highlight_prominence(value) %>
           <% else %>
@@ -26,10 +26,10 @@
       </td>
 
       <td>
-        <% truncated_value = truncate(h(outgoing_message.raw_body&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Toggle hidden', class: 'toggle-hidden' } %>
+        <% truncated_value = truncate(h(outgoing_message.raw_body&.squish), length: 100, omission: '') { link_to '…', '#', title: 'Show more', class: 'toggle-hidden' } %>
         <%= simple_format(truncated_value) %>
         <div style="display:none;">
-          <%= simple_format(outgoing_message.raw_body) %>
+          <%= simple_format(outgoing_message.raw_body&.truncate(1000)) %>
         </div>
       </td>
     </tr>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Update admin text column rendering (Graeme Porteous)
 * Add public annotations configuration (Graeme Porteous)
 * Add attachment locking and replacement (Graeme Porteous)
 * Only send clarification notifications to recent requests (Gareth Rees)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8709

## What does this do?

Fix admin text columns rendering


## Implementation notes

Limit the amount of content shown even when expanding the content.

Showing more than 1000 characters might be possible but lets see if this works for the admin.

