### PR TITLE
404 for not found AttachmentToHTML sub-files

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -102,6 +102,9 @@ class AttachmentsController < ApplicationController
         request.format = :html
         render_hidden('request/hidden_attachment')
       end
+    elsif params[:file_name] =~ /^foiextract.*/
+      # 404 for AttachmentToHTML sub-files that can't be found
+      raise ActiveRecord::RecordNotFound
     elsif params[:file_name]
       # If we can't find the right attachment, redirect to the incoming message:
       redirect_to incoming_message_url(@incoming_message), status: 303

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Don't redirect missing HTML conversion attachments to the request page
+  (Matthew Somerville, Gareth Rees)
 * Don't run the spam checker for admin accounts or accounts confirmed as not
   spam on sign in (Gareth Rees)
 * Add no crawl meta tags to banned/closed user profile pages (Graeme Porteous)

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe AttachmentsController, type: :controller do
       expect(response).to redirect_to(incoming_message_path(message))
     end
 
+    it '404s for HTML extraction sub-files that are not found' do
+      params = {
+        part: attachment.url_part_number + 1,
+        file_name: 'foiextract20250908-21-h85mbn-1_1.jpg'
+      }
+
+      expect { show(params) }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
     it 'should find a uniquely named filename even if the URL part number was wrong' do
       show(part: 5)
       expect(response.body).to match('hereisthemaskedtext')


### PR DESCRIPTION
When we extract PDFs to HTML we try to extract the text to HTML text, but many will also include images for parts of the PDF that can't be parsed or don't make sense to parse as text.

Parts of this can fail, leaving missing images. Every missing image in an attachment causes a redirect to the request page, meaning we see large spikes to request pages when accessing attachments with lots of missing images, effectively self-DDOSing the app.

The 303 redirect was introduced in 501b2b8. For top-level attachments this makes more sense, since occasionally the part number / filename can change (through reparsing, and since then we can now modify attachment names), so in that case it's nicer to take users back to at least the request page where the attachment originated as they may be able to find the equivalent current version.

It doesn't make sense to do this for these sub-files that are used in the to-HTML process, as these aren't intended to be accessed directly.

h/t @dracos for the diagnosis and bones of this improvement.
