### PR TITLE
Attachment locking - outgoing message body edits logging

### DIFF
--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -28,7 +28,7 @@ class AdminOutgoingMessageController < AdminController
     old_prominence_reason = @outgoing_message.prominence_reason
     old_tag_string = @outgoing_message.tag_string
     if @outgoing_message.update(outgoing_message_params)
-      @outgoing_message.info_request.log_event(
+      @outgoing_message.log_event(
         'edit_outgoing',
         outgoing_message_id: @outgoing_message.id,
         editor: admin_current_user,
@@ -42,7 +42,7 @@ class AdminOutgoingMessageController < AdminController
         tag_string: @outgoing_message.tag_string
       )
       flash[:notice] = 'Outgoing message successfully updated.'
-      @outgoing_message.info_request.expire
+      @outgoing_message.expire
       redirect_to admin_request_url(@outgoing_message.info_request)
     else
       render action: 'edit'

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -25,7 +25,8 @@ class AdminOutgoingMessageController < AdminController
   def update
     if @outgoing_message.update_and_log_event(
       **outgoing_message_params,
-      event: { editor: admin_current_user }
+      event: { editor: admin_current_user },
+      options: { skip_body_logging: params[:skip_body_logging] }
     )
       @outgoing_message.expire
 

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -23,26 +23,13 @@ class AdminOutgoingMessageController < AdminController
   end
 
   def update
-    old_body = @outgoing_message.raw_body
-    old_prominence = @outgoing_message.prominence
-    old_prominence_reason = @outgoing_message.prominence_reason
-    old_tag_string = @outgoing_message.tag_string
-    if @outgoing_message.update(outgoing_message_params)
-      @outgoing_message.log_event(
-        'edit_outgoing',
-        outgoing_message_id: @outgoing_message.id,
-        editor: admin_current_user,
-        old_body: old_body,
-        body: @outgoing_message.raw_body,
-        old_prominence: old_prominence,
-        prominence: @outgoing_message.prominence,
-        old_prominence_reason: old_prominence_reason,
-        prominence_reason: @outgoing_message.prominence_reason,
-        old_tag_string: old_tag_string,
-        tag_string: @outgoing_message.tag_string
-      )
-      flash[:notice] = 'Outgoing message successfully updated.'
+    if @outgoing_message.update_and_log_event(
+      **outgoing_message_params,
+      event: { editor: admin_current_user }
+    )
       @outgoing_message.expire
+
+      flash[:notice] = 'Outgoing message successfully updated.'
       redirect_to admin_request_url(@outgoing_message.info_request)
     else
       render action: 'edit'

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -413,6 +413,27 @@ class OutgoingMessage < ApplicationRecord
     self.body = get_default_message if raw_body == original_default
   end
 
+  def update_and_log_event(event: {}, **params)
+    old_tag_string = tag_string
+
+    return false unless update(params)
+
+    log_event(
+      'edit_outgoing',
+      event.merge(
+        outgoing_message_id: id,
+        old_body: body_previously_was,
+        body: raw_body,
+        old_prominence: prominence_previously_was,
+        prominence: prominence,
+        old_prominence_reason: prominence_reason_previously_was,
+        prominence_reason: prominence_reason,
+        old_tag_string: old_tag_string,
+        tag_string: tag_string
+      )
+    )
+  end
+
   private
 
   def cache_from_name

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -413,7 +413,9 @@ class OutgoingMessage < ApplicationRecord
     self.body = get_default_message if raw_body == original_default
   end
 
-  def update_and_log_event(event: {}, **params)
+  def update_and_log_event(event: {}, options: {}, **params)
+    options[:skip_body_logging] ||= false
+
     old_tag_string = tag_string
 
     return false unless update(params)
@@ -422,8 +424,9 @@ class OutgoingMessage < ApplicationRecord
       'edit_outgoing',
       event.merge(
         outgoing_message_id: id,
-        old_body: body_previously_was,
-        body: raw_body,
+        old_body: options[:skip_body_logging] ? nil : body_previously_was,
+        body: options[:skip_body_logging] ? nil : raw_body,
+        body_changed: body_previously_changed?,
         old_prominence: prominence_previously_was,
         prominence: prominence,
         old_prominence_reason: prominence_reason_previously_was,

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -68,6 +68,7 @@ class OutgoingMessage < ApplicationRecord
            inverse_of: :outgoing_message,
            dependent: :destroy
 
+  delegate :expire, :log_event, to: :info_request
   delegate :public_body, to: :info_request, private: true, allow_nil: true
 
   after_initialize :set_default_letter
@@ -241,7 +242,7 @@ class OutgoingMessage < ApplicationRecord
     self.status = 'failed'
     save!
 
-    info_request.log_event(
+    log_event(
       'send_error',
       reason: failure_reason,
       outgoing_message_id: id
@@ -258,7 +259,7 @@ class OutgoingMessage < ApplicationRecord
       log_event_type = "followup_#{ log_event_type }"
     end
 
-    info_request.log_event(
+    log_event(
       log_event_type,
       email: to_addrs,
       outgoing_message_id: id,

--- a/app/views/admin_outgoing_message/edit.html.erb
+++ b/app/views/admin_outgoing_message/edit.html.erb
@@ -68,6 +68,16 @@
         </div>
       </div>
 
+      <div class="control-group">
+        <label class="control-label">Logging</label>
+        <div class="controls">
+          <label class="checkbox">
+            <%= checkbox_tag 'skip_body_logging', checked: false %>
+            Skip logging of body edits
+          </label>
+        </div>
+      </div>
+
       <div class="form-actions" >
         <% if @outgoing_message.from_name != @info_request.user_name %>
           <div class="alert alert-error">

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add admin ability to edit outgoing messages without storing old body content
+  (Graeme Porteous)
 * Add user-to-user messaging configuration (Graeme Porteous)
 * Add `rel=nofollow` attributes to links in outgoing messages (Graeme Porteous)
 * Add task to purge profile content for limited user profiles after six months

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -228,6 +228,7 @@ RSpec.describe AdminOutgoingMessageController do
         editor: 'Admin user',
         old_body: 'Some information please',
         body: 'changed body',
+        body_changed: true,
         old_prominence: 'normal',
         prominence: 'hidden',
         old_prominence_reason: nil,

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -1881,6 +1881,24 @@ RSpec.describe OutgoingMessage do
       expect{ subject }.to change{ outgoing_message.last_sent_at }
     end
   end
+
+  describe '#expire' do
+    let(:outgoing_message) { FactoryBot.create(:initial_request) }
+
+    it 'delegates to info_request' do
+      expect(outgoing_message.info_request).to receive(:expire)
+      outgoing_message.expire
+    end
+  end
+
+  describe '#log_event' do
+    let(:outgoing_message) { FactoryBot.create(:initial_request) }
+
+    it 'delegates to info_request' do
+      expect(outgoing_message.info_request).to receive(:log_event).with('edit')
+      outgoing_message.log_event('edit')
+    end
+  end
 end
 
 RSpec.describe OutgoingMessage, " when making an outgoing message" do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -1899,6 +1899,58 @@ RSpec.describe OutgoingMessage do
       outgoing_message.log_event('edit')
     end
   end
+
+  describe '#update_and_log_event' do
+    let(:outgoing_message) do
+      FactoryBot.create(:initial_request, tag_string: 'foo')
+    end
+
+    let(:info_request) { outgoing_message.info_request }
+
+    def last_event
+      info_request.info_request_events.last
+    end
+
+    it 'updates and logs edit_attachment event' do
+      expect do
+        outgoing_message.update_and_log_event(prominence: 'hidden')
+      end.to change { last_event }
+
+      expect(last_event.event_type).to eq('edit_outgoing')
+    end
+
+    it 'logs prominence and reason changes' do
+      outgoing_message.update_and_log_event(
+        prominence: 'hidden', prominence_reason: 'just because'
+      )
+      expect(last_event.params[:old_prominence]).to eq('normal')
+      expect(last_event.params[:prominence]).to eq('hidden')
+      expect(last_event.params[:old_prominence_reason]).to be_nil
+      expect(last_event.params[:prominence_reason]).to eq('just because')
+    end
+
+    it 'logs tag_string changes' do
+      outgoing_message.update_and_log_event(tag_string: 'foo bar')
+      expect(last_event.params[:old_tag_string]).to eq('foo')
+      expect(last_event.params[:tag_string]).to eq('foo bar')
+      outgoing_message.update_and_log_event(tag_string: 'foo bar baz')
+      expect(last_event.params[:old_tag_string]).to eq('foo bar')
+      expect(last_event.params[:tag_string]).to eq('foo bar baz')
+    end
+
+    it 'logs additional event data' do
+      outgoing_message.update_and_log_event(
+        prominence: 'hidden', event: { editor: 'me' }
+      )
+      expect(last_event.params[:editor]).to eq('me')
+    end
+
+    it 'does not log event if update fails' do
+      expect do
+        outgoing_message.update_and_log_event(prominence: nil)
+      end.to_not change { last_event }
+    end
+  end
 end
 
 RSpec.describe OutgoingMessage, " when making an outgoing message" do


### PR DESCRIPTION
## What does this do?

Feature: Attachment locking - add ability to prevent logging of outgoing message body edits

## Why was this needed?

Sometimes the outgoing messages might contain content which we don't want to retain. Before this PR editing the message in the admin UI would result in the content being stored in the request event log.

## Screenshots

<img width="346" alt="image" src="https://github.com/user-attachments/assets/96346e37-3a94-46a2-b7f4-3199960bf61b" />


