### PR TITLE
Add request creation interval rate limit

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -189,13 +189,12 @@ class RequestController < ApplicationController
       # can squirrel it away for tomorrow, so we detect this later after
       # we have constructed the InfoRequest.
       user_exceeded_limit = authenticated_user.exceeded_limit?(:info_requests)
+
       unless user_exceeded_limit
         @details = authenticated_user.can_fail_html
         render template: 'user/banned'
         return
       end
-      # User did exceed limit
-      @next_request_permitted_at = authenticated_user.next_request_permitted_at
     end
 
     # First time we get to the page, just display it

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -24,18 +24,7 @@ class Comment < ApplicationRecord
   include Rails.application.routes.url_helpers
   include LinkToHelper
 
-  DEFAULT_CREATION_RATE_LIMITS = {
-    1 => 2.seconds,
-    2 => 5.minutes,
-    4 => 30.minutes,
-    6 => 1.hour
-  }.freeze
-
-  cattr_accessor :creation_rate_limits,
-                 instance_reader: false,
-                 instance_writer: false,
-                 instance_accessor: false,
-                 default: DEFAULT_CREATION_RATE_LIMITS
+  include RateLimited
 
   strip_attributes allow_empty: true
 
@@ -99,14 +88,6 @@ class Comment < ApplicationRecord
       # For other databases (e.g. SQLite) not the end of the world being
       # space-sensitive for this check
       Comment.where(info_request_id: info_request_id, body: body).first
-    end
-  end
-
-  def self.exceeded_creation_rate?(comments)
-    comments = comments.reorder(created_at: :desc)
-
-    creation_rate_limits.any? do |limit, duration|
-      comments.where(created_at: duration.ago..).size >= limit
     end
   end
 

--- a/app/models/concerns/rate_limited.rb
+++ b/app/models/concerns/rate_limited.rb
@@ -1,0 +1,41 @@
+# Ability to set and check the rate at which records are created.
+#
+# Custom limits can be set per record type:
+#
+# rate_limited 5 => 30.minutes, 10 => 2.hours
+#
+# Read this as: "A maximum of N (records) every X (time)"
+module RateLimited
+  extend ActiveSupport::Concern
+
+  DEFAULT_CREATION_RATE_LIMITS = {
+    1 => 2.seconds,
+    2 => 5.minutes,
+    4 => 30.minutes,
+    6 => 1.hour
+  }.freeze
+
+  included do
+    class << self
+      def rate_limited(limits = nil)
+        self.creation_rate_limits = limits if limits
+      end
+    end
+
+    cattr_accessor :creation_rate_limits,
+                   instance_reader: false,
+                   instance_writer: false,
+                   instance_accessor: false,
+                   default: DEFAULT_CREATION_RATE_LIMITS
+  end
+
+  class_methods do
+    def exceeded_creation_rate?(records)
+      records = records.reorder(created_at: :desc)
+
+      creation_rate_limits.any? do |limit, duration|
+        records.where(created_at: duration.ago..).size >= limit
+      end
+    end
+  end
+end

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -48,6 +48,7 @@ class InfoRequest < ApplicationRecord
   include Categorisable
   include Taggable
   include Notable
+  include RateLimited
 
   include AlaveteliPro::RequestSummaries
   include AlaveteliFeatures::Helpers
@@ -64,6 +65,8 @@ class InfoRequest < ApplicationRecord
   def self.admin_title
     'Request'
   end
+
+  rate_limited 1 => 1.minute, 2 => 8.minutes, 3 => 15.minutes, 5 => 1.hour
 
   strip_attributes allow_empty: true
   strip_attributes only: [:title],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -494,7 +494,10 @@ class User < ApplicationRecord
 
   # Various ways the user can be banned, and text to describe it if failed
   def can_file_requests?
-    active? && !exceeded_limit?(:info_requests)
+    return false unless active?
+
+    !exceeded_limit?(:info_requests) &&
+      !InfoRequest.exceeded_creation_rate?(info_requests)
   end
 
   def can_make_followup?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -527,22 +527,6 @@ class User < ApplicationRecord
     recent_content >= content_limit(content)
   end
 
-  def next_request_permitted_at
-    return nil if no_limit
-
-    request_limit = content_limit(:info_requests)
-    n_most_recent_requests =
-      InfoRequest.
-        where(["user_id = ? AND created_at > now() - '1 day'::interval", id]).
-          order(created_at: :desc).
-            limit(request_limit)
-
-    return nil if n_most_recent_requests.size < request_limit
-
-    nth_most_recent_request = n_most_recent_requests[-1]
-    nth_most_recent_request.created_at + 1.day
-  end
-
   def can_fail_html
     if banned?
       text = ban_text.strip

--- a/app/views/user/rate_limited.html.erb
+++ b/app/views/user/rate_limited.html.erb
@@ -2,13 +2,12 @@
 
 <h1><%=@title%></h1>
 
-<p><%= _("You have hit the rate limit on new requests. Users are ordinarily " \
-	       "limited to {{max_requests_per_user_per_day}} requests in any " \
-	       "rolling 24-hour period. You will be able to make another request " \
-	       "in {{can_make_another_request}}.",
-	     :max_requests_per_user_per_day => AlaveteliConfiguration::max_requests_per_user_per_day,
-	     :can_make_another_request => distance_of_time_in_words(
-      Time.zone.now, @next_request_permitted_at)) %></p>
+<p>
+  <%= _("You have hit the rate limit on new requests. Users are ordinarily " \
+        "limited to {{max_requests_per_user_per_day}} requests in any " \
+        "rolling 24-hour period." ,
+        max_requests_per_user_per_day: AlaveteliConfiguration.max_requests_per_user_per_day) %>
+</p>
 
 <p><%= _("There is a limit on the number of requests you can make in a day, " \
 	        "because we don’t want public authorities to be bombarded with " \

--- a/app/views/user/rate_limited.html.erb
+++ b/app/views/user/rate_limited.html.erb
@@ -9,6 +9,12 @@
         max_requests_per_user_per_day: AlaveteliConfiguration.max_requests_per_user_per_day) %>
 </p>
 
