### PR TITLE
Extract `IncomingMessage::QuoteHandling`

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -413,14 +413,13 @@ class IncomingMessage < ApplicationRecord
   def get_body_for_html_display(collapse_quoted_sections = true)
     # Find the body text and remove emails for privacy/anti-spam reasons
     text = get_main_body_text_unfolded
-    folded_quoted_text = get_main_body_text_folded
 
     # Remove quoted sections, adding HTML. TODO: The FOLDED_QUOTED_SECTION is
     # a nasty hack so we can escape other HTML before adding the unfold
     # links, without escaping them. Rather than using some proper parser
     # making a tree structure (I don't know of one that is to hand, that
     # works well in this kind of situation, such as with regexps).
-    text = folded_quoted_text if collapse_quoted_sections
+    text = get_main_body_text_folded if collapse_quoted_sections
     text = MySociety::Format.simplify_angle_bracketed_urls(text)
     text = CGI.escapeHTML(text)
     text = MySociety::Format.make_clickable(text, contract: 1)
@@ -432,20 +431,7 @@ class IncomingMessage < ApplicationRecord
     text.gsub!(/\[(#{email_pattern}|#{mobile_pattern})\]/,
                '[<a href="/help/officers#mobiles">\1</a>]')
 
-    if collapse_quoted_sections
-      text = text.gsub(/(\s*FOLDED_QUOTED_SECTION\s*)+/m, "FOLDED_QUOTED_SECTION")
-      text = text.strip
-      # if there is nothing but quoted stuff, then show the subject
-      if text == "FOLDED_QUOTED_SECTION"
-        text = "[Subject only] " + CGI.escapeHTML(subject || '') + text
-      end
-      # and display link for quoted stuff
-      text = text.gsub(/FOLDED_QUOTED_SECTION/, "\n\n" + '<span class="unfold_link"><a href="?unfold=1#incoming-'+id.to_s+'">'+_("show quoted sections")+'</a></span>' + "\n\n")
-    elsif folded_quoted_text.include?('FOLDED_QUOTED_SECTION')
-      text = text + "\n\n" + '<span class="unfold_link"><a href="?#incoming-'+id.to_s+'">'+_("hide quoted sections")+'</a></span>'
-    end
-    text = text.strip
-
+    text = handle_quoted_sections(text, collapse: collapse_quoted_sections)
     text = ActionController::Base.helpers.simple_format(text)
     text.html_safe
   end

--- a/app/models/incoming_message/quote_handling.rb
+++ b/app/models/incoming_message/quote_handling.rb
@@ -94,4 +94,25 @@ module IncomingMessage::QuoteHandling
     # http://www.whatdotheyknow.com/request/229/response/809
     text.gsub(/^\s?From: [^\n]+\n\s?Sent: [^\n]+\n\s?To:\s+['"]?#{name}['"]?\n\s?Subject:.*/im, "\n\n" + replacement)
   end
+
+  private
+
+  def handle_quoted_sections(text, collapse: true)
+    if collapse
+      text = text.gsub(/(\s*FOLDED_QUOTED_SECTION\s*)+/m, "FOLDED_QUOTED_SECTION")
+      text = text.strip
+
+      # if there is nothing but quoted stuff, then show the subject
+      if text == "FOLDED_QUOTED_SECTION"
+        text = "[Subject only] " + CGI.escapeHTML(subject || '') + text
+      end
+
+      # and display link for quoted stuff
+      text = text.gsub(/FOLDED_QUOTED_SECTION/, "\n\n" + '<span class="unfold_link"><a href="?unfold=1#incoming-'+id.to_s+'">'+_("show quoted sections")+'</a></span>' + "\n\n")
+    elsif get_main_body_text_folded.include?('FOLDED_QUOTED_SECTION')
+      text = text + "\n\n" + '<span class="unfold_link"><a href="?#incoming-'+id.to_s+'">'+_("hide quoted sections")+'</a></span>'
+    end
+
+    text.strip
+  end
 end


### PR DESCRIPTION
Extracts `IncomingMessage` quote handling to a concern to make the file more readable. Obviously lots to clean up still but first step is compartmentalising the related behaviour.

Almost no change in the implementation code, but verified in browser:

<img width="772" height="509" alt="Screenshot 2026-01-13 at 15 23 17" src="https://github.com/user-attachments/assets/2c63f609-de6c-42e2-b3dc-f28304c0a57a" />

<img width="774" height="571" alt="Screenshot 2026-01-13 at 15 23 07" src="https://github.com/user-attachments/assets/15ee414f-0e0d-4145-a367-fb6a07e51552" />

In service of https://github.com/mysociety/alaveteli/issues/8803 to aid debugging of https://github.com/mysociety/alaveteli/pull/9040.

[skip changelog]

Ignoring the rubocop warnings on this one as it will be too complex to fix lots of long regexps etc and we don't have great tests around it.