### PR TITLE
[#8799] Clarify no sign ins message

### DIFF
--- a/app/views/admin/users/_sign_in_table.html.erb
+++ b/app/views/admin/users/_sign_in_table.html.erb
@@ -90,6 +90,9 @@
       </div>
     </div>
   <% elsif User::SignIn.retain_signins? %>
-    <p>None yet.</p>
+    <p>
+      None within the retention period
+      (<%= User::SignIn.retention_days %> days).
+    </p>
   <% end %>
 </div>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Clarify no sign ins message (Gareth Rees)
 * Check user spam scoring on email address change (Graeme Porteous)
 * Make requests sortable in the admin interface (Gareth Rees)
 * Add classification icons to request lists in admin (Gareth Rees)


### PR DESCRIPTION
Make it clear that we don't have any sign in data within the retention period. "None yet" makes it look like the user hasn't signed in at all, unless you're familiar with the details of the retention period which some admins may not be.

Fixes https://github.com/mysociety/alaveteli/issues/8799

<img width="983" height="140" alt="Screenshot 2025-08-18 at 17 13 18" src="https://github.com/user-attachments/assets/a16f978c-b7dd-48b5-b04f-ddadb57206b3" />
