### PR TITLE
Model concern include consistency

### DIFF
--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -34,6 +34,7 @@ require 'digest'
 class FoiAttachment < ApplicationRecord
   include Rails.application.routes.url_helpers
   include LinkToHelper
+
   include MessageProminence
 
   MissingAttachment = Class.new(StandardError)

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -38,8 +38,9 @@ require 'zip'
 
 class IncomingMessage < ApplicationRecord
   include MessageProminence
-  include CacheAttributesFromRawEmail
   include Taggable
+
+  include IncomingMessage::CacheAttributesFromRawEmail
 
   UnableToExtractAttachments = Class.new(StandardError)
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -43,16 +43,20 @@ class InfoRequest < ApplicationRecord
   OLD_AGE_IN_DAYS = 21.days
 
   include Rails.application.routes.url_helpers
+  include LinkToHelper
+
+  include Categorisable
+  include Taggable
+  include Notable
+
   include AlaveteliPro::RequestSummaries
   include AlaveteliFeatures::Helpers
+
   include InfoRequest::BatchPagination
   include InfoRequest::PublicToken
   include InfoRequest::Sluggable
   include InfoRequest::TitleValidation
-  include Categorisable
-  include Taggable
-  include Notable
-  include LinkToHelper
+
 
   admin_columns exclude: %i[title url_title],
                 include: %i[rejected_incoming_count]

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -31,13 +31,15 @@ require 'set'
 require 'confidence_intervals'
 
 class PublicBody < ApplicationRecord
-  include CalculatedHomePage
-  include Categorisable
-  include CsvImport
-  include Taggable
-  include Notable
   include Rails.application.routes.url_helpers
   include LinkToHelper
+
+  include Categorisable
+  include Taggable
+  include Notable
+
+  include PublicBody::CalculatedHomePage
+  include PublicBody::CsvImport
 
   admin_columns exclude: %i[name last_edit_editor]
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,8 +42,14 @@
 #
 
 class User < ApplicationRecord
+  include Rails.application.routes.url_helpers
+  include LinkToHelper
+
+  include Taggable
+
   include AlaveteliFeatures::Helpers
   include AlaveteliPro::PhaseCounts
+
   include User::Authentication
   include User::InternalAdmin
   include User::LimitedProfile
@@ -53,9 +59,6 @@ class User < ApplicationRecord
   include User::SpreadableAlerts
   include User::Survey
   include User::Unused
-  include Taggable
-  include Rails.application.routes.url_helpers
-  include LinkToHelper
 
   DEFAULT_CONTENT_LIMITS = {
     info_requests: AlaveteliConfiguration.max_requests_per_user_per_day,


### PR DESCRIPTION
Include namespace in model concern includes. This makes it obvious at a glance whether a concern is shared or just nesting some behaviour under the specific model.

Order includes by most general to most specific. This is more likely to ensure generic methods are included first so that more specific concerns that rely on them have the methods needed. This isn't guaranteed so we can deviate from this as necessary.

[skip changelog]
