### PR TITLE
[#8906] Prevent on-site citations

### DIFF
--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -30,10 +30,14 @@ class Citation < ApplicationRecord
   belongs_to :info_request_batch, via: :citable, optional: true
 
   validates :citable_type, inclusion: { in: %w(InfoRequest InfoRequestBatch) }
+
   validates :source_url, length: { maximum: 255,
                                    message: _('Source URL is too long') },
                          format: { with: /\Ahttps?:\/\/.*\z/,
                                    message: _('Please enter a Source URL') }
+  validates :source_url, format: { without: /\Ahttps?:\/\/#{AlaveteliConfiguration.domain}.*\z/,
+                         message: _('Citations can only be added for external URLs') }
+
   validates :type, inclusion: { in: %w(journalism research campaigning other),
                                 message: _('Please select a type') }
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Only allow Citations to be added for external URLs (Gareth Rees)
 * Allow censor rules to ignore diacritics (Gareth Rees)
 * Allow censor rules to be case insensitive (Gareth Rees)
 * Add Content Security Policy with nonce-based script protection (Graeme

--- a/spec/models/citation_spec.rb
+++ b/spec/models/citation_spec.rb
@@ -232,6 +232,17 @@ RSpec.describe Citation, type: :model do
       is_expected.not_to be_valid
     end
 
+    it 'requires source_url to be an external domain' do
+      citation.source_url = "https://#{AlaveteliConfiguration.domain}/foo.pdf"
+      is_expected.not_to be_valid
+    end
+
+    it 'allows source_url where the external domain is incidental' do
+      domain = AlaveteliConfiguration.domain
+      citation.source_url = "https://example.com/#{domain}-is-great.pdf"
+      is_expected.to be_valid
+    end
+
     it 'requires type' do
       citation.type = nil
       is_expected.not_to be_valid


### PR DESCRIPTION
We've seen a few cases where Citations have been added where the source_url is a link to the Alaveteli site.

* In a few cases the requester has added a Citation linking to the request the citation was added to
* A user included a confirmation URL, which when followed logged you in to their account
* In one case a user legitimately added a citation to another request, where the request was based on a previous response

In most cases citations are intended to be more about external sources that link to the platform.

Fixes https://github.com/mysociety/alaveteli/issues/8906.

<img width="1042" height="354" alt="Screenshot 2025-10-02 at 12 25 47" src="https://github.com/user-attachments/assets/0a3a84ac-f533-4ba4-8705-b29ba5ba44e4" />

## Notes to reviewer

Do we have a helper instead of using the full `AlaveteliConfiguration.domain` call? Don't think its worth adding just for this, but if we've got something shorter I'll push a fixup.