### PR TITLE
Move `IncomingMessage#locked?` to concern

### DIFF
--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -175,10 +175,6 @@ class IncomingMessage < ApplicationRecord
     (Time.zone.now - created_at) <= 3.days
   end
 
-  def locked?
-    foi_attachments.locked.any?
-  end
-
   def storage_keys
     keys = {}
     keys[:raw_email] = raw_email.storage_key

--- a/app/models/incoming_message/attachments.rb
+++ b/app/models/incoming_message/attachments.rb
@@ -136,6 +136,10 @@ module IncomingMessage::Attachments
     ret.keys.join(" ")
   end
 
+  def locked?
+    foi_attachments.locked.any?
+  end
+
   private
 
   def _get_attachment_text_internal


### PR DESCRIPTION
This relates only to attachments so move it to the `IncomingMessage::Attachments` concern.

In service of https://github.com/mysociety/alaveteli/issues/8803 to aid debugging of https://github.com/mysociety/alaveteli/pull/9040.

[skip changelog]
