### PR TITLE
Permitted countries

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -454,6 +454,13 @@ class ApplicationController < ActionController::Base
     AlaveteliConfiguration.iso_country_code
   end
 
+  def blocked_ip?
+    return false if country_from_ip == AlaveteliConfiguration.iso_country_code
+
+    restricted = Array(AlaveteliConfiguration.restricted_countries.split(' '))
+    restricted.include?(country_from_ip)
+  end
+
   def user_ip
     request.remote_ip
   rescue ActionDispatch::RemoteIp::IpSpoofAttackError

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -458,7 +458,13 @@ class ApplicationController < ActionController::Base
     return false if country_from_ip == AlaveteliConfiguration.iso_country_code
 
     restricted = Array(AlaveteliConfiguration.restricted_countries.split(' '))
-    restricted.include?(country_from_ip)
+    permitted = restricted.map { |c| c.delete_prefix!('!') }.compact
+
+    if permitted.any?
+      !permitted.include?(country_from_ip)
+    else
+      restricted.include?(country_from_ip)
+    end
   end
 
   def user_ip

--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -267,7 +267,7 @@ class RequestController < ApplicationController
       handle_spam_subject(@info_request.user) && return
     end
 
-    if blocked_ip?(country_from_ip, @user)
+    if !@user.confirmed_not_spam? && blocked_ip?
       handle_blocked_ip(@info_request) && return
     end
 
@@ -764,12 +764,6 @@ class RequestController < ApplicationController
       render action: 'new'
       true
     end
-  end
-
-  def blocked_ip?(ip, user)
-    !user.confirmed_not_spam? &&
-      AlaveteliConfiguration.restricted_countries.include?(ip) &&
-      country_from_ip != AlaveteliConfiguration.iso_country_code
   end
 
   def block_restricted_country_ips?

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -157,7 +157,7 @@ class UserController < ApplicationController
       # Block signups from suspicious countries
       # TODO: Add specs (see RequestController#create)
       # TODO: Extract to UserSpamScorer?
-      if blocked_ip?(country_from_ip, @user_signup)
+      if blocked_ip?
         handle_blocked_ip(@user_signup) && return
       end
 
@@ -414,11 +414,6 @@ class UserController < ApplicationController
   def block_restricted_country_ips?
     AlaveteliConfiguration.block_restricted_country_ips ||
       AlaveteliConfiguration.enable_anti_spam
-  end
-
-  def blocked_ip?(country, _user)
-    AlaveteliConfiguration.restricted_countries.include?(country) &&
-      country != AlaveteliConfiguration.iso_country_code
   end
 
   def handle_blocked_ip(user)

--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -986,12 +986,16 @@ BLOCK_SPAM_REQUESTS: false
 # If set, requests from IP addresses in the countries specified will be
 # prevented from making new requests on the site.
 #
+# Country codes can be prefixed with ! to invert the list from restricted
+# to permitted (i.e., only allow requests from the specified countries).
+#
 # RESTRICTED_COUNTRIES – String of space-separated uppercase ISO Alpha-2 codes
 # (default '')
 #
 # Examples:
 #
-#    RESTRICTED_COUNTRIES: 'GB ES'
+#    RESTRICTED_COUNTRIES: 'GB ES'     # Block GB and ES
+#    RESTRICTED_COUNTRIES: '!GB !ES'   # Only allow GB and ES
 #
 # ---
 RESTRICTED_COUNTRIES: ''

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Highlighted Features
 
+* Update `RESTRICTED_COUNTRIES` configuration option to allow countries to be
+  marked as permitted countries. With `BLOCK_RESTRICTED_COUNTRY_IPS` this will
+  restrict sign ups and new requests to IP addresses from permitted countries
+  (Graeme Porteous)
 * Add tracking of user profile email address changes (Graeme Porteous)
 * Update outgoing mail failure handling (Graeme Porteous)
 * Track user agents strings associated with User sign ins if configured (Graeme

--- a/spec/controllers/request_controller_spec.rb
+++ b/spec/controllers/request_controller_spec.rb
@@ -1532,6 +1532,38 @@ RSpec.describe RequestController, "when creating a new request" do
     end
   end
 
+  describe 'when the request is from an IP address in a permitted country' do
+    let(:user) { FactoryBot.create(:user, confirmed_not_spam: false) }
+    let(:body) { FactoryBot.create(:public_body) }
+
+    before do
+      allow(@controller).
+        to receive(:block_restricted_country_ips?).and_return(true)
+      allow(AlaveteliConfiguration).to receive(:restricted_countries).
+        and_return('!EN !ES')
+      allow(controller).to receive(:country_from_ip).and_return('EN')
+    end
+
+    it 'allows the request' do
+      sign_in user
+      post :new, params: {
+        info_request: {
+          public_body_id: body.id,
+          title: "Some request content",
+          tag_string: ""
+        },
+        outgoing_message: {
+          body: "Please supply the answer from your files."
+        },
+        submitted_new_request: 1,
+        preview: 0
+      }
+      expect(response).to redirect_to(
+        show_request_path('some_request_content')
+      )
+    end
+  end
+
   describe 'when the request is from an IP address in a blocked country' do
     let(:user) { FactoryBot.create(:user,
                                    confirmed_not_spam: false) }


### PR DESCRIPTION
## What does this do?

Update blocked IP helper for permitted countries

## Why was this needed?

While I appreciate we're dealing with double negative here this is a
quick way of implementing a permitted country list using the existing
restricted countries configuration option.
