### PR TITLE
[#2046] improve rake tasks to remove user generate content

### DIFF
--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -161,6 +161,13 @@ namespace :users do
   desc 'Destroy user accounts that have not created any content'
   task destroy_unused: :environment do
     users = User.unused.where(created_at: ...2.years.ago)
-    users.destroy_all
+
+    TrackThing.where(tracked_user_id: users).update_all(tracked_user_id: nil)
+
+    ActiveRecord::Base.logger.silence do
+      users.preload(
+        User.reflect_on_all_associations.map(&:name)
+      ).in_batches.destroy_all
+    end
   end
 end


### PR DESCRIPTION
Part of https://github.com/mysociety/sysadmin/issues/2046

## What does this do?

Improve rake tasks to remove user generate content optimising so tasks run quicker. Initially on WDTK these will still take a long time but running on a rolling basis should be much quicker now.

<hr>

[skip changelog]

