### PR TITLE
Fix crashes from invalid public_body_id in request form

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -213,6 +213,12 @@ class RequestController < ApplicationController
                                                       outgoing_message_params)
     @outgoing_message = @info_request.outgoing_messages.first
 
+    # Redirect if public body doesn't exist (invalid public_body_id)
+    unless @info_request.public_body
+      redirect_to frontpage_url
+      return
+    end
+
     # Maybe we lost the address while they're writing it
     unless @info_request.public_body.is_requestable?
       render action: "new_#{ @info_request.public_body.not_requestable_reason }"
@@ -550,6 +556,12 @@ class RequestController < ApplicationController
     params[:info_request][:tag_string] = params[:tags] if params[:tags]
 
     @info_request = InfoRequest.new(info_request_params)
+
+    # Redirect if public body doesn't exist (invalid public_body_id)
+    unless @info_request.public_body
+      redirect_to frontpage_url
+      return
+    end
 
     params[:info_request_id] = @info_request.id
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Reduce exception notification spam from invalid public body requests (gfrmin)
 * Fix importing holidays from iCal feed (Gareth Rees)
 * Ability to search users by tag in admin interface (Gareth Rees)
 * Add ATI Network Impacts Showcase (Lucas Cumsille Montesinos, Gareth Rees)


### PR DESCRIPTION
## Summary

Defend against invalid `public_body_id` parameters that cause crashes in the request form.

## Problem

Attackers sending invalid or malicious `public_body_id` values (e.g., `abc`, `99999`, or SQL injection attempts) causes:

1. ActiveRecord safely rejects the invalid value → returns `nil` for `public_body`
2. Controller/View tries to access `@info_request.public_body.is_requestable?` → crashes with `undefined method for nil:NilClass`
3. Error emails spam administrators via exception notification

## Solution

Add explicit nil check for `@info_request.public_body` in both controller paths (`new` method and `render_new_compose`) before accessing any `public_body` methods. Invalid values now redirect to frontpage instead of crashing.

## Test plan

- [x] Verify normal request form still works with valid public body
- [ ] Test that invalid `public_body_id` parameter (e.g., `abc`, `99999`) no longer causes crashes
- [ ] Confirm error notifications are no longer triggered by these attacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)