### PR TITLE
Update `cattr_*` calls

### DIFF
--- a/app/models/concerns/rate_limited.rb
+++ b/app/models/concerns/rate_limited.rb
@@ -23,8 +23,6 @@ module RateLimited
     end
 
     cattr_accessor :creation_rate_limits,
-                   instance_reader: false,
-                   instance_writer: false,
                    instance_accessor: false,
                    default: DEFAULT_CREATION_RATE_LIMITS
   end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -21,14 +21,18 @@ class Note < ApplicationRecord
   delegate :rich_body, :rich_body=, :rich_body?, to: :translation
   after_save { rich_body.save if rich_body.changed? }
 
-  cattr_accessor :default_style, default: 'original'
-  cattr_accessor :style_labels, default: {
-    '🔴 Red': 'red',
-    '🟡 Yellow': 'yellow',
-    '🟢 Green': 'green',
-    '🔵 Blue': 'blue',
-    'Original': 'original'
-  }
+  cattr_accessor :default_style,
+                 instance_accessor: false,
+                 default: 'original'
+  cattr_accessor :style_labels,
+                 instance_accessor: false,
+                 default: {
+                   '🔴 Red': 'red',
+                   '🟡 Yellow': 'yellow',
+                   '🟢 Green': 'green',
+                   '🔵 Blue': 'blue',
+                   'Original': 'original'
+                 }
 
   enum :style, Note.style_labels.values.index_by(&:itself),
                default: Note.default_style,

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -50,7 +50,9 @@ class PublicBody < ApplicationRecord
   attr_accessor :no_xapian_reindex
 
   # Set to 0 to prevent application of the not_many_requests tag
-  cattr_accessor :not_many_public_requests_size, default: 5
+  cattr_accessor :not_many_public_requests_size,
+                 instance_writer: false,
+                 default: 5
 
   # Any PublicBody tagged with any of the follow tags won't be returned in the
   # batch authority search results or batch category UI

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -54,7 +54,9 @@ class PublicBody < ApplicationRecord
 
   # Any PublicBody tagged with any of the follow tags won't be returned in the
   # batch authority search results or batch category UI
-  cattr_accessor :batch_excluded_tags, default: %w[not_apply defunct]
+  cattr_accessor :batch_excluded_tags,
+                 instance_accessor: false,
+                 default: %w[not_apply defunct]
 
   has_many :info_requests,
            -> { order(created_at: :desc) },

--- a/app/models/public_body/calculated_home_page.rb
+++ b/app/models/public_body/calculated_home_page.rb
@@ -2,9 +2,14 @@
 module PublicBody::CalculatedHomePage
   extend ActiveSupport::Concern
 
-  included do
-    cattr_accessor :excluded_calculated_home_page_domains,
-                   default: Domains.webmail_providers
+  class_methods do
+    def excluded_calculated_home_page_domains
+      @excluded_calculated_home_page_domains ||= Domains.webmail_providers
+    end
+
+    def excluded_calculated_home_page_domains=(domains)
+      @excluded_calculated_home_page_domains = domains
+    end
   end
 
   def calculated_home_page
@@ -34,6 +39,6 @@ module PublicBody::CalculatedHomePage
   end
 
   def excluded_calculated_home_page_domain?(domain)
-    excluded_calculated_home_page_domains.include?(domain)
+    self.class.excluded_calculated_home_page_domains.include?(domain)
   end
 end

--- a/app/models/public_body/csv_import.rb
+++ b/app/models/public_body/csv_import.rb
@@ -9,7 +9,7 @@ module PublicBody::CsvImport
   included do
     # Default fields available for importing from CSV, in the format
     # [field_name, 'short description of field (basic html allowed)']
