### PR TITLE
Destroy sample data external requests

### DIFF
--- a/script/load-sample-data
+++ b/script/load-sample-data
@@ -52,6 +52,10 @@ end
 
 # run everything as a single transaction - all the deletes then all the inserts
 ActiveRecord::FixtureSet.create_fixtures(fixtures_dir, fixture_files)
+
+# Destroy deprecated external requests
+# See https://github.com/mysociety/alaveteli/issues/6893
+InfoRequest.external.destroy_all
 EOF
 
 bundle exec rails runner tmp/data-loader.rb


### PR DESCRIPTION
We now assume no external requests will exist. The external requests provided by the sample data fixtures cause breakages. They are due to be removed, but this will take some work to fix up unrelated specs.

Until then, just destroy the sample ones so that the site doesn't break when using the sample data.

Related to https://github.com/mysociety/alaveteli/issues/6893.

[skip changelog]
