### PR TITLE
Remove :email from filtered parameters

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,3 +6,6 @@
 Rails.application.config.filter_parameters += [
   :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
 ]
+
+# Explicitly override above Rails defaults to allow logging of email parameters.
+Rails.application.config.filter_parameters.delete(:email)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Restore logging of :email parameters (Gareth Rees)
 * Fix importing holidays from iCal feed (Gareth Rees)
 * Ability to search users by tag in admin interface (Gareth Rees)
 * Add ATI Network Impacts Showcase (Lucas Cumsille Montesinos, Gareth Rees)


### PR DESCRIPTION
I’ve noticed that we no longer log the email parameter when users submit the signup / signin forms. It got introduced in 0869eac1b as an updated rails default (https://github.com/rails/rails/pull/49600).

This makes debugging / abuse detection quite difficult.

We already hold this information, we rotate logs, and our privacy policy is written with this in mind. There's no concern around additional/ unexpected data processing, or from a security standpoint.
