### PR TITLE
Add logging of storage keys

### DIFF
--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -34,7 +34,8 @@ class AdminIncomingMessageController < AdminController
     @incoming_message.info_request.log_event(
       'destroy_incoming',
       editor: admin_current_user,
-      deleted_incoming_message_id: @incoming_message.id
+      deleted_incoming_message_id: @incoming_message.id,
+      storage_keys: @incoming_message.storage_keys
     )
     # expire cached files
     @incoming_message.info_request.expire(preserve_database_cache: true)
@@ -57,7 +58,8 @@ class AdminIncomingMessageController < AdminController
         info_request.log_event(
           'destroy_incoming',
           editor: admin_current_user,
-          deleted_incoming_message_id: message.id
+          deleted_incoming_message_id: message.id,
+          storage_keys: message.storage_keys
         )
       rescue
         errors << message.id
@@ -114,7 +116,8 @@ class AdminIncomingMessageController < AdminController
           'redeliver_incoming',
           editor: admin_current_user,
           destination_request: destination_request.id,
-          deleted_incoming_message_id: @incoming_message.id
+          deleted_incoming_message_id: @incoming_message.id,
+          storage_keys: @incoming_message.storage_keys
         )
 
         flash[:notice] =

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -343,6 +343,10 @@ class FoiAttachment < ApplicationRecord
                  normalize_line_endings(body)
   end
 
+  def storage_key
+    file.blob.key if file&.attached?
+  end
+
   private
 
   def mail_attributes

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -656,6 +656,13 @@ class IncomingMessage < ApplicationRecord
     foi_attachments.locked.any?
   end
 
+  def storage_keys
+    keys = {}
+    keys[:raw_email] = raw_email.storage_key
+    keys[:attachments] = foi_attachments.map(&:storage_key)
+    keys
+  end
+
   private
 
   def legislation_references

--- a/app/models/raw_email.rb
+++ b/app/models/raw_email.rb
@@ -110,6 +110,10 @@ class RawEmail < ApplicationRecord
     MailHandler.get_subject(mail)
   end
 
+  def storage_key
+    file.blob.key if file&.attached?
+  end
+
   private
 
   def empty_return_path?

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add logging of storage keys when destroying and redelivering incoming messages
+  (Graeme Porteous)
 * Add icons to classification forms (Gareth Rees, Lucas Cumsille Montesinos)
 * Store user locale preference in a separate cookie instead of the encrypted
   Rails session cookie to enable Varnish and other caching layers to read it

--- a/spec/factories/raw_emails.rb
+++ b/spec/factories/raw_emails.rb
@@ -9,4 +9,19 @@
 
 FactoryBot.define do
   factory :raw_email
+
+  trait :with_file do
+    transient do
+      sequence(:filename) { |n| "#{n + 1}.eml" }
+      mail { Mail.new }
+    end
+
+    after(:build) do |foi_attachment, evaluator|
+      foi_attachment.file.attach(
+        io: StringIO.new(evaluator.mail.to_s),
+        filename: evaluator.filename,
+        content_type: 'message/rfc822'
+      )
+    end
+  end
 end

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -919,4 +919,27 @@ RSpec.describe FoiAttachment do
       end
     end
   end
+
+  describe '#storage_key' do
+    let(:foi_attachment) { FactoryBot.create(:foi_attachment) }
+
+    context 'when file is attached' do
+      it 'returns the blob key' do
+        expect(foi_attachment.file).to be_attached
+        storage_key = foi_attachment.storage_key
+        expect(storage_key).to eq(foi_attachment.file.blob.key)
+      end
+    end
+
+    context 'when file is not attached' do
+      before do
+        allow(foi_attachment).to receive(:file).
+          and_return(double(attached?: false))
+      end
+
+      it 'returns nil' do
+        expect(foi_attachment.storage_key).to be_nil
+      end
+    end
+  end
 end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -1300,4 +1300,33 @@ RSpec.describe IncomingMessage, 'when getting the main body text' do
       )
     end
   end
+
+  describe '#storage_keys' do
+    let(:incoming_message) { FactoryBot.create(:incoming_message) }
+
+    it 'returns blob keys from raw email and foi attachments' do
+      storage_keys = incoming_message.storage_keys
+
+      expect(storage_keys).to be_an(Hash)
+      expect(storage_keys).to include(
+        raw_email: incoming_message.raw_email.file.blob.key,
+        attachments: incoming_message.foi_attachments.map { _1.file.blob.key }
+      )
+    end
+
+    context 'when no attachments are present' do
+      let(:incoming_message) { FactoryBot.create(:incoming_message) }
+
+      before do
+        allow(incoming_message.raw_email).to receive(:file).
+          and_return(double(attached?: false))
+        allow(incoming_message).to receive(:foi_attachments).and_return([])
+      end
+
+      it 'returns an hash without any keys' do
+        expect(incoming_message.storage_keys).
+          to eq({ raw_email: nil, attachments: [] })
+      end
+    end
+  end
 end

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -211,4 +211,24 @@ RSpec.describe RawEmail do
 
     it { is_expected.to eq('example.net') }
   end
+
+  describe '#storage_key' do
+    let(:raw_email) { FactoryBot.create(:raw_email, :with_file) }
+
+    context 'when file is attached' do
+      it 'returns the blob key' do
+        expect(raw_email.file).to be_attached
+        storage_key = raw_email.storage_key
+        expect(storage_key).to eq(raw_email.file.blob.key)
+      end
+    end
+
+    context 'when file is not attached' do
+      let(:raw_email) { FactoryBot.create(:raw_email) }
+
+      it 'returns nil' do
+        expect(raw_email.storage_key).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## What does this do?

Add logging of storage keys to `destroy_incomming` events

## Why was this needed?

When deleting incoming messages we sometimes need to know the storage keys used to ensure the raw email and attachment files are promptly deleted from our systems and backups.

## Implementation notes

We also delete raw emails/attachments we redelivering messages to different requests; so logging happens here too.

## Screenshots

<img width="682" height="122" alt="Screenshot 2025-10-16 at 10 46 03" src="https://github.com/user-attachments/assets/93211c17-fe68-4810-a86a-21e2e388993e" />
<img width="848" height="133" alt="Screenshot 2025-10-16 at 10 47 05" src="https://github.com/user-attachments/assets/d5ff2f5d-f727-4404-a3a6-a234913a29c7" />

