### PR TITLE
Add no crawl meta tags to banned/closed user profile pages

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -22,6 +22,7 @@ class UserController < ApplicationController
   before_action :set_request_from_foreign_country, only: [ :signup ]
   before_action :set_in_pro_area, only: [ :signup ]
   before_action :set_display_user, only: [ :show, :wall, :get_profile_photo ]
+  before_action :set_no_crawl, only: [ :show, :wall ]
 
   # Normally we wouldn't be verifying the authenticity token on these actions
   # anyway as there shouldn't be a user_id in the session when the before
@@ -446,6 +447,10 @@ class UserController < ApplicationController
 
   def set_in_pro_area
     @in_pro_area = true if @post_redirect && @post_redirect.reason_params[:pro]
+  end
+
+  def set_no_crawl
+    @no_crawl = true unless @display_user&.active?
   end
 
   def normalize_url_name

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -21,6 +21,7 @@ class UserController < ApplicationController
   before_action :work_out_post_redirect, only: [ :signup ]
   before_action :set_request_from_foreign_country, only: [ :signup ]
   before_action :set_in_pro_area, only: [ :signup ]
+  before_action :set_display_user, only: [ :show, :wall, :get_profile_photo ]
 
   # Normally we wouldn't be verifying the authenticity token on these actions
   # anyway as there shouldn't be a user_id in the session when the before
@@ -33,7 +34,6 @@ class UserController < ApplicationController
   # Show page about a user
   def show
     long_cache
-    @display_user = set_display_user
     set_view_instance_variables
     @same_name_users = User.find_similar_named_users(@display_user)
     @is_you = current_user_is_display_user
@@ -80,7 +80,6 @@ class UserController < ApplicationController
   # Show the user's wall
   def wall
     long_cache
-    @display_user = set_display_user
     @is_you = current_user_is_display_user
     feed_results = Set.new
     # Use search query for this so can collapse and paginate easily
@@ -398,7 +397,6 @@ class UserController < ApplicationController
   # actual profile photo of a user
   def get_profile_photo
     long_cache
-    @display_user = set_display_user
     unless @display_user.profile_photo
       raise ActiveRecord::RecordNotFound, "user has no profile photo, url_name=" + params[:url_name]
     end
@@ -549,7 +547,8 @@ class UserController < ApplicationController
   end
 
   def set_display_user
-    User.where(email_confirmed: true).friendly.find(params[:url_name])
+    @display_user = User.where(email_confirmed: true).
+                         friendly.find(params[:url_name])
   end
 
   def set_show_requests

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add no crawl meta tags to banned/closed user profile pages (Graeme Porteous)
 * Clarify no sign ins message (Gareth Rees)
 * Check user spam scoring on email address change (Graeme Porteous)
 * Make requests sortable in the admin interface (Gareth Rees)


### PR DESCRIPTION
## What does this do?

Add no crawl meta tags to banned/closed user profile pages

