### PR TITLE
Redirect to attachment after update

### DIFF
--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -23,7 +23,7 @@ class Admin::FoiAttachmentsController < AdminController
       else
         flash[:notice] = 'Attachment successfully updated.'
       end
-      redirect_to edit_admin_incoming_message_path(@incoming_message)
+      redirect_to edit_admin_foi_attachment_path(@foi_attachment)
 
     else
       render action: 'edit'

--- a/spec/controllers/admin/foi_attachments_controller_spec.rb
+++ b/spec/controllers/admin/foi_attachments_controller_spec.rb
@@ -146,10 +146,10 @@ RSpec.describe Admin::FoiAttachmentsController do
     context 'on a successful update of attachment' do
       include_context 'successful update'
 
-      it 'redirects to the incoming message admin' do
+      it 'redirects to the attachment admin' do
         patch :update, params: params
         expect(response).to redirect_to(
-          edit_admin_incoming_message_path(incoming_message)
+          edit_admin_foi_attachment_path(attachment)
         )
       end
     end
@@ -190,10 +190,10 @@ RSpec.describe Admin::FoiAttachmentsController do
       context 'as pro admin' do
         before { sign_in(pro_admin_user) }
 
-        it 'redirects to the incoming message admin' do
+        it 'redirects to the attachment admin' do
           patch :update, params: params
           expect(response).to redirect_to(
-            edit_admin_incoming_message_path(incoming_message)
+            edit_admin_foi_attachment_path(attachment)
           )
         end
       end


### PR DESCRIPTION
Less surprising than being redirected to a different record type

In service of https://github.com/mysociety/alaveteli/issues/8803.

[skip changelog]
