### PR TITLE
Improve locking & replacement UI

### DIFF
--- a/app/views/admin/foi_attachments/edit.html.erb
+++ b/app/views/admin/foi_attachments/edit.html.erb
@@ -108,7 +108,7 @@
           <%= f.label :replacement_body, class: 'control-label' %>
 
           <div class="controls">
-            <%= f.text_area :replacement_body, rows: 5, class: 'span6' %>
+            <%= f.text_area :replacement_body, rows: 20, class: 'span9' %>
           </div>
         </div>
       <% else %>


### PR DESCRIPTION
Minor improvements to layout and inline help:

* Use separate fieldsets for locking & replacement
* Expand locking & replacement inline help

Will later add notes about erasure into these as appropriate.

<img width="1031" height="706" alt="Screenshot 2026-01-08 at 16 55 17" src="https://github.com/user-attachments/assets/9e8f028b-df61-48e2-be99-5f6eac7dc5c0" />

In service of https://github.com/mysociety/alaveteli/issues/8803.

[skip changelog]