### PR TITLE
Extract PublicBody::CsvImport concern

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -26,7 +26,6 @@
 #  disclosure_log                         :text
 #
 
-require 'csv'
 require 'securerandom'
 require 'set'
 require 'confidence_intervals'
@@ -34,12 +33,11 @@ require 'confidence_intervals'
 class PublicBody < ApplicationRecord
   include CalculatedHomePage
   include Categorisable
+  include CsvImport
   include Taggable
   include Notable
   include Rails.application.routes.url_helpers
   include LinkToHelper
-
-  class ImportCSVDryRun < StandardError; end
 
   admin_columns exclude: %i[name last_edit_editor]
 
@@ -48,20 +46,6 @@ class PublicBody < ApplicationRecord
   end
 
   attr_accessor :no_xapian_reindex
-
-  # Default fields available for importing from CSV, in the format
-  # [field_name, 'short description of field (basic html allowed)']
-  cattr_accessor :csv_import_fields do
-    [
-      ['name', '(i18n)<strong>Existing records cannot be renamed</strong>'],
-      ['short_name', '(i18n)'],
-      ['request_email', '(i18n)'],
-      ['publication_scheme', '(i18n)'],
-      ['disclosure_log', '(i18n)'],
-      ['home_page', ''],
-      ['tag_string', '(tags separated by spaces)']
-    ]
-  end
 
   # Set to 0 to prevent application of the not_many_requests tag
   cattr_accessor :not_many_public_requests_size, default: 5
@@ -449,186 +433,6 @@ class PublicBody < ApplicationRecord
     else
       raise "Multiple public bodies (#{matching_pbs.length}) found with url_name 'internal_admin_authority'"
     end
