### PR TITLE
Fix signup button layout

### DIFF
--- a/app/views/user/_signup.html.erb
+++ b/app/views/user/_signup.html.erb
@@ -48,9 +48,12 @@
     <div class="form_button">
       <%= hidden_field_tag 'token', params[:token], {:id => 'signup_token' } %>
       <%= hidden_field_tag :modal, params[:modal], {:id => 'signup_modal' } %>
-      <%= submit_tag _('Sign up'),
-                     :tabindex => 50,
-                     :data => { :disable_with => _("Sending...") } %>
+
+      <p>
+        <%= submit_tag _('Sign up'),
+                       :tabindex => 50,
+                       :data => { :disable_with => _("Sending...") } %>
+      </p>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
Other form fields are within a `<p>` tag to give them margin bottom. In WDTK we customise this view to add another form_item_note underneath the button, which gets jammed up against it.

A `<p>` isn't the most ideal way to fix this but it mirrors what's there without having to mess around with the whole view.

No real change in core but see https://github.com/mysociety/whatdotheyknow-theme/pull/2056 for theme context.

[skip changelog]
