### PR TITLE
Drop syck gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,7 +130,6 @@ gem 'sidekiq-limit_fetch', '~> 4.4.1'
 gem 'statistics2', '~> 0.54'
 gem 'strip_attributes', mysociety: 'strip_attributes', branch: 'globalize3-rails8'
 gem 'stripe', '~> 13.5.1'
-gem 'syck', '~> 1.4.1', require: false
 gem 'syslog_protocol', '~> 0.9.0'
 gem 'vpim', '~> 24.2.20'
 gem 'will_paginate', '~> 4.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -606,7 +606,6 @@ GEM
       drb (>= 2.0.4, < 3)
       multi_json (~> 1.0)
       stripe (> 5, < 14)
-    syck (1.4.1)
     syslog_protocol (0.9.2)
     text (1.3.1)
     thor (1.4.0)
@@ -757,7 +756,6 @@ DEPENDENCIES
   strip_attributes!
   stripe (~> 13.5.1)
   stripe-ruby-mock (~> 5.0.0)
-  syck (~> 1.4.1)
   syslog_protocol (~> 0.9.0)
   turbo-rails (~> 2.0.20)
   uglifier (~> 4.2.1)


### PR DESCRIPTION
Unused since switching to psych which is default Ruby gem.

<hr>

[skip changelog]