### PR TITLE
[sys#2038] Add configuration for user-to-user messaging feature

### DIFF
--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -1,6 +1,7 @@
 # Allowing users to send user-to-user messages
 class Users::MessagesController < UserController
   before_action :set_recipient,
+                :check_messaging_enabled,
                 :check_recipient_accepts_messages,
                 :check_can_send_messages,
                 :check_logged_in,
@@ -33,6 +34,12 @@ class Users::MessagesController < UserController
 
   def set_recipient
     @recipient_user = User.find_by!(url_name: params[:url_name])
+  end
+
+  def check_messaging_enabled
+    return if feature_enabled?(:user_to_user_messaging)
+
+    render template: 'users/messages/disabled'
   end
 
   def check_recipient_accepts_messages

--- a/app/controllers/users/messages_controller.rb
+++ b/app/controllers/users/messages_controller.rb
@@ -36,8 +36,17 @@ class Users::MessagesController < UserController
     @recipient_user = User.find_by!(url_name: params[:url_name])
   end
 
+  def signed_recipient
+    return unless params[:sgid]
+
+    GlobalID::Locator.locate_signed(
+      params[:sgid], for: 'user_to_user_messaging'
+    )
+  end
+
   def check_messaging_enabled
     return if feature_enabled?(:user_to_user_messaging)
+    return if @recipient_user == signed_recipient
 
     render template: 'users/messages/disabled'
   end

--- a/app/views/projects/projects/_project_nav.html.erb
+++ b/app/views/projects/projects/_project_nav.html.erb
@@ -11,7 +11,7 @@
         </li>
 
         <li>
-          <%= link_to contact_user_path(url_name: project.owner.url_name) do %>
+          <%= link_to contact_user_path(url_name: project.owner.url_name, sgid: project.owner.to_sgid(expires_in: 1.day, for: :user_to_user_messaging)) do %>
             <%= _('Contact {{recipient}}', recipient: project.owner.name) %>
           <% end %>
         </li>

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -138,7 +138,7 @@
               <p><%= @project.owner.about_me %></p>
             <% end %>
 
-             <%= link_to contact_user_path(url_name: @project.owner.url_name),
+             <%= link_to contact_user_path(url_name: @project.owner.url_name, sgid: @project.owner.to_sgid(expires_in: 1.day, for: :user_to_user_messaging)),
                  class: 'button-tertiary' do %>
               <%= _('Contact {{recipient}}', recipient: @project.owner.name) %>
             <% end %>

--- a/app/views/user/contact.html.erb
+++ b/app/views/user/contact.html.erb
@@ -42,6 +42,7 @@
 
   <div class="form_button">
     <%= hidden_field_tag(:submitted_contact_form, { :value => 1 } ) %>
+    <%= hidden_field_tag(:sgid, params[:sgid]) if params[:sgid] %>
     <%= submit_tag _("Send message") %>
   </div>
 <% end %>

--- a/app/views/user/show/_show_profile.html.erb
+++ b/app/views/user/show/_show_profile.html.erb
@@ -63,7 +63,7 @@
       <% end %>
     </p>
 
-    <% if @display_user.active? %>
+    <% if @display_user.active? && feature_enabled?(:user_to_user_messaging) %>
       <p>
         <% if @is_you %>
           <%= link_to _('Send message to {{user_name}} just to see how it works',
@@ -75,7 +75,7 @@
                       contact_user_path(url_name: @display_user.url_name) %>
         <% end %>
       </p>
-    <% else %>
+    <% elsif @display_user.suspended? %>
       <div id="user_public_suspended">
         <p>
           <strong>

--- a/app/views/users/messages/disabled.html.erb
+++ b/app/views/users/messages/disabled.html.erb
@@ -1,0 +1,7 @@
+<% @title = _('Cannot send messages') %>
+
+<h1><%= @title %></h1>
+
+<p>
+  <%= _('User-to-user messaging has been disabled.') %>
+</p>

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1323,3 +1323,13 @@ USER_SIGN_IN_ACTIVITY_RETENTION_DAYS: 0
 #
 # ---
 ENABLE_PUBLIC_ANNOTATIONS: true
+
+# If ENABLE_USER_TO_USER_MESSAGING is set to true, Alaveteli will allow users
+# to send messages to each other through the site.
+#
+# If set to false, user-to-user messaging functionality will be disabled.
+#
+# ENABLE_USER_TO_USER_MESSAGING- Boolean (default: true)
+#
+# ---
+ENABLE_USER_TO_USER_MESSAGING: true

--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -14,6 +14,7 @@ features = %i[
   pro_pricing
   pro_self_serve
   public_annotations
+  user_to_user_messaging
 ]
 
 backend = AlaveteliFeatures.backend

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add user-to-user messaging configuration (Graeme Porteous)
 * Improve visual accessibility and UX (Lucas Cumsille Montesinos)
 * Add public annotations configuration (Graeme Porteous)
 * Add attachment locking and replacement (Graeme Porteous)

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -49,6 +49,7 @@ module AlaveteliConfiguration
       ENABLE_PRO_PRICING: false,
       ENABLE_PRO_SELF_SERVE: false,
       ENABLE_TWO_FACTOR_AUTH: false,
+      ENABLE_USER_TO_USER_MESSAGING: true,
       ENABLE_WIDGETS: false,
       EXCEPTION_NOTIFICATIONS_FROM: 'errors@localhost',
       EXCEPTION_NOTIFICATIONS_TO: 'user-support@localhost',

--- a/spec/controllers/users/messages_controller_spec.rb
+++ b/spec/controllers/users/messages_controller_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe Users::MessagesController do
       end
     end
 
+    context 'when user-to-user messaging is disabled', features: { user_to_user_messaging: false } do
+      it 'prevents user messages' do
+        get :contact, params: { url_name: recipient.url_name }
+        expect(response).to render_template('users/messages/disabled')
+      end
+    end
+
     it 'prevents messages from users who have reached their rate limit' do
       allow_any_instance_of(User).
         to receive(:exceeded_limit?).with(:user_messages).and_return(true)
@@ -78,6 +85,22 @@ RSpec.describe Users::MessagesController do
 
         expect(ActionMailer::Base.deliveries).to be_empty
         expect(response).to render_template('users/messages/opted_out')
+      end
+    end
+
+    context 'when user-to-user messaging is disabled', features: { user_to_user_messaging: false } do
+      it 'prevents the submission' do
+        post :contact, params: {
+          url_name: recipient.url_name,
+          contact: {
+            subject: 'Hi',
+            message: 'Gah'
+          },
+          submitted_contact_form: 1
+        }
+
+        expect(ActionMailer::Base.deliveries).to be_empty
+        expect(response).to render_template('users/messages/disabled')
       end
     end
 

--- a/spec/controllers/users/messages_controller_spec.rb
+++ b/spec/controllers/users/messages_controller_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe Users::MessagesController do
       end
     end
 
+    context 'when user-to-user messaging is disabled but there is a signed global ID', features: { user_to_user_messaging: false } do
+      it 'shows the contact form' do
+        get :contact, params: {
+          url_name: recipient.url_name,
+          sgid: recipient.to_sgid(for: 'user_to_user_messaging')
+        }
+        expect(response).to render_template('contact')
+      end
+    end
+
     it 'prevents messages from users who have reached their rate limit' do
       allow_any_instance_of(User).
         to receive(:exceeded_limit?).with(:user_messages).and_return(true)
@@ -101,6 +111,29 @@ RSpec.describe Users::MessagesController do
 
         expect(ActionMailer::Base.deliveries).to be_empty
         expect(response).to render_template('users/messages/disabled')
+      end
+    end
+
+    context 'when user-to-user messaging is disabled but there is a signed global ID', features: { user_to_user_messaging: false } do
+      it 'sends the message' do
+        post :contact, params: {
+          url_name: recipient.url_name,
+          contact: {
+            subject: 'Dearest you',
+            message: 'Just a test!'
+          },
+          submitted_contact_form: 1,
+          sgid: recipient.to_sgid(for: 'user_to_user_messaging')
+        }
+        expect(response).to redirect_to(user_url(recipient))
+
+        deliveries = ActionMailer::Base.deliveries
+        expect(deliveries.size).to eq(1)
+        expect(deliveries[0].body).to include(
+          "Bob Smith has used #{site_name} to send you the message below"
+        )
+        expect(deliveries[0].body).to include('Just a test!')
+        expect(deliveries[0].header['Reply-To'].to_s).to match(sender.email)
       end
     end
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes mysociety/sysadmin#2038

## What does this do?

Add configuration to disable user-to-user messaging feature. If "projects" is used then members/contributors will still be able to message the project owner as we now grant access to the user-to-user messaging through a temp signed global ID.

## Why was this needed?

Reduce WDTK service OSA risk around the "Harassment, stalking threats and abuse" illegal harm.
