### PR TITLE
add ability to add invalid addresses

### DIFF
--- a/app/controllers/admin_invalid_reply_addresses_controller.rb
+++ b/app/controllers/admin_invalid_reply_addresses_controller.rb
@@ -1,0 +1,39 @@
+class AdminInvalidReplyAddressesController < AdminController
+  before_action :set_invalid_reply_address, only: [:destroy]
+
+  def index
+    @invalid_reply_addresses = InvalidReplyAddress.all
+    @invalid_reply_address = InvalidReplyAddress.new
+  end
+
+  def create
+    @invalid_reply_address = InvalidReplyAddress.new(invalid_reply_address_params)
+    if @invalid_reply_address.save
+      notice = "#{ @invalid_reply_address.email } has been added to the invalid reply addresses list"
+      redirect_to admin_invalid_reply_addresses_path, notice: notice
+    else
+      @invalid_reply_addresses = InvalidReplyAddress.all
+      render :index
+    end
+  end
+
+  def destroy
+    @invalid_reply_address.destroy
+    notice = "#{ @invalid_reply_address.email } has been removed from the invalid reply addresses list"
+    redirect_to admin_invalid_reply_addresses_path, notice: notice
+  end
+
+  private
+
+  def invalid_reply_address_params
+    if params[:invalid_reply_address]
+      params.require(:invalid_reply_address).permit(:email)
+    else
+      {}
+    end
+  end
+
+  def set_invalid_reply_address
+    @invalid_reply_address = InvalidReplyAddress.find(params[:id])
+  end
+end

--- a/app/models/invalid_reply_address.rb
+++ b/app/models/invalid_reply_address.rb
@@ -1,0 +1,32 @@
+# == Schema Information
+# Schema version: 20250611141800
+#
+# Table name: invalid_reply_addresses
+#
+#  id         :bigint           not null, primary key
+#  email      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class InvalidReplyAddress < ApplicationRecord
+  validates_presence_of :email,
+                        message: 'Enter the email address to mark as invalid reply address'
+
+  validates_uniqueness_of :email,
+                          message: 'This address is already marked as invalid reply address'
+
+  strip_attributes
+
+  before_save :downcase_email
+
+  def self.invalid?(email_address)
+    exists?(email: Array(email_address).compact.map(&:downcase))
+  end
+
+  private
+
+  def downcase_email
+    email.downcase!
+  end
+end

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -42,7 +42,7 @@ class RawEmail < ApplicationRecord
     return false if email.nil? || !MySociety::Validate.is_valid_email(email)
 
     # Check whether the email is a known invalid reply address
-    if ReplyToAddressValidator.invalid_reply_addresses.include?(email)
+    if ReplyToAddressValidator.invalid_reply_address?(email)
       return false
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 # == Schema Information
-# Schema version: 20230301110831
+# Schema version: 20250611141800
 #
 # Table name: users
 #
@@ -12,7 +12,7 @@
 #  updated_at                        :datetime         not null
 #  email_confirmed                   :boolean          default(FALSE), not null
 #  url_name                          :text             not null
-#  last_daily_track_email            :datetime         default(2000-01-01 00:00:00.000000000 GMT +00:00)
+#  last_daily_track_email            :datetime         default(2000-01-01 00:00:00.000000000 UTC +00:00)
 #  ban_text                          :text             default(""), not null
 #  about_me                          :text             default(""), not null
 #  locale                            :string

--- a/app/validators/reply_to_address_validator.rb
+++ b/app/validators/reply_to_address_validator.rb
@@ -20,4 +20,19 @@ class ReplyToAddressValidator
   def self.invalid_reply_addresses=(addresses)
     @invalid_reply_addresses = addresses.map(&:downcase)
   end
+
+  def self.invalid_reply_address?(email_address)
+    return false if email_address.blank?
+    
+    # Debug logging
+    Rails.logger.info "DEBUG: Checking invalid reply address for: '#{email_address}'"
+    Rails.logger.info "DEBUG: Database check result: #{InvalidReplyAddress.invalid?(email_address)}"
+    Rails.logger.info "DEBUG: Manual config check result: #{invalid_reply_addresses.include?(email_address.downcase)}"
+    
+    # Check against database first
+    return true if InvalidReplyAddress.invalid?(email_address)
+    
+    # Check against manually configured addresses (for backward compatibility)
+    invalid_reply_addresses.include?(email_address.downcase)
+  end
 end

--- a/app/views/admin_invalid_reply_addresses/index.html.erb
+++ b/app/views/admin_invalid_reply_addresses/index.html.erb
@@ -1,0 +1,50 @@
+<% @title = 'Invalid Reply Addresses' %>
+
+<h1><%= @title %></h1>
+
+<div class="row">
+  <div class="span12">
+    <p>
+      Email addresses on this list will be marked as invalid for reply-to 
+      addresses, preventing automated responses to these addresses.
+    </p>
+  </div>
+</div>
+
+<hr />
+
+<div class="row">
+  <div class="span12">
+    <%= form_for(@invalid_reply_address, :url => admin_invalid_reply_addresses_path, :html => { :class => 'form-inline' }) do |f| -%>
+      <%= foi_error_messages_for :invalid_reply_address %>
+      <%= f.text_field :email, :class => 'input-xxlarge', :placeholder => 'Enter email' %>
+      <%= f.submit 'Add Invalid Reply Address', :class => 'btn btn-success' %>
+    <% end -%>
+  </div>
+</div>
+
+<hr />
+
+<% if @invalid_reply_addresses.any? %>
+  <div class="row">
+    <table class="table table-hover span12">
+      <thead>
+        <tr>
+          <th>Email</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @invalid_reply_addresses.each do |invalid_address| %>
+          <tr>
+            <td><%= invalid_address.email %></td>
+            <td><%= link_to 'Remove', admin_invalid_reply_address_path(invalid_address),
+              :method => :delete,
+              :data => { :confirm => 'This is permanent! Are you sure?' },
+              :class => 'btn btn-mini btn-danger' %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -808,6 +808,14 @@ Rails.application.routes.draw do
   end
   ####
 
+  #### AdminInvalidReplyAddresses controller
+  scope '/admin', :as => 'admin' do
+    resources :invalid_reply_addresses,
+      :controller => 'admin_invalid_reply_addresses',
+      :only => [:index, :create, :destroy]
+  end
+  ####
+
   #### AdminAnnouncement controller
   scope '/admin', :as => 'admin' do
     resources :announcements, :controller => 'admin_announcements'

--- a/db/migrate/20250611141800_create_invalid_reply_addresses.rb
+++ b/db/migrate/20250611141800_create_invalid_reply_addresses.rb
@@ -1,0 +1,9 @@
+class CreateInvalidReplyAddresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :invalid_reply_addresses do |t|
+      t.string :email, null: false
+
+      t.timestamps null: false
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)
Unknown
## What does this do?
Attempts to add ability to add DNR emails in app
## Why was this needed?
Had to manually add them via a patch in the theme before
## Implementation notes
n/a
## Screenshots
n/a
## Notes to reviewer
Not looked at this yet - just a test. Seems to work.
<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
