### PR TITLE
Extract `IncomingMessage#parse_raw_email`

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -71,7 +71,7 @@ class AttachmentsController < ApplicationController
 
   def find_attachment
     @attachment = (
-      @incoming_message.parse_raw_email!
+      @incoming_message.parse_raw_email
 
       IncomingMessage.get_attachment_by_url_part_number_and_filename!(
         @incoming_message.get_attachments_for_display,

--- a/app/jobs/foi_attachment_mask_job.rb
+++ b/app/jobs/foi_attachment_mask_job.rb
@@ -19,7 +19,7 @@ class FoiAttachmentMaskJob < ApplicationJob
     mask
 
   rescue FoiAttachment::MissingAttachment
-    incoming_message.parse_raw_email!(true)
+    incoming_message.parse_raw_email!
 
     begin
       attachment.reload

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -89,25 +89,29 @@ class IncomingMessage < ApplicationRecord
     info_request_events.where(event_type: 'response').first
   end
 
-  def parse_raw_email!(force = nil)
+  def parse_raw_email!
     # The following fields may be absent; we treat them as cached
     # values in case we want to regenerate them (due to mail
     # parsing bugs, etc).
     raise "Incoming message id=#{id} has no raw_email" if raw_email.nil?
 
-    if !force.nil? || last_parsed.nil?
-      ActiveRecord::Base.transaction do
-        extract_attachments
-        self.sent_at = raw_email.date || created_at
-        self.subject = raw_email.subject
-        self.from_name = raw_email.from_name
-        self.from_email = raw_email.from_email || ''
-        self.from_email_domain = raw_email.from_email_domain || ''
-        self.valid_to_reply_to = raw_email.valid_to_reply_to?
-        self.last_parsed = Time.zone.now
-        save!
-      end
+    ActiveRecord::Base.transaction do
+      extract_attachments
+      self.sent_at = raw_email.date || created_at
+      self.subject = raw_email.subject
+      self.from_name = raw_email.from_name
+      self.from_email = raw_email.from_email || ''
+      self.from_email_domain = raw_email.from_email_domain || ''
+      self.valid_to_reply_to = raw_email.valid_to_reply_to?
+      self.last_parsed = Time.zone.now
+      save!
     end
+  end
+
+  def parse_raw_email
+    raise "Incoming message id=#{id} has no raw_email" if raw_email.nil?
+
+    parse_raw_email! if last_parsed.nil?
   end
 
   alias valid_to_reply_to? valid_to_reply_to
@@ -337,7 +341,7 @@ class IncomingMessage < ApplicationRecord
 
   # Returns body text from main text part of email, converted to UTF-8
   def get_main_body_text_internal
-    parse_raw_email!
+    parse_raw_email
     main_part = get_main_body_text_part
     _convert_part_body_to_text(main_part)
 
@@ -426,7 +430,7 @@ class IncomingMessage < ApplicationRecord
   end
 
   def get_attachments_for_display
-    parse_raw_email!
+    parse_raw_email
     # return what user would consider attachments, i.e. not the main body
     main_part = get_main_body_text_part
     attachments = []

--- a/app/models/incoming_message/cache_attributes_from_raw_email.rb
+++ b/app/models/incoming_message/cache_attributes_from_raw_email.rb
@@ -10,7 +10,7 @@ module IncomingMessage::CacheAttributesFromRawEmail
 
     def cache_attribute_from_raw_email(attr)
       define_method(attr) do
-        parse_raw_email!
+        parse_raw_email
         super()
       end
     end

--- a/config/initializers/excel_analyzer.rb
+++ b/config/initializers/excel_analyzer.rb
@@ -3,5 +3,5 @@ require "excel_analyzer"
 ExcelAnalyzer.on_spreadsheet_received = ->(raw_email_blob) do
   incoming_message = IncomingMessage.joins(raw_email: :file_blob).
     find_by(active_storage_blobs: { id: raw_email_blob })
-  incoming_message&.parse_raw_email!
+  incoming_message&.parse_raw_email
 end

--- a/script/redact-raw-emails.rb
+++ b/script/redact-raw-emails.rb
@@ -142,7 +142,7 @@ scope.each do |incoming_message|
   else
     FileUtils.copy(@raw_email.filepath, "#{@raw_email.filepath}.bak")
     @raw_email.data = mail.to_s
-    @incoming_message.parse_raw_email!(true)
+    @incoming_message.parse_raw_email!
     puts " has been updated"
     puts "Backup created at #{@raw_email.filepath}.bak"
   end

--- a/spec/integration/admin_censor_rule_spec.rb
+++ b/spec/integration/admin_censor_rule_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Updating censor rules' do
     incoming_message = FactoryBot.create(:incoming_message,
                                          info_request: request)
     incoming_message.raw_email.data = raw_email_data
-    incoming_message.parse_raw_email!(true)
+    incoming_message.parse_raw_email!
     InfoRequestEvent.create(event_type: "response",
                             incoming_message: incoming_message,
                             info_request: request,

--- a/spec/jobs/foi_attachment_mask_job_spec.rb
+++ b/spec/jobs/foi_attachment_mask_job_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe FoiAttachmentMaskJob, type: :job do
     end
 
     it 'parses raw email again' do
-      expect(incoming_message).to receive(:parse_raw_email!).with(true)
+      expect(incoming_message).to receive(:parse_raw_email!)
       perform
     end
 

--- a/spec/mailers/outgoing_mailer_spec.rb
+++ b/spec/mailers/outgoing_mailer_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe OutgoingMailer, "when working out follow up subjects" do
     om.incoming_message_followup = im
 
     im.raw_email.data = im.raw_email.data.sub("Subject: Geraldine FOI Code AZXB421", "Subject: re: Geraldine FOI Code AZXB421")
-    im.parse_raw_email! true
+    im.parse_raw_email!
 
     expect(OutgoingMailer.subject_for_followup(ir, om, html: false)).to eq("re: Geraldine FOI Code AZXB421")
   end
@@ -104,7 +104,7 @@ RSpec.describe OutgoingMailer, "when working out follow up subjects" do
 
     im.raw_email.data = im.raw_email.data.sub("foiperson@localhost", "postmaster@localhost")
     im.raw_email.data = im.raw_email.data.sub("Subject: Geraldine FOI Code AZXB421", "Subject: Delivery Failed")
-    im.parse_raw_email! true
+    im.parse_raw_email!
 
     expect(OutgoingMailer.subject_for_followup(ir, om, html: false)).to eq("Re: Freedom of Information request - Why do you have & such a fancy dog?")
   end

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe FoiAttachment do
           with(foi_attachment).
           and_invoke(-> (_) {
             # mock the job
-            incoming_message.parse_raw_email!(true)
+            incoming_message.parse_raw_email!
           })
       end
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.from_name).to eq('FOI Person')
     end
 
@@ -108,7 +108,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.from_name).to be_nil
     end
 
@@ -123,7 +123,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.from_name).
         to eq('Coordenação de Relacionamento, Pesquisa e Informação/CEDI')
     end
