### PR TITLE
[#9019] Fix importing holidays from ical feed

### DIFF
--- a/app/models/holiday_import.rb
+++ b/app/models/holiday_import.rb
@@ -65,7 +65,7 @@ class HolidayImport
   end
 
   def populate_from_ical_feed
-    cal_file = open(ical_feed_url)
+    cal_file = URI.open(ical_feed_url)
     cal_parser = Icalendar::Parser.new(cal_file)
     cals = cal_parser.parse
     cal = cals.first

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix importing holidays from iCal feed (Gareth Rees)
 * Ability to search users by tag in admin interface (Gareth Rees)
 * Add ATI Network Impacts Showcase (Lucas Cumsille Montesinos, Gareth Rees)
 * Improve raw email testing fixtures (Graeme Porteous)

--- a/spec/models/holiday_import_spec.rb
+++ b/spec/models/holiday_import_spec.rb
@@ -128,7 +128,11 @@ RSpec.describe HolidayImport do
     end
 
     it 'should populate holidays from the feed that are between the dates' do
-      allow(@holiday_import).to receive(:open).and_return(load_file_fixture('ical-holidays.ics'))
+      stub_request(:get, 'http://www.example.com/').to_return(
+        status: 200,
+        body: load_file_fixture('ical-holidays.ics')
+      )
+
       @holiday_import.populate
       expect(@holiday_import.holidays.size).to eq(1)
       holiday = @holiday_import.holidays.first
@@ -137,14 +141,20 @@ RSpec.describe HolidayImport do
     end
 
     it 'should add an error if the calendar cannot be parsed' do
-      allow(@holiday_import).to receive(:open).and_return('some invalid data')
+      stub_request(:get, 'http://www.example.com/').to_return(
+        status: 200,
+        body: 'some invalid data'
+      )
+
       @holiday_import.populate
       expected = ["Sorry, there's a problem with the format of that feed."]
       expect(@holiday_import.errors[:ical_feed_url]).to eq(expected)
     end
 
     it 'should add an error if the calendar cannot be found' do
-      allow(@holiday_import).to receive(:open).and_raise Errno::ENOENT.new('No such file or directory')
+      allow(URI).to receive(:open).
+        and_raise(Errno::ENOENT.new('No such file or directory'))
+
       @holiday_import.populate
       expected = ["Sorry we couldn't find that feed."]
       expect(@holiday_import.errors[:ical_feed_url]).to eq(expected)


### PR DESCRIPTION
Not sure exactly what update changed this but looks like `open` doesn't open URIs now and we have to explicitly call `URI.open`.

Fixes https://github.com/mysociety/alaveteli/issues/9019.

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
