### PR TITLE
8794 padding correspondence

### DIFF
--- a/app/assets/stylesheets/responsive/_request_layout.scss
+++ b/app/assets/stylesheets/responsive/_request_layout.scss
@@ -178,15 +178,9 @@ a.track-request-action {
   }
 
   .correspondence {
-    @include grid-column(12);
+    display: inline-block;
     @include respond-min( $main_menu-mobile_menu_cutoff ){
-      @include grid-column(9);
-      @include ie8{
-        padding-right: 0.9375em;
-      }
-      @include lte-ie7 {
-        width: 41.625em;
-      }
+      width: 42rem;
     }
   }
 

--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -112,8 +112,9 @@ a.track-request-action {
 .correspondence__header__date,
 .correspondence__header__date:visited {
   font-size: 0.875em;
-  color: #777;
+  color: #626262;
   text-decoration: none;
+  margin-left: 0.25rem;
   &:hover,
   &:active,
   &:focus {


### PR DESCRIPTION
## Relevant issue(s)
Fixes: https://github.com/mysociety/alaveteli/issues/8794

## What does this do?
- Fixes odd padding on `#show_response_view.correspondence` element
- Increases color contrast for `.correspondence__header__date`
- Add `margin-left` to `.correspondence__header__date`

## Why was this needed?

## Implementation notes

## Screenshots

<img width="1166" height="677" alt="Screenshot 2025-09-22 at 07 35 07" src="https://github.com/user-attachments/assets/28f48b8d-f179-43af-8245-b0819de7941e" />

<img width="1166" height="677" alt="Screenshot 2025-09-22 at 07 38 58" src="https://github.com/user-attachments/assets/9b8a882d-910f-49d3-b5f6-57e81e7a9693" />


## Notes to reviewer

<hr>

[skip changelog]