@@ -140,7 +140,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       message.reload
       FactoryBot.create(:censor_rule,
                         text: 'Person',
@@ -161,7 +161,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.from_email).to eq('authority@mail.example.com')
     end
 
@@ -174,7 +174,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.from_email).to eq('')
     end
   end
@@ -190,7 +190,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.from_email_domain).to eq('mail.example.com')
     end
 
@@ -203,7 +203,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.from_email_domain).to eq('')
     end
   end
@@ -219,7 +219,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.subject).to eq('A response')
     end
 
@@ -232,7 +232,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.subject).to be_nil
     end
 
@@ -246,7 +246,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.subject).to eq('Câmara Responde:  Banco de ideias')
     end
   end
@@ -263,7 +263,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.sent_at).
         to eq(DateTime.parse('Fri, 9 Dec 2011 10:42:02 -0200').in_time_zone)
     end
@@ -278,7 +278,7 @@ RSpec.describe IncomingMessage do
 
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = raw_email_data
-      message.parse_raw_email!(true)
+      message.parse_raw_email!
       expect(message.sent_at).to eq(message.created_at)
     end
   end
@@ -750,7 +750,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     receive_incoming_mail('quoted-subject-iso8859-1.eml',
                           email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_part.charset).to eq("iso-8859-1")
     expect(message.get_main_body_text_internal).to include("política")
   end
