### PR TITLE
Added `button` class to share private link buttons

### DIFF
--- a/app/views/request/_share_by_link.html.erb
+++ b/app/views/request/_share_by_link.html.erb
@@ -6,9 +6,9 @@
       <%= text_field_tag 'share_by_link',
         public_token_url(info_request.public_token, locale: false) %>
 
-      <%= button_to _('Disable'), public_tokens_path, method: :delete %>
+      <%= button_to _('Disable'), public_tokens_path, method: :delete, class: 'button' %>
     <% else %>
-      <%= button_to _('Enable'), public_tokens_path %>
+      <%= button_to _('Enable'), public_tokens_path, class: 'button' %>
     <% end %>
 
     <p class="sidebar__note">


### PR DESCRIPTION
## Relevant issue(s)

Fixes: [Embargoed request private link "Enable" button has odd (absent) styling](https://github.com/mysociety/whatdotheyknow-theme/issues/1957)	https://github.com/mysociety/whatdotheyknow-theme/issues/1957

## What does this do?
Adds class `button` to "Enable" and "Disable" buttons, so it matches the style of each theme.
## Why was this needed?

## Implementation notes

## Screenshots

<img width="1013" height="808" alt="Screenshot 2025-09-17 at 11 31 26" src="https://github.com/user-attachments/assets/8e1af19b-da7e-4908-993b-6f348bac435d" />


## Notes to reviewer

<hr>

[skip changelog]