### PR TITLE
Remove projects self-serve feature flag

### DIFF
--- a/app/views/alaveteli_pro/dashboard/_create_project.html.erb
+++ b/app/views/alaveteli_pro/dashboard/_create_project.html.erb
@@ -9,9 +9,7 @@
               site_name: site_name) %>
       </p>
 
-      <% if feature_enabled?(:pro_projects_self_serve, current_user) %>
-        <%= link_to _('Create a new Project'), new_alaveteli_pro_project_path, class: 'button' %>
-      <% end %>
+      <%= link_to _('Create a new Project'), new_alaveteli_pro_project_path, class: 'button' %>
     </div>
   </div>
 </div>

--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -56,10 +56,6 @@ Rails.configuration.after_initialize do
     :pro_batch_category_add_all,
     label: 'Batch category "add all" button'
   )
-  AlaveteliFeatures.features.add(
-    :pro_projects_self_serve,
-    label: 'Projects creation'
-  )
 
   next unless ActiveRecord::Base.connection.data_source_exists?(:roles)
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Made "Projects" feature available to all Pro users (Graeme Porteous)
 * Added batch stats to /version.json endpoint (Gareth Rees)
 * Add logging of storage keys when destroying and redelivering incoming messages
   (Graeme Porteous)


### PR DESCRIPTION
This allows the self-serve project creation making it generally available for all Pro users.