@@ -760,7 +760,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     receive_incoming_mail('no-part-charset-bad-utf8.eml',
                           email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_internal).to include("贵公司负责人")
   end
 
@@ -769,7 +769,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     receive_incoming_mail('no-part-charset-random-data.eml',
                           email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_internal).to include("The above text was badly encoded")
   end
 
@@ -777,7 +777,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     ir = info_requests(:fancy_dog_request)
     receive_incoming_mail('dos-linebreaks.eml', email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_internal).not_to match(/\r\n/)
   end
 
@@ -797,7 +797,7 @@ RSpec.describe IncomingMessage, " when dealing with incoming mail" do
     ir = info_requests(:fancy_dog_request)
     receive_incoming_mail('no-body.eml', email_to: ir.incoming_email)
     message = ir.incoming_messages[1]
-    message.parse_raw_email!
+    message.parse_raw_email
     expect(message.get_main_body_text_internal).
       to eq "[ Email has no body, please see attachments ]"
   end
@@ -962,7 +962,7 @@ RSpec.describe IncomingMessage, " when uudecoding bad messages" do
     allow(raw_email).to receive(:data).and_return(data)
     allow(im).to receive(:raw_email).and_return(raw_email)
     allow(im).to receive(:mail).and_return(mail)
-    im.parse_raw_email!(true)
+    im.parse_raw_email!
     attachments = im.foi_attachments
     expect(attachments.size).to eq(2)
   end
@@ -1005,7 +1005,7 @@ RSpec.describe IncomingMessage, "when messages are attached to messages" do
     # are rendered out in the local time - using the Mail gem this is not necessary
     with_env_tz('London') do
       populate_raw_email('rfc822-attachment.eml')
-      im.parse_raw_email!(true)
+      im.parse_raw_email!
       attachments = im.get_attachments_for_display
       expect(attachments.size).to eq(1)
       attachment = attachments.first
@@ -1035,7 +1035,7 @@ RSpec.describe IncomingMessage, "when messages are attached to messages" do
     # are rendered out in the local time - using the Mail gem this is not necessary
     with_env_tz('London') do
       populate_raw_email('incoming-request-attachment-headers.eml')
-      im.parse_raw_email!(true)
+      im.parse_raw_email!
       attachments = im.get_attachments_for_display
       expect(attachments.size).to eq(2)
       expect(attachments[0].body).to match('Date: Fri, 23 May 2008')

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2557,7 +2557,7 @@ RSpec.describe InfoRequest do
     end
 
     it "copes with indexing after item is deleted" do
-      IncomingMessage.find_each(&:parse_raw_email!)
+      IncomingMessage.find_each(&:parse_raw_email)
       destroy_and_rebuild_xapian_index
       # delete event from underneath indexing; shouldn't cause error
       info_request_events(:useless_incoming_message_event).save!

--- a/spec/support/email_helpers.rb
+++ b/spec/support/email_helpers.rb
@@ -13,7 +13,7 @@ def get_fixture_mail(filename, email_to = nil, email_from = nil)
 end
 
 def parse_all_incoming_messages
-  IncomingMessage.find_each(&:parse_raw_email!)
+  IncomingMessage.find_each(&:parse_raw_email)
 end
 
 def load_mail_server_logs(log)


### PR DESCRIPTION
Remove force option from IncomingMessage#parse_raw_email! and add the safe IncomingMessage#parse_raw_email counterpart so that we have a more conventional bang/non-bang pair of methods.

Currently retains the exception raising if there's no raw email, but this doesn't seem necessary for the non-bang version as it only matters when we actually attempt to parse the raw email.

In service of https://github.com/mysociety/alaveteli/issues/8803.

[skip changelog]
