### PR TITLE
Unify terminology

### DIFF
--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -364,7 +364,7 @@
     <%= form_tag bulk_destroy_admin_incoming_messages_path do %>
       <%= hidden_field_tag(:ids) %>
       <%= hidden_field_tag(:request_id, @info_request.id) %>
-      <%= submit_tag("Delete selected messages",
+      <%= submit_tag("Destroy selected messages",
                      { :class => "btn btn-danger",
                        :disabled => true }) %>
     <% end %>


### PR DESCRIPTION
We use Destroy on the edit page for the records so be consistent here.

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
