### PR TITLE
[#8870] Confirm users after following password reset link

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -13,9 +13,10 @@ class Users::ConfirmationsController < UserController
         clear_session_credentials
       end
 
+      confirm_user!(post_redirect.user)
+
       redirect_to SafeRedirect.new(post_redirect.uri).path
       return
-
     when 'normal', 'change_email'
       # !User.stay_logged_in_on_redirect?(nil)
       # # => true

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Confirm unconfirmed users after following a password reset confirmation link
+  (Gareth Rees)
 * Don't run the spam checker for admin accounts or accounts confirmed as not
   spam on sign in (Gareth Rees)
 * Add no crawl meta tags to banned/closed user profile pages (Graeme Porteous)

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe Users::ConfirmationsController do
         expect(assigns[:user]).to eq(user)
       end
 
-      it 'does not confirm an unconfirmed user' do
+      it 'confirms an unconfirmed user' do
         get :confirm, params: { email_token: post_redirect.email_token }
-        expect(user.reload.email_confirmed).to eq(false)
+        expect(user.reload.email_confirmed).to eq(true)
       end
 
       it 'redirects to the post redirect uri' do


### PR DESCRIPTION
If an unconfirmed user resets their password, they are logged in and can perform actions like creating requests while their account is still unconfirmed.

The password reset link acts as a confirmation email, so it doesn't seem like there's a reason not to confirm them in this step.

Fixes https://github.com/mysociety/alaveteli/issues/8870.

## Notes to Reviewer

@gbp can you think of any reasons _not_ to do this?
