### PR TITLE
[#8973] Fix dataset download headers

### DIFF
--- a/app/models/project/export.rb
+++ b/app/models/project/export.rb
@@ -57,7 +57,7 @@ class Project::Export
 
   def to_csv
     CSV.generate do |csv|
-      header = data.first
+      header = data_for_csv.first
       csv << header.keys.map(&:to_s) if header
       data_for_csv.each { |row| csv << row.values }
     end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8973

## What does this do?

Fix dataset download headers

## Why was this needed?

Ensure we are using the correct hash to generate the headers. The `data` method returns all columns include some extra ones used on the frontend which we don't want to include in the CSV.

<hr>

[skip changelog]