### PR TITLE
Clean up raw email actions

### DIFF
--- a/app/views/admin_incoming_message/_actions.html.erb
+++ b/app/views/admin_incoming_message/_actions.html.erb
@@ -21,17 +21,8 @@
     </label>
 
     <div class="controls">
-      <%
-        redeliver_to =
-        if @guessed_info_requests&.one?
-          @guessed_info_requests.first.info_request.url_title
-        else
-            ''
-        end
-      %>
-
       <div class="input-append">
-        <%= text_field_tag 'url_title', redeliver_to, size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
+        <%= text_field_tag 'url_title', nil, size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
         <%= submit_tag 'Redeliver to another request', class: 'btn' %>
       </div>
 
@@ -73,18 +64,14 @@
   </div>
 <% end %>
 
-<% if @raw_email.nil? %>
-  <%# we're not on the raw_email page itself %>
-  <div class="control-group">
-    <label class="control-label">Inspect raw email</label>
+<div class="control-group">
+  <label class="control-label">Inspect raw email</label>
 
-    <div class="controls">
-      <div class="btn-group">
-        <%= link_to 'View', admin_raw_email_path(incoming_message.raw_email_id), class: 'btn' %>
-        <%= link_to 'Download', admin_raw_email_path(incoming_message.raw_email, format: 'eml'), class: 'btn' %>
-      </div>
+  <div class="controls">
+    <div class="btn-group">
+      <%= link_to 'View', admin_raw_email_path(incoming_message.raw_email_id), class: 'btn' %>
+      <%= link_to 'Download', admin_raw_email_path(incoming_message.raw_email, format: 'eml'), class: 'btn' %>
     </div>
   </div>
-<% end %>
-
+</div>
 </fieldset>

--- a/app/views/admin_incoming_message/_holding_pen_actions.html.erb
+++ b/app/views/admin_incoming_message/_holding_pen_actions.html.erb
@@ -1,0 +1,49 @@
+<fieldset class="form-horizontal">
+  <legend>Actions</legend>
+
+  <%= form_tag redeliver_admin_incoming_message_path(incoming_message), class: 'form form-inline' do %>
+    <div class="control-group">
+      <label class="control-label" for="url_title_<%= incoming_message.id %>">
+        Redeliver message to one or more other requests
+      </label>
+
+      <div class="controls">
+        <%
+          redeliver_to =
+          if @guessed_info_requests&.one?
+            @guessed_info_requests.first.info_request.url_title
+          else
+              ''
+          end
+        %>
+
+        <div class="input-append">
+          <%= text_field_tag 'url_title', redeliver_to, size: 20, id: "url_title_#{ incoming_message.id }", required: true %>
+          <%= submit_tag 'Redeliver to another request', class: 'btn' %>
+        </div>
+
+        <p class="help-block">
+          <code>id</code> or <code>url_title</code>; you can supply more than one,
+          separated by commas
+        </p>
+      </div>
+    </div>
+  <% end %>
+
+  <%= form_tag admin_incoming_message_path(incoming_message), method: 'delete', class: 'form form-inline' do %>
+    <div class="control-group">
+      <label class="control-label" for="destroy_message_<%= incoming_message.id %>">
+        Destroy message
+      </label>
+
+      <div class="controls">
+        <%= hidden_field_tag 'incoming_message_id', incoming_message.id, id: nil %>
+
+        <%= submit_tag 'Destroy message',
+                       class: 'btn btn-danger',
+                       data: { confirm: 'This is permanent! Are you sure?' },
+                       id: "destroy_message_#{ incoming_message.id }" %>
+      </div>
+    </div>
+  <% end %>
+</fieldset>

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -4,7 +4,7 @@
   <%= render partial: 'admin_raw_email/holding_pen' %>
 
   <div>
-    <%= render partial: 'admin_incoming_message/actions',
+    <%= render partial: 'admin_incoming_message/holding_pen_actions',
                locals: { incoming_message: @raw_email.incoming_message } %>
   </div>
 <% end %>

--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -2,13 +2,12 @@
 
 <% if @holding_pen %>
   <%= render partial: 'admin_raw_email/holding_pen' %>
+
+  <div>
+    <%= render partial: 'admin_incoming_message/actions',
+               locals: { incoming_message: @raw_email.incoming_message } %>
+  </div>
 <% end %>
-
-<div>
-  <%= render :partial => 'admin_incoming_message/actions', :locals => { :incoming_message => @raw_email.incoming_message } %>
-</div>
-
-<h2>Preview</h2>
 
 <p>
   <%= link_to 'Download', admin_raw_email_path(@raw_email, format: 'eml'), class: 'btn' %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Simplify IncomingMessage/RawEmail admin actions so that only relevant actions
+  are shown in various admin UI screens (Gareth Rees)
 * Confirm unconfirmed users after following a password reset confirmation link
   (Gareth Rees)
 * Don't redirect missing HTML conversion attachments to the request page


### PR DESCRIPTION
Minor clean up the admin raw email actions while thinking about https://github.com/mysociety/alaveteli/issues/8803.

---

Actions on the incoming message view as they are now:

<img width="975" height="698" alt="Screenshot 2025-09-23 at 16 11 55" src="https://github.com/user-attachments/assets/4134782d-fcd6-4cdf-a2b7-8d84492a6121" />

But now no actions on the raw email page (since the actions are all taken on the incoming message):

<img width="971" height="258" alt="Screenshot 2025-09-23 at 16 12 02" src="https://github.com/user-attachments/assets/b53e7f98-f603-412c-b0ad-279f4dd099b2" />

…except when in the holding pen we now have the subset of relevant actions (we _show_ the raw email but take _action_ on the incoming message 🫠):

<img width="985" height="682" alt="Screenshot 2025-09-23 at 16 11 39" src="https://github.com/user-attachments/assets/4663272c-b15a-4685-9afa-b13a14f5a7ae" />


[skip changelog]