-    cattr_accessor :csv_import_fields do
+    cattr_accessor :csv_import_fields, instance_writer: false do
       [
         ['name', '(i18n)<strong>Existing records cannot be renamed</strong>'],
         ['short_name', '(i18n)'],

--- a/app/models/public_body/foi_officer_access.rb
+++ b/app/models/public_body/foi_officer_access.rb
@@ -3,13 +3,19 @@
 module PublicBody::FoiOfficerAccess
   extend ActiveSupport::Concern
 
-  included do
-    cattr_accessor :excluded_foi_officer_access_domains,
-                   default: Domains.webmail_providers
+  class_methods do
+    def excluded_foi_officer_access_domains
+      @excluded_foi_officer_access_domains ||= Domains.webmail_providers
+    end
+
+    def excluded_foi_officer_access_domains=(domains)
+      @excluded_foi_officer_access_domains = domains
+    end
   end
 
   def foi_officer_domain_excluded?
-    excluded_foi_officer_access_domains.include?(request_email_domain)
+    self.class.excluded_foi_officer_access_domains.
+      include?(request_email_domain)
   end
 
   # Does this user have the power of FOI officer for this body?
@@ -32,7 +38,7 @@ module PublicBody::FoiOfficerAccess
   end
 
   def no_restrictions_on_domain?(user)
-    !excluded_foi_officer_access_domains.include?(user.email_domain)
+    !self.class.excluded_foi_officer_access_domains.include?(user.email_domain)
   end
 
   def outside_user?(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,7 +65,9 @@ class User < ApplicationRecord
     user_messages: AlaveteliConfiguration.max_requests_per_user_per_day
   }.freeze
 
-  cattr_accessor :content_limits, default: DEFAULT_CONTENT_LIMITS
+  cattr_accessor :content_limits,
+                 instance_writer: false,
+                 default: DEFAULT_CONTENT_LIMITS
 
   rolify before_add: :setup_pro_account,
          after_add: :assign_role_features,

--- a/lib/acts_as_xapian/acts_as_xapian.rb
+++ b/lib/acts_as_xapian/acts_as_xapian.rb
@@ -1181,7 +1181,7 @@ module ActsAsXapian
 
       include InstanceMethods
 
-      cattr_accessor :xapian_options
+      cattr_accessor :xapian_options, instance_writer: false
       self.xapian_options = options
 
       ActsAsXapian.init(self.class.to_s, options)

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -252,7 +252,12 @@ RSpec.describe PublicBody do
       let!(:public_body) { FactoryBot.create(:public_body) }
 
       # Reduce size for test so we have to create fewer records
-      before { public_body.not_many_public_requests_size = 2 }
+      around do |example|
+        original_size = PublicBody.not_many_public_requests_size
+        PublicBody.not_many_public_requests_size = 2
+        example.run
+        PublicBody.not_many_public_requests_size = original_size
+      end
 
       before do
         FactoryBot.create_list(:info_request, 2, public_body: public_body)
@@ -2376,10 +2381,15 @@ RSpec.describe PublicBody do
   describe '#info_request_count_changed' do
     subject { public_body.info_request_count_changed }
 
+    around do |example|
+      original_size = PublicBody.not_many_public_requests_size
+      PublicBody.not_many_public_requests_size = 2
+      example.run
+      PublicBody.not_many_public_requests_size = original_size
+    end
+
     context 'when there are not many public requests' do
       let!(:public_body) { FactoryBot.create(:public_body) }
-
-      before { public_body.not_many_public_requests_size = 2 }
 
       it 'adds the not many requests tag' do
         subject
@@ -2389,8 +2399,6 @@ RSpec.describe PublicBody do
 
     context 'when a request email is removed' do
       let!(:public_body) { FactoryBot.create(:public_body) }
-
-      before { public_body.not_many_public_requests_size = 2 }
 
       before do
         FactoryBot.create_list(:info_request, 3, public_body: public_body)


### PR DESCRIPTION
## What does this do?

Update `cattr_*` calls

## Why was this needed?

We noticed in https://github.com/mysociety/whatdotheyknow-theme/pull/2052 that using the defaults value option for `cattr_*` can cause issues when the defaul value itself is sourced from the class attribute. This PR fixes this and updates other `cattr_*` as now I've looked more at the documentation of the method I understand what it is actually doing and in some cases we don't need the instance methods in defined by default.

<hr>

[skip changelog]