### PR TITLE
Update production logging

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [ :request_id ]
-  # config.logger   = ActiveSupport::TaggedLogging.logger(STDOUT)
+  config.log_formatter = Logger::Formatter.new
 
   # Change to "debug" to log everything (including potentially personally-identifiable information!)
   config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")


### PR DESCRIPTION
Use the original logger we used before upgrading to Rails 7.1 which includes PID and timestamps.

See: 3b5f9edb13b7d8bc3547f8a55482211a534cf117

<hr>

[skip changelog]