+<p>
+  <%= _('There is also a limit on the speed at which you are able to create ' \
+        'requests. Please try again later if you have not hit your daily ' \
+        'limit.') %>
+</p>
+
 <p><%= _("There is a limit on the number of requests you can make in a day, " \
 	        "because we don’t want public authorities to be bombarded with " \
 	        "large numbers of inappropriate requests. If you feel you have a " \

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add rate limiting to request creation (Gareth Rees)
 * Don't run the spam checker for admin accounts or accounts confirmed as not
   spam on sign in (Gareth Rees)
 * Add no crawl meta tags to banned/closed user profile pages (Graeme Porteous)

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -130,6 +130,107 @@ RSpec.describe InfoRequest do
     end
   end
 
+  # rubocop:disable Layout/FirstArrayElementIndentation
+  describe '.exceeded_creation_rate?' do
+    subject { described_class.exceeded_creation_rate?(records) }
+
+    context 'when there are no records' do
+      let(:records) { described_class.where(id: nil) }
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the last record was created in the last second' do
+      let(:records) do
+        described_class.where(id: [
+          FactoryBot.create(:info_request, created_at: 0.seconds.ago)
+        ])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the last record was created a few minutes ago' do
+      let(:records) do
+        described_class.where(id: [
+          FactoryBot.create(:info_request, created_at: 2.minutes.ago)
+        ])
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the last 2 records were created in the last 8 minutes' do
+      let(:records) do
+        described_class.where(id: [
+          FactoryBot.create(:info_request, created_at: 1.second.ago),
+          FactoryBot.create(:info_request, created_at: 2.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 3.days.ago)
+        ])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the last 3 records were created in the last 15 minutes' do
+      let(:records) do
+        described_class.where(id: [
+          FactoryBot.create(:info_request, created_at: 1.second.ago),
+          FactoryBot.create(:info_request, created_at: 2.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 5.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 10.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 3.days.ago)
+        ])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the last 5 records were created in the last hour' do
+      let(:records) do
+        described_class.where(id: [
+          FactoryBot.create(:info_request, created_at: 1.second.ago),
+          FactoryBot.create(:info_request, created_at: 2.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 5.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 10.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 40.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 50.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 3.days.ago)
+        ])
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the records are reasonably spaced' do
+      let(:records) do
+        described_class.where(id: [
+          FactoryBot.create(:info_request, created_at: 15.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 12.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 40.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 3.hours.ago),
+          FactoryBot.create(:info_request, created_at: 8.hours.ago),
+          FactoryBot.create(:info_request, created_at: 1.day.ago),
+          FactoryBot.create(:info_request, created_at: 3.days.ago)
+        ])
+      end
+
+      it { is_expected.to eq(false) }
+    end
+
+    context 'when the records are provided out of order' do
+      let(:records) do
+        described_class.where(id: [
+          FactoryBot.create(:info_request, created_at: 3.days.ago),
+          FactoryBot.create(:info_request, created_at: 2.minutes.ago),
+          FactoryBot.create(:info_request, created_at: 1.second.ago)
+        ]).order(created_at: :asc)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+  end
+  # rubocop:enable Layout/FirstArrayElementIndentation
+
   describe '#foi_attachments' do
     subject { info_request.foi_attachments }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2111,7 +2111,7 @@ RSpec.describe User do
       it { is_expected.to eq(false) }
     end
 
-    context 'when the user has reached their rate limit' do
+    context 'when the user has reached their daily limit' do
       let(:user) { FactoryBot.build(:user) }
 
       before do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2121,6 +2121,32 @@ RSpec.describe User do
 
       it { is_expected.to eq(false) }
     end
+
+    context 'when the user has not reached their rate limit' do
+      let(:user) { FactoryBot.build(:user) }
+
+      before do
+        expect(InfoRequest).
+          to receive(:exceeded_creation_rate?).
+          with(user.info_requests).
+          and_return(false)
+      end
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the user has reached their rate limit' do
+      let(:user) { FactoryBot.build(:user) }
+
+      before do
+        expect(InfoRequest).
+          to receive(:exceeded_creation_rate?).
+          with(user.info_requests).
+          and_return(true)
+      end
+
+      it { is_expected.to eq(false) }
+    end
   end
 
   describe '#can_make_comments?' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/whatdotheyknow-private/issues/415

## What does this do?

Prevents too many requests being created too quickly.

## Why was this needed?

We don't want to allow a user to sign up and smash through their daily limit in 5 minutes, then create a new account to do the same, and so on.

This ensures that the allocation is used sensibly. It hopefully won't affect the majority of genuine users.

## Implementation notes

Same vibe as https://github.com/mysociety/alaveteli/pull/7602. Extracted out a shared concern (cc https://github.com/mysociety/alaveteli/issues/7620) 

## Screenshots

<img width="1056" height="369" alt="Screenshot 2025-09-08 at 08 32 06" src="https://github.com/user-attachments/assets/bb526778-d147-4401-b857-89b63e54740a" />

