### PR TITLE
Handle array return value for auto-submitted mail header

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Handle array return value for auto-submitted mail header (gfrmin)
 * Restore logging of :email parameters (Gareth Rees)
 * Fix importing holidays from iCal feed (Gareth Rees)
 * Ability to search users by tag in admin interface (Gareth Rees)

--- a/lib/mail_handler/backends/mail_backend.rb
+++ b/lib/mail_handler/backends/mail_backend.rb
@@ -162,7 +162,10 @@ module MailHandler
       end
 
       def get_auto_submitted(mail)
-        mail['auto-submitted'] ? mail['auto-submitted'].value : nil
+        field = mail['auto-submitted']
+        return nil unless field
+
+        field.is_a?(Array) ? field.first.value : field.value
       end
 
       def get_content_type(part)

--- a/spec/lib/mail_handler/backends/mail_backend_spec.rb
+++ b/spec/lib/mail_handler/backends/mail_backend_spec.rb
@@ -263,6 +263,13 @@ when it really should be application/pdf.\n
       mail = Mail.new
       expect(get_auto_submitted(mail)).to be_nil
     end
+
+    it 'returns the first value when multiple auto-submitted headers exist' do
+      mail = Mail.new
+      mail['auto-submitted'] = 'auto-replied'
+      mail['auto-submitted'] = 'auto-generated'
+      expect(get_auto_submitted(mail)).to eq('auto-replied')
+    end
   end
 
   describe :expand_and_normalize_parts do


### PR DESCRIPTION
## Summary

This PR fixes a crash in the mail handler when processing emails with multiple `auto-submitted` headers.

## Problem

The Mail gem returns an Array when multiple headers with the same name exist in an email (which is valid per RFC 5322). The `get_auto_submitted` method in `MailHandler::Backends::MailBackend` assumed a single header object and would crash with `NoMethodError: undefined method 'value' for Array` when encountering duplicate auto-submitted headers.

## Solution

- Added handling for both single header objects and arrays of headers
- When multiple headers exist, returns the first value
- Maintains backward compatibility with single header case

## Files Changed

- `lib/mail_handler/backends/mail_backend.rb` - Added array handling in `get_auto_submitted` method
- `spec/lib/mail_handler/backends/mail_backend_spec.rb` - Added test case for multiple headers

## Test Coverage

Added new test case that matches existing testing patterns:
```ruby
it 'returns the first value when multiple auto-submitted headers exist' do
  mail = Mail.new
  mail['auto-submitted'] = 'auto-replied'
  mail['auto-submitted'] = 'auto-generated'
  expect(get_auto_submitted(mail)).to eq('auto-replied')
end
```

## Impact

Prevents email processing crashes when receiving emails with duplicate auto-submitted headers from certain mail servers.