### PR TITLE
Don't spam-check admins

### DIFF
--- a/app/controllers/concerns/user_spam_check.rb
+++ b/app/controllers/concerns/user_spam_check.rb
@@ -8,7 +8,7 @@ module UserSpamCheck
   end
 
   def spam_user?(user)
-    return false if user.admin?
+    return false if user.admin? || user.confirmed_not_spam?
 
     user_with_request = User::WithRequest.new(user, request)
     UserSpamScorer.new(spam_scorer_config).spam?(user_with_request)

--- a/app/controllers/concerns/user_spam_check.rb
+++ b/app/controllers/concerns/user_spam_check.rb
@@ -8,6 +8,8 @@ module UserSpamCheck
   end
 
   def spam_user?(user)
+    return false if user.admin?
+
     user_with_request = User::WithRequest.new(user, request)
     UserSpamScorer.new(spam_scorer_config).spam?(user_with_request)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -398,6 +398,10 @@ class User < ApplicationRecord
     is_admin?
   end
 
+  def admin?
+    is_admin? || is_pro_admin?
+  end
+
   def can_admin_roles
     roles.
       flat_map { |role| Role.grants_and_revokes(role.name.to_sym) }.

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Don't run the spam checker for admin accounts on sign in (Gareth Rees)
 * Add no crawl meta tags to banned/closed user profile pages (Graeme Porteous)
 * Add `UserSpamScorer.spam_email_formats` to test email addresses against
   regular expressions to see if they are spammy or not (Graeme Porteous)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## Highlighted Features
 
-* Don't run the spam checker for admin accounts on sign in (Gareth Rees)
+* Don't run the spam checker for admin accounts or accounts confirmed as not
+  spam on sign in (Gareth Rees)
 * Add no crawl meta tags to banned/closed user profile pages (Graeme Porteous)
 * Add `UserSpamScorer.spam_email_formats` to test email addresses against
   regular expressions to see if they are spammy or not (Graeme Porteous)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -236,7 +236,8 @@ RSpec.describe Users::SessionsController do
         FactoryBot.create(
           :user,
           email: 'spammer@example.com', name: 'Download New Person 1080p!',
-          password: 'password1234', email_confirmed: true
+          password: 'password1234', email_confirmed: true,
+          confirmed_not_spam: false
         )
       end
 
@@ -300,6 +301,20 @@ RSpec.describe Users::SessionsController do
       context 'when the user is an admin' do
         before do
           user.add_role(:admin)
+
+          allow(@controller).
+            to receive(:spam_should_be_blocked?).and_return(true)
+        end
+
+        it 'allows the signin' do
+          do_signin(user.email, 'password1234')
+          expect(session[:user_id]).to eq user.id
+        end
+      end
+
+      context 'when the user is confirmed_not_spam' do
+        before do
+          user.update(confirmed_not_spam: true)
 
           allow(@controller).
             to receive(:spam_should_be_blocked?).and_return(true)

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -296,6 +296,20 @@ RSpec.describe Users::SessionsController do
           expect(session[:user_id]).to eq user.id
         end
       end
+
+      context 'when the user is an admin' do
+        before do
+          user.add_role(:admin)
+
+          allow(@controller).
+            to receive(:spam_should_be_blocked?).and_return(true)
+        end
+
+        it 'allows the signin' do
+          do_signin(user.email, 'password1234')
+          expect(session[:user_id]).to eq user.id
+        end
+      end
     end
 
     it "should ask you to confirm your email if it isn't confirmed, after log in" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1710,6 +1710,25 @@ RSpec.describe User do
     end
   end
 
+  describe '#admin?' do
+    subject { user.admin? }
+
+    context 'normal user' do
+      let(:user) { FactoryBot.build(:user) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'admin' do
+      let(:user) { FactoryBot.create(:user, :admin) }
+      it { is_expected.to eq(true) }
+    end
+
+    context 'pro admin' do
+      let(:user) { FactoryBot.create(:user, :pro_admin) }
+      it { is_expected.to eq(true) }
+    end
+  end
+
   describe 'pro scope' do
     it "only includes pro user" do
       pro_user = FactoryBot.create(:pro_user)


### PR DESCRIPTION
Admins may do things that trigger the spam scorer for testing purposes (e.g. use plus accounts). Admins should always be allowed to log in.
