### PR TITLE
Remove redundant project extract ivar assignments

### DIFF
--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -35,14 +35,10 @@ class Projects::ExtractsController < Projects::BaseController
   end
 
   def edit
-    @info_request = @submission.info_request
-    @value_set = @submission.resource
-
     render :show
   end
 
   def update
-    @value_set = Dataset::ValueSet.new(extract_params)
     @submission = @submission.create_new_version(
       user: current_user, **submission_params
     )


### PR DESCRIPTION
These instance variables are already set by before_action callbacks and the redundant assignments were incorrectly resetting @info_request to nil when no submission exists.

Fixes ActionView::Template::Error caused by nil @info_request variable.

<hr>

[skip changelog]