### PR TITLE
Allow users to be searched by tag

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -221,11 +221,16 @@ class User < ApplicationRecord
                  if: :indexed_by_search?
 
   def self.search(query)
-    where(<<~SQL, query: query)
-      lower(users.name) LIKE lower('%'||:query||'%') OR
-      lower(users.email) LIKE lower('%'||:query||'%') OR
-      lower(users.about_me) LIKE lower('%'||:query||'%')
+    sql = <<~SQL
+      users.name ILIKE '%'||:query||'%' OR
+      users.email ILIKE '%'||:query||'%' OR
+      users.about_me ILIKE '%'||:query||'%' OR
+      has_tag_string_tags.name ILIKE :query
     SQL
+
+    left_outer_joins(:tags).
+      where(sql, query: query).
+      distinct
   end
 
   def self.pro

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -8,7 +8,9 @@
       <%= submit_tag 'Search', class: 'btn' %>
     </div>
 
-    <span class="help-inline">(substring search, names, emails and about me)</span>
+    <span class="help-inline">
+      (substring search, names, emails and about me; exact match of tags)
+    </span>
 
     <div class="input-group role-filter">
       <span class="help-inline">Filter by role:</span>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Ability to search users by tag in admin interface (Gareth Rees)
 * Add ATI Network Impacts Showcase (Lucas Cumsille Montesinos, Gareth Rees)
 * Improve raw email testing fixtures (Graeme Porteous)
 * Add support for Debian 13 "Trixie" (Graeme Porteous)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -619,12 +619,23 @@ RSpec.describe User do
     subject { described_class.search(query) }
 
     let(:user_1) do
-      attrs = { name: 'Alice', email: 'alice@example.com', about_me: 'foo bar' }
+      attrs = {
+        name: 'Alice',
+        email: 'alice@example.com',
+        about_me: 'foo bar'
+      }
+
       FactoryBot.create(:user, attrs)
     end
 
     let(:user_2) do
-      attrs = { name: 'James', email: 'james@example.com', about_me: 'bar' }
+      attrs = {
+        name: 'James',
+        email: 'james@example.com',
+        about_me: 'bar',
+        tag_string: 'foo_bar'
+      }
+
       FactoryBot.create(:user, attrs)
     end
 
@@ -656,6 +667,17 @@ RSpec.describe User do
     context 'when given an about_me matching multiple users' do
       let(:query) { 'bar' }
       it { is_expected.to match_array([user_1, user_2]) }
+    end
+
+    context 'when given an exact tag' do
+      let(:query) { 'foo_bar' }
+      it { is_expected.to match_array([user_2]) }
+    end
+
+    context 'when given a partial tag' do
+      let(:query) { 'foo' }
+      # Matches user_1 about_me; doesn't match the initial part of user_2 tag
+      it { is_expected.to match_array([user_1]) }
     end
   end
 


### PR DESCRIPTION
Allow users to be searched by tag in the admin interface

<img width="970" height="343" alt="Screenshot 2025-11-13 at 17 25 43" src="https://github.com/user-attachments/assets/39305564-70c8-4b98-b5ed-9e26be9a5adc" />
