### PR TITLE
Record user email address history changes

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -272,8 +272,12 @@ class UserController < ApplicationController
     end
 
     # circumstance is 'change_email', so can actually change the email
+    old_email = @user.email
     @user.email = @signchangeemail.new_email
     @user.save!
+
+    # Record the email change in history
+    @user.email_histories.record_change(old_email, @signchangeemail.new_email)
 
     sign_in(@user)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -482,6 +482,7 @@ class User < ApplicationRecord
     transaction do
       slugs.destroy_all
       sign_ins.destroy_all
+      email_histories.destroy_all
       profile_photo&.destroy!
 
       outgoing_messages.update!(

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,6 +171,12 @@ class User < ApplicationRecord
            inverse_of: :user,
            dependent: :destroy
 
+  has_many :email_histories,
+           -> { order(changed_at: :desc) },
+           class_name: 'User::EmailHistory',
+           inverse_of: :user,
+           dependent: :destroy
+
   scope :active, -> { not_banned.not_closed }
   scope :banned, -> { where.not(ban_text: '') }
   scope :not_banned, -> { where(ban_text: '') }

--- a/app/models/user/email_history.rb
+++ b/app/models/user/email_history.rb
@@ -1,0 +1,30 @@
+# == Schema Information
+# Schema version: 20250717064136
+#
+# Table name: user_email_histories
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint           not null
+#  old_email  :string           not null
+#  new_email  :string           not null
+#  changed_at :datetime         not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class User::EmailHistory < ApplicationRecord
+  belongs_to :user
+
+  validates :old_email, presence: true
+  validates :new_email, presence: true
+  validates :changed_at, presence: true
+
+  # Create a history record for an email change
+  def self.record_change(old_email, new_email)
+    create!(
+      old_email: old_email,
+      new_email: new_email,
+      changed_at: Time.current
+    )
+  end
+end

--- a/app/views/admin/users/_email_history_table.html.erb
+++ b/app/views/admin/users/_email_history_table.html.erb
@@ -1,0 +1,24 @@
+<div id="sign-ins">
+  <% if email_histories.any? %>
+    <table class="table table-condensed table-striped">
+      <thead>
+        <tr>
+          <th>Old email</th>
+          <th>New email</th>
+          <th>Changed at</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% email_histories.each do |history| %>
+          <tr class="<%= cycle('odd', 'even') %>">
+            <td><%= mail_to history.old_email %></td>
+            <td><%= mail_to history.new_email %></td>
+            <td><%= history.changed_at.strftime("%Y-%m-%d %H:%M:%S") %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <p>None yet.</p>
+  <% end %>
+</div>

--- a/app/views/admin_user/show.html.erb
+++ b/app/views/admin_user/show.html.erb
@@ -185,6 +185,13 @@
   <hr>
 <% end %>
 
+<h2>Email history</h2>
+
+<%= render partial: 'admin/users/email_history_table',
+           locals: { email_histories: @admin_user.email_histories } %>
+
+<hr>
+
 <h2>Sign Ins</h2>
 
 <%= render partial: 'admin/users/sign_in_table',

--- a/db/migrate/20250717064136_create_user_email_histories.rb
+++ b/db/migrate/20250717064136_create_user_email_histories.rb
@@ -1,0 +1,12 @@
+class CreateUserEmailHistories < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_email_histories do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :old_email, null: false
+      t.string :new_email, null: false
+      t.datetime :changed_at, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add tracking of user profile email address changes (Graeme Porteous)
 * Update outgoing mail failure handling (Graeme Porteous)
 * Track user agents strings associated with User sign ins if configured (Graeme
   Porteous)

--- a/spec/factories/user/email_histories.rb
+++ b/spec/factories/user/email_histories.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+# Schema version: 20250717064136
+#
+# Table name: user_email_histories
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint           not null
+#  old_email  :string           not null
+#  new_email  :string           not null
+#  changed_at :datetime         not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :user_email_history, class: 'User::EmailHistory' do
+    association :user
+    old_email { 'old@example.com' }
+    new_email { 'new@example.com' }
+    changed_at { Time.current }
+  end
+end

--- a/spec/models/user/email_history_spec.rb
+++ b/spec/models/user/email_history_spec.rb
@@ -1,0 +1,71 @@
+# == Schema Information
+# Schema version: 20250717064136
+#
+# Table name: user_email_histories
+#
+#  id         :bigint           not null, primary key
+#  user_id    :bigint           not null
+#  old_email  :string           not null
+#  new_email  :string           not null
+#  changed_at :datetime         not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require 'spec_helper'
+
+RSpec.describe User::EmailHistory, type: :model do
+  subject(:user_email_history) do
+    FactoryBot.build(:user_email_history, user: user)
+  end
+
+  let(:user) { FactoryBot.create(:user) }
+  let(:old_email) { 'old@example.com' }
+  let(:new_email) { 'new@example.com' }
+
+  describe 'associations' do
+    it 'belongs to user' do
+      expect(user_email_history.user).to be_a(User)
+    end
+  end
+
+  describe 'validations' do
+    it { is_expected.to be_valid }
+
+    it 'requires user' do
+      user_email_history.user = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires old_email' do
+      user_email_history.old_email = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires new_email' do
+      user_email_history.new_email = nil
+      is_expected.not_to be_valid
+    end
+
+    it 'requires changed_at' do
+      user_email_history.changed_at = nil
+      is_expected.not_to be_valid
+    end
+  end
+
+  describe '.record_change' do
+    it 'creates a new email history record' do
+      expect {
+        user.email_histories.record_change(old_email, new_email)
+      }.to change(User::EmailHistory, :count).by(1)
+    end
+
+    it 'sets the correct attributes' do
+      history = user.email_histories.record_change(old_email, new_email)
+
+      expect(history.user).to eq(user)
+      expect(history.old_email).to eq(old_email)
+      expect(history.new_email).to eq(new_email)
+      expect(history.changed_at).to be_within(1.second).of(Time.current)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1293,6 +1293,7 @@ RSpec.describe User do
         allow(AlaveteliConfiguration).
           to receive(:user_sign_in_activity_retention_days).and_return(1)
         FactoryBot.create(:user_sign_in, user: user)
+        FactoryBot.create(:user_email_history, user: user)
         FactoryBot.create(:profile_photo, user: user)
 
         allow(Digest::SHA1).to receive(:hexdigest).and_return('a1b2c3d4')
@@ -1338,6 +1339,10 @@ RSpec.describe User do
 
       it 'destroys any sign_ins' do
         expect(user.sign_ins).to be_empty
+      end
+
+      it 'destroys any email_histories' do
+        expect(user.email_histories).to be_empty
       end
 
       it 'destroys any profile photo' do


### PR DESCRIPTION
## Relevant issue(s)

Extracted from #8758 

## What does this do?

Record user email address history changes

## Why was this needed?

This will be useful for support purposes regardless of if we change the email change confirmation destination as purposed in #8758 