### PR TITLE
Refactor outgoing message sendable check

### DIFF
--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -107,13 +107,17 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   end
 
   def send_initial_message(outgoing_message)
-    return unless outgoing_message.sendable?
-
     mail_message = OutgoingMailer.initial_request(
       outgoing_message.info_request,
       outgoing_message
-    ).deliver_now
+    ).deliver_now if outgoing_message.sendable?
 
+  rescue *OutgoingMessage.expected_send_errors => e
+    outgoing_message.record_email_failure(
+      e.message
+    )
+
+  else
     outgoing_message.record_email_delivery(
       mail_message.to_addrs.join(', '),
       mail_message.message_id

--- a/app/controllers/followups_controller.rb
+++ b/app/controllers/followups_controller.rb
@@ -134,8 +134,6 @@ class FollowupsController < ApplicationController
   end
 
   def send_followup
-    @outgoing_message.sendable?
-
     # OutgoingMailer.followup() depends on DB id of the
     # outgoing message, save just before sending.
     @outgoing_message.save!
@@ -145,7 +143,7 @@ class FollowupsController < ApplicationController
         @outgoing_message.info_request,
         @outgoing_message,
         @outgoing_message.incoming_message_followup
-      ).deliver_now
+      ).deliver_now if @outgoing_message.sendable?
 
     rescue *OutgoingMessage.expected_send_errors => e
       authority_name = @outgoing_message.info_request.public_body.name

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -289,37 +289,35 @@ class RequestController < ApplicationController
     # This automatically saves dependent objects, such as @outgoing_message, in the same transaction
     @info_request.save!
 
-    if @outgoing_message.sendable?
-      begin
-        mail_message = OutgoingMailer.initial_request(
-          @outgoing_message.info_request,
-          @outgoing_message
-        ).deliver_now
+    begin
+      mail_message = OutgoingMailer.initial_request(
+        @outgoing_message.info_request,
+        @outgoing_message
+      ).deliver_now if @outgoing_message.sendable?
 
-      rescue *OutgoingMessage.expected_send_errors => e
-        # Catch a wide variety of potential ActionMailer failures and
-        # record the exception reason so administrators don't have to
-        # dig into logs.
-        @outgoing_message.record_email_failure(
-          e.message
-        )
+    rescue *OutgoingMessage.expected_send_errors => e
+      # Catch a wide variety of potential ActionMailer failures and
+      # record the exception reason so administrators don't have to
+      # dig into logs.
+      @outgoing_message.record_email_failure(
+        e.message
+      )
 
-        flash[:error] = _("An error occurred while sending your request to " \
-                          "{{authority_name}} but has been saved and flagged " \
-                          "for administrator attention.",
-                          authority_name: @info_request.public_body.name)
-      else
-        @outgoing_message.record_email_delivery(
-          mail_message.to_addrs.join(', '),
-          mail_message.message_id
-        )
+      flash[:error] = _("An error occurred while sending your request to " \
+                        "{{authority_name}} but has been saved and flagged " \
+                        "for administrator attention.",
+                        authority_name: @info_request.public_body.name)
+    else
+      @outgoing_message.record_email_delivery(
+        mail_message.to_addrs.join(', '),
+        mail_message.message_id
+      )
 
-        flash[:request_sent] = true
-      ensure
-        # Ensure the InfoRequest is fully updated before templating to
-        # isolate templating issues recording delivery status.
-        @info_request.save!
-      end
+      flash[:request_sent] = true
+    ensure
+      # Ensure the InfoRequest is fully updated before templating to
+      # isolate templating issues recording delivery status.
+      @info_request.save!
     end
 
     redirect_to show_request_path(@info_request.url_title)

--- a/app/models/info_request_batch.rb
+++ b/app/models/info_request_batch.rb
@@ -144,14 +144,22 @@ class InfoRequestBatch < ApplicationRecord
   # Send a FOI request to a public body
   def send_request(info_request)
     outgoing_message = info_request.outgoing_messages.first
-    outgoing_message.sendable?
+
     mail_message = OutgoingMailer.initial_request(
       outgoing_message.info_request,
       outgoing_message
-    ).deliver_now
+    ).deliver_now if outgoing_message.sendable?
+
+  rescue *OutgoingMessage.expected_send_errors => e
+    outgoing_message.record_email_failure(
+      e.message
+    )
+
+  else
     outgoing_message.record_email_delivery(
       mail_message.to_addrs.join(', '),
-      mail_message.message_id)
+      mail_message.message_id
+    )
   end
 
   # Do we consider the InfoRequestBatch to be sent to all authorities?


### PR DESCRIPTION
## What does this do?

Refactor outgoing message sendable check

Ensure in all instances where we attempt to deliver an outgoing message we check the `sendable` conditional and handle any exceptions it might raise by rescuing and recording email failures.

## Why was this needed?

This change makes sending messages consistent across the application, both in the standard and Pro workflows.

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
