### PR TITLE
Update user email change confirmation process

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -33,7 +33,7 @@ class UserMailer < ApplicationMailer
       "Confirm your new email address on {{site_name}}",
       site_name: site_name
     )
-    mail_user(new_email, subject: -> { subject })
+    mail_user(user, subject: -> { subject })
   end
 
   def changeemail_already_used(old_email, new_email)

--- a/app/views/user/signchangeemail.html.erb
+++ b/app/views/user/signchangeemail.html.erb
@@ -28,7 +28,7 @@
     </p>
 
     <p class="form_note">
-      <%= _('<strong>Note:</strong> We will send an email to your new email ' \
+      <%= _('<strong>Note:</strong> We will send an email to your old email ' \
             'address. Follow the instructions in it to confirm changing your ' \
             'email.') %>
     </p>

--- a/app/views/user/signchangeemail_confirm.html.erb
+++ b/app/views/user/signchangeemail_confirm.html.erb
@@ -5,7 +5,7 @@
 </h1>
 
 <p class="confirmation_message">
-  <%= _("We've sent an email to your new email address. You'll need to click " \
+  <%= _("We've sent an email to your old email address. You'll need to click " \
         "the link in it before your email address will be changed.") %>
 </p>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Switch to sending user email change confirmation emails to the old email
+  address for increased security verification (Graeme Porteous)
 * Add tracking of user profile email address changes (Graeme Porteous)
 * Update outgoing mail failure handling (Graeme Porteous)
 * Track user agents strings associated with User sign ins if configured (Graeme

--- a/spec/integration/change_email_address_spec.rb
+++ b/spec/integration/change_email_address_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'integration/alaveteli_dsl'
 
 RSpec.describe 'changing your email address' do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, email: 'oldbob@localhost') }
 
   it "sends a confirmation email if you get all the details right" do
     using_session(login(user)) do
@@ -16,7 +16,7 @@ RSpec.describe 'changing your email address' do
 
       mail = ActionMailer::Base.deliveries.first
       expect(mail.body).to include("confirm that you want to change")
-      expect(mail.to).to eq([ 'newbob@localhost' ])
+      expect(mail.to).to eq([ 'oldbob@localhost' ])
 
       # Check confirmation URL works
       visit confirmation_url_from_email


### PR DESCRIPTION
## Related issues

Original PR included the changes in #8763, which subsequently was extracted into its own PR.

## What does this do?

Update user email change confirmation process, switching to sending confirmation emails to the old email address.

~~Also adds tracking of user profile email address changes.~~

## Why was this needed?

Helps verify that the request to change the email address is legitimate and initiated by the user. This prevents unauthorised changes that could compromise the account.

~~Email address change tracking is needed so admins are able to assist users when mistakes are made when changing their address as new email addresses aren't validated.~~
