### PR TITLE
Refactor include of url_helpers

### DIFF
--- a/app/helpers/link_to_helper.rb
+++ b/app/helpers/link_to_helper.rb
@@ -6,6 +6,9 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 module LinkToHelper
+  # Required for when LinkToHelper is included in ActiveRecord models
+  include Rails.application.routes.url_helpers
+
   # Links to various models
 
   # Requests

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -32,7 +32,6 @@
 require 'digest'
 
 class FoiAttachment < ApplicationRecord
-  include Rails.application.routes.url_helpers
   include LinkToHelper
 
   include MessageProminence

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -42,7 +42,6 @@ require 'fileutils'
 class InfoRequest < ApplicationRecord
   OLD_AGE_IN_DAYS = 21.days
 
-  include Rails.application.routes.url_helpers
   include LinkToHelper
 
   include Categorisable

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -31,7 +31,6 @@ require 'set'
 require 'confidence_intervals'
 
 class PublicBody < ApplicationRecord
-  include Rails.application.routes.url_helpers
   include LinkToHelper
 
   include Categorisable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,7 +42,6 @@
 #
 
 class User < ApplicationRecord
-  include Rails.application.routes.url_helpers
   include LinkToHelper
 
   include Taggable


### PR DESCRIPTION
This include is only required because we're including LinkToHelper in models, so include it there to reduce duplication.

[skip changelog]
