### PR TITLE
Fix project queue submission redirection

### DIFF
--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -31,7 +31,7 @@ class Projects::ClassifiesController < Projects::BaseController
 
     if @submission.save
       flash[:notice] = _('Classification saved successfully!')
-      redirect_to params.fetch(:r, project_classify_path)
+      redirect_to params[:r].presence || project_classify_path
     else
       flash.now[:error] = _("Classification couldn't be saved.")
       render :show

--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -27,7 +27,7 @@ class Projects::ExtractsController < Projects::BaseController
 
     if @submission.save
       flash[:notice] = _('Extraction saved successfully!')
-      redirect_to params.fetch(:r, project_extract_path)
+      redirect_to params[:r].presence || project_extract_path
     else
       flash.now[:error] = _("Extraction couldn't be saved.")
       render :show


### PR DESCRIPTION
## What does this do?

Fix project queue submission redirection

## Why was this needed?

When submitting classifications or extractions for any request on the project queue we should redirect to the next request or to the project page if the queue is empty.

Before this commit we were redirecting to the pro dashboard as the `r` param would be empty instead of nil.

<hr>

[skip changelog]