### PR TITLE
Add basic rendering of body category notes

### DIFF
--- a/app/controllers/public_body_controller.rb
+++ b/app/controllers/public_body_controller.rb
@@ -126,8 +126,8 @@ class PublicBodyController < ApplicationController
              count: @public_bodies.total_entries,
              first_letter: @tag)
         else
-          category = PublicBody.category_list.find_by(category_tag: @tag)
-          if category.nil?
+          @category = PublicBody.category_list.find_by(category_tag: @tag)
+          if @category.nil?
             n_('Found {{count}} public authority matching the tag ' \
                '‘{{tag_name}}’',
                'Found {{count}} public authorities matching the tag ' \
@@ -142,7 +142,7 @@ class PublicBodyController < ApplicationController
                '‘{{category}}’',
                @public_bodies.total_entries,
                count: @public_bodies.total_entries,
-               category: category.title)
+               category: @category.title)
           end
         end
 

--- a/app/views/public_body/_category.html.erb
+++ b/app/views/public_body/_category.html.erb
@@ -1,0 +1,2 @@
+<%= render_notes(@category.all_notes) %>
+<%= @category.body %>

--- a/app/views/public_body/_category.html.erb
+++ b/app/views/public_body/_category.html.erb
@@ -1,2 +1,3 @@
 <%= render_notes(@category.all_notes) %>
 <%= @category.body %>
+<% if @category.body.present? %><br><% end %>

--- a/app/views/public_body/list.html.erb
+++ b/app/views/public_body/list.html.erb
@@ -15,6 +15,10 @@
     <%= @description %>
   </h2>
 
+  <% if @category %>
+    <%= render partial: 'category' %>
+  <% end %>
+
   <%= render :partial => 'body_listing', :locals => { :public_bodies => @public_bodies } %>
   <%= will_paginate(@public_bodies) %><br/>
   <%= link_to _("Can't find the one you want?"), help_requesting_path(:anchor => 'missing_body') %>

--- a/app/views/public_body/list.html.erb
+++ b/app/views/public_body/list.html.erb
@@ -11,12 +11,18 @@
     </div>
   <% end %>
 
-  <h2 class="publicbody_results">
-    <%= @description %>
-  </h2>
-
   <% if @category %>
+    <h2 class="publicbody_results">
+      <%= @category.title %>
+    </h2>
+
     <%= render partial: 'category' %>
+
+    <p><i><%= @description %></i></p>
+  <% else %>
+    <h2 class="publicbody_results">
+      <%= @description %>
+    </h2>
   <% end %>
 
   <%= render :partial => 'body_listing', :locals => { :public_bodies => @public_bodies } %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Render public body category notes (Gareth Rees)
 * Prevent external search indexing of password change form (Gareth Rees)
 * Allow customisation of text masks (Gareth Rees)
 * Strip ActionText attachments from Project rich text fields (Graeme Porteous)


### PR DESCRIPTION
Prior to this commit we could create notes for public body categories, but they were not rendered. This also applies to the `Category#description` text.

This adds basic rendering of these elements using the same pattern as for request categories.

<img width="1056" height="707" alt="Screenshot 2026-01-05 at 15 46 40" src="https://github.com/user-attachments/assets/8497da9f-291b-43f9-8728-aa5eb9888414" />

---

Improves the layout in bfe02ef:

**Category with notes/body.** Uses the main category title:

<img width="1071" height="706" alt="Screenshot 2026-01-05 at 17 22 20" src="https://github.com/user-attachments/assets/d756218e-d4bd-4f25-a76a-77234b0207b3" />

**Category with title only.** Uses the main category title:

<img width="991" height="580" alt="Screenshot 2026-01-05 at 17 22 32" src="https://github.com/user-attachments/assets/2289fd5b-4e61-4e44-9e77-fc5bebcc23fd" />

**List by tag.** Falls back to previous heading:

<img width="953" height="566" alt="Screenshot 2026-01-05 at 17 22 36" src="https://github.com/user-attachments/assets/8bdd7870-dc5b-4968-ba03-648170b9352c" />

**List by search term.** Falls back to previous heading:

<img width="931" height="588" alt="Screenshot 2026-01-05 at 17 22 41" src="https://github.com/user-attachments/assets/47042ea6-d844-46c1-80f3-6b0fa6dc5d44" />