-  end
-
-  # Import from a string in CSV format.
-  # Just tests things and returns messages if dry_run is true.
-  # Returns an array of [array of errors, array of notes]. If there
-  # are errors, always rolls back (as with dry_run).
-  def self.import_csv(csv, tag, tag_behaviour, dry_run, editor, available_locales = [])
-    tmp_csv = nil
-    Tempfile.open('alaveteli') do |f|
-      f.write csv
-      tmp_csv = f
-    end
-    PublicBody.import_csv_from_file(tmp_csv.path, tag, tag_behaviour, dry_run, editor, available_locales)
-  end
-
-  # Import from a CSV file.
-  # Just tests things and returns messages if dry_run is true.
-  # Returns an array of [array of errors, array of notes]. If there
-  # are errors, always rolls back (as with dry_run).
-  def self.import_csv_from_file(csv_filename, tag, tag_behaviour, dry_run, editor, available_locales = [])
-    errors = []
-    notes = []
-    begin
-      ActiveRecord::Base.transaction do
-        # Use the default locale when retrieving existing bodies; otherwise
-        # matching names won't work afterwards, and we'll create new bodies instead
-        # of updating them
-        bodies_by_name = {}
-        set_of_existing = Set.new
-        internal_admin_body_id = PublicBody.internal_admin_body.id
-        AlaveteliLocalization.
-          with_locale(AlaveteliLocalization.default_locale) do
-          bodies = (tag.nil? || tag.empty?) ? PublicBody.includes(:translations) : PublicBody.find_by_tag(tag)
-          bodies.each do |existing_body|
-            # Hide InternalAdminBody from import notes
-            next if existing_body.id == internal_admin_body_id
-
-            bodies_by_name[existing_body.name] = existing_body
-            set_of_existing.add(existing_body.name)
-          end
-        end
-
-        set_of_importing = Set.new
-        # Default values in case no field list is given
-        field_names = { 'name' => 1, 'request_email' => 2 }
-        line = 0
-
-        import_options = { field_names: field_names,
-                          available_locales: available_locales,
-                          tag: tag,
-                          tag_behaviour: tag_behaviour,
-                          editor: editor,
-                          notes: notes,
-                          errors: errors }
-
-        CSV.foreach(csv_filename) do |row|
-          line += 1
-
-          # Parse the first line as a field list if it starts with '#'
-          if (line==1) && row.first.to_s =~(/^#(.*)$/)
-            row[0] = row[0][1..-1] # Remove the # sign on first field
-            row.each_with_index { |field, i| field_names[field] = i }
-            next
-          end
-
-          fields = {}
-          field_names.each { |name, i| fields[name] = row[i] }
-
-          yield line, fields if block_given?
-
-          name = row[field_names['name']]
-          email = row[field_names['request_email']]
-          next if name.nil?
-
-          name.strip!
-          email.strip! unless email.nil?
-
-          if !email.nil? && !email.empty? && !MySociety::Validate.is_valid_email(email)
-            errors.push "error: line #{line}: invalid email '#{email}' for authority '#{name}'"
-            next
-          end
-
-          public_body = bodies_by_name[name] || PublicBody.new(name: "",
-                                                               short_name: "",
-                                                               request_email: "")
-
-          public_body.import_values_from_csv_row(row, line, name, import_options)
-          set_of_importing.add(name)
-        end
-
-        # Give an error listing ones that are to be deleted
-        deleted_ones = set_of_existing - set_of_importing
-        if !deleted_ones.empty?
-          notes.push "Notes: Some " + tag + " bodies are in database, but not in CSV file:\n    " + Array(deleted_ones).sort.join("\n    ") + "\nYou may want to delete them manually.\n"
-        end
-
-        # Rollback if a dry run, or we had errors
-        raise ImportCSVDryRun if dry_run || (!errors.empty?)
-      end
-    rescue ImportCSVDryRun
-      # Ignore
-    end
-
-    [errors, notes]
-  end
-
-  def self.localized_csv_field_name(locale, field_name)
-    if AlaveteliLocalization.default_locale?(locale)
-      field_name
-    else
-      "#{field_name}.#{locale}"
-    end
-  end
-
-  # import values from a csv row (that may include localized columns)
-  def import_values_from_csv_row(row, line, name, options)
-    is_new = new_record?
-    edit_info = if is_new
-      { action: "creating new authority",
-        comment: 'Created from spreadsheet' }
-    else
-      { action: "updating authority",
-        comment: 'Updated from spreadsheet' }
-    end
-    locales = options[:available_locales]
-    locales = [AlaveteliLocalization.default_locale] if locales.empty?
-    locales.each do |locale|
-      AlaveteliLocalization.with_locale(locale) do
-        changed = set_locale_fields_from_csv_row(is_new, locale, row, options)
-        unless changed.empty?
-          options[:notes].push "line #{ line }: #{ edit_info[:action] } '#{ name }' (locale: #{ locale }):\n\t#{ changed.to_json }"
-          self.last_edit_comment = edit_info[:comment]
-          self.publication_scheme = publication_scheme || ""
-          self.last_edit_editor = options[:editor]
-
-          begin
-            save!
-          rescue ActiveRecord::RecordInvalid
-            errors.each do |error|
-              options[:errors].push "error: line #{ line }: " \
-                "#{ error.full_message } for authority '#{ name }'"
-            end
-            next
-          end
-        end
-      end
-    end
-  end
-
-  # Sets attribute values for a locale from a csv row
-  def set_locale_fields_from_csv_row(is_new, locale, row, options)
-    changed = ActiveSupport::OrderedHash.new
-    csv_field_names = options[:field_names]
-    csv_import_fields.each do |field_name, _field_notes|
-      localized_field_name = self.class.localized_csv_field_name(locale, field_name)
-      column = csv_field_names[localized_field_name]
-      value = column && row[column]
-      # Tags are a special case, as we support adding to the field,
-      # not just setting a new value
-      if field_name == 'tag_string'
-        new_tags = [value, options[:tag]].select { |new_tag| !new_tag.blank? }
-        if new_tags.empty?
-          value = nil
-        else
-          value = new_tags.join(" ")
-          value = "#{value} #{tag_string}"if options[:tag_behaviour] == 'add'
-        end
-      end
-
-      if value && read_attribute_value(field_name, locale) != value
-        if is_new
-          changed[field_name] = value
-        else
-          changed[field_name] = "#{read_attribute_value(field_name, locale)}:" \
-                                " #{value}"
-        end
-        assign_attributes({ field_name => value })
-      end
-    end
-    changed
   end
 
   # Does this user have the power of FOI officer for this body?

--- a/app/models/public_body/csv_import.rb
+++ b/app/models/public_body/csv_import.rb
@@ -1,0 +1,206 @@
+require 'csv'
+
+# Allow PublicBody records to get created or updated en masse via CSV.
+module PublicBody::CsvImport
+  extend ActiveSupport::Concern
+
+  class ImportCSVDryRun < StandardError; end
+
+  included do
+    # Default fields available for importing from CSV, in the format
+    # [field_name, 'short description of field (basic html allowed)']
+    cattr_accessor :csv_import_fields do
+      [
+        ['name', '(i18n)<strong>Existing records cannot be renamed</strong>'],
+        ['short_name', '(i18n)'],
+        ['request_email', '(i18n)'],
+        ['publication_scheme', '(i18n)'],
+        ['disclosure_log', '(i18n)'],
+        ['home_page', ''],
+        ['tag_string', '(tags separated by spaces)']
+      ]
+    end
+  end
+
+  class_methods do
+    # Import from a string in CSV format.
+    # Just tests things and returns messages if dry_run is true.
+    # Returns an array of [array of errors, array of notes]. If there
+    # are errors, always rolls back (as with dry_run).
+    def import_csv(csv, tag, tag_behaviour, dry_run, editor, available_locales = [])
+      tmp_csv = nil
+      Tempfile.open('alaveteli') do |f|
+        f.write csv
+        tmp_csv = f
+      end
+      PublicBody.import_csv_from_file(tmp_csv.path, tag, tag_behaviour, dry_run, editor, available_locales)
+    end
+
+    # Import from a CSV file.
+    # Just tests things and returns messages if dry_run is true.
+    # Returns an array of [array of errors, array of notes]. If there
+    # are errors, always rolls back (as with dry_run).
+    def import_csv_from_file(csv_filename, tag, tag_behaviour, dry_run, editor, available_locales = [])
+      errors = []
+      notes = []
+      begin
+        ActiveRecord::Base.transaction do
+          # Use the default locale when retrieving existing bodies; otherwise
+          # matching names won't work afterwards, and we'll create new bodies instead
+          # of updating them
+          bodies_by_name = {}
+          set_of_existing = Set.new
+          internal_admin_body_id = PublicBody.internal_admin_body.id
+          AlaveteliLocalization.
+            with_locale(AlaveteliLocalization.default_locale) do
+            bodies = (tag.nil? || tag.empty?) ? PublicBody.includes(:translations) : PublicBody.find_by_tag(tag)
+            bodies.each do |existing_body|
+              # Hide InternalAdminBody from import notes
+              next if existing_body.id == internal_admin_body_id
+
+              bodies_by_name[existing_body.name] = existing_body
+              set_of_existing.add(existing_body.name)
+            end
+          end
+
+          set_of_importing = Set.new
+          # Default values in case no field list is given
+          field_names = { 'name' => 1, 'request_email' => 2 }
+          line = 0
+
+          import_options = { field_names: field_names,
+                            available_locales: available_locales,
+                            tag: tag,
+                            tag_behaviour: tag_behaviour,
+                            editor: editor,
+                            notes: notes,
+                            errors: errors }
+
+          CSV.foreach(csv_filename) do |row|
+            line += 1
+
+            # Parse the first line as a field list if it starts with '#'
+            if (line==1) && row.first.to_s =~(/^#(.*)$/)
+              row[0] = row[0][1..-1] # Remove the # sign on first field
+              row.each_with_index { |field, i| field_names[field] = i }
+              next
+            end
+
+            fields = {}
+            field_names.each { |name, i| fields[name] = row[i] }
+
+            yield line, fields if block_given?
+
+            name = row[field_names['name']]
+            email = row[field_names['request_email']]
+            next if name.nil?
+
+            name.strip!
+            email.strip! unless email.nil?
+
+            if !email.nil? && !email.empty? && !MySociety::Validate.is_valid_email(email)
+              errors.push "error: line #{line}: invalid email '#{email}' for authority '#{name}'"
+              next
+            end
+
+            public_body = bodies_by_name[name] || PublicBody.new(name: "",
+                                                                 short_name: "",
+                                                                 request_email: "")
+
+            public_body.import_values_from_csv_row(row, line, name, import_options)
+            set_of_importing.add(name)
+          end
+
+          # Give an error listing ones that are to be deleted
+          deleted_ones = set_of_existing - set_of_importing
+          if !deleted_ones.empty?
+            notes.push "Notes: Some " + tag + " bodies are in database, but not in CSV file:\n    " + Array(deleted_ones).sort.join("\n    ") + "\nYou may want to delete them manually.\n"
+          end
+
+          # Rollback if a dry run, or we had errors
+          raise ImportCSVDryRun if dry_run || (!errors.empty?)
+        end
+      rescue ImportCSVDryRun
+        # Ignore
+      end
+
+      [errors, notes]
+    end
+
+    def localized_csv_field_name(locale, field_name)
+      if AlaveteliLocalization.default_locale?(locale)
+        field_name
+      else
+        "#{field_name}.#{locale}"
+      end
+    end
+  end
+
+  # import values from a csv row (that may include localized columns)
+  def import_values_from_csv_row(row, line, name, options)
+    is_new = new_record?
+    edit_info = if is_new
+      { action: "creating new authority",
+        comment: 'Created from spreadsheet' }
+    else
+      { action: "updating authority",
+        comment: 'Updated from spreadsheet' }
+    end
+    locales = options[:available_locales]
+    locales = [AlaveteliLocalization.default_locale] if locales.empty?
+    locales.each do |locale|
+      AlaveteliLocalization.with_locale(locale) do
+        changed = set_locale_fields_from_csv_row(is_new, locale, row, options)
+        unless changed.empty?
+          options[:notes].push "line #{ line }: #{ edit_info[:action] } '#{ name }' (locale: #{ locale }):\n\t#{ changed.to_json }"
+          self.last_edit_comment = edit_info[:comment]
+          self.publication_scheme = publication_scheme || ""
+          self.last_edit_editor = options[:editor]
+
+          begin
+            save!
+          rescue ActiveRecord::RecordInvalid
+            errors.each do |error|
+              options[:errors].push "error: line #{ line }: " \
+                "#{ error.full_message } for authority '#{ name }'"
+            end
+            next
+          end
+        end
+      end
+    end
+  end
+
+  # Sets attribute values for a locale from a csv row
+  def set_locale_fields_from_csv_row(is_new, locale, row, options)
+    changed = ActiveSupport::OrderedHash.new
+    csv_field_names = options[:field_names]
+    csv_import_fields.each do |field_name, _field_notes|
+      localized_field_name = self.class.localized_csv_field_name(locale, field_name)
+      column = csv_field_names[localized_field_name]
+      value = column && row[column]
+      # Tags are a special case, as we support adding to the field,
+      # not just setting a new value
+      if field_name == 'tag_string'
+        new_tags = [value, options[:tag]].select { |new_tag| !new_tag.blank? }
+        if new_tags.empty?
+          value = nil
+        else
+          value = new_tags.join(" ")
+          value = "#{value} #{tag_string}"if options[:tag_behaviour] == 'add'
+        end
+      end
+
+      if value && read_attribute_value(field_name, locale) != value
+        if is_new
+          changed[field_name] = value
+        else
+          changed[field_name] = "#{read_attribute_value(field_name, locale)}:" \
+                                " #{value}"
+        end
+        assign_attributes({ field_name => value })
+      end
+    end
+    changed
+  end
+end


### PR DESCRIPTION
Simply move the methods to a concern given they're an isolated concept and take up a significant amount of line length in the main class.

Obviously there's lots of refactoring to be done here – ideally this would be a well-tested class in its own right with the concern being a simple interface, but for now just extracting the pieces out to their own file is a nice improvement.

Tested a basic CSV-based update in the browser and all still works as expected.

[skip changelog]
