### PR TITLE
[#9085] Update locale cookie handling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -91,13 +91,8 @@ class ApplicationController < ActionController::Base
 
   def store_gettext_locale
     # set the current stored locale to the requested_locale
-    locale = params[:locale].presence || AlaveteliLocalization.locale
-
-    if locale == AlaveteliLocalization.default_locale
-      cookies.delete(:locale)
-    else
-      cookies[:locale] = locale
-    end
+    locale = AlaveteliLocalization.locale
+    cookies[:locale] = locale
 
     # ensure current user locale attribute is up-to-date
     current_user.update_column(:locale, locale) if current_user

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Update locale cookie handling (Graeme Porteous)
 * Restore logging of :email parameters (Gareth Rees)
 * Fix importing holidays from iCal feed (Gareth Rees)
 * Ability to search users by tag in admin interface (Gareth Rees)

--- a/spec/integration/cookie_stripping_spec.rb
+++ b/spec/integration/cookie_stripping_spec.rb
@@ -1,9 +1,0 @@
-require 'spec_helper'
-require 'integration/alaveteli_dsl'
-
-RSpec.describe 'when making stripping cookies' do
-  it 'should not set a cookie when no significant session data is set' do
-    get '/country_message'
-    expect(response.headers['Set-Cookie']).to be_blank
-  end
-end

--- a/spec/integration/localisation_spec.rb
+++ b/spec/integration/localisation_spec.rb
@@ -30,6 +30,16 @@ RSpec.describe 'when generating URLs' do
     expect(response.headers['Content-Language']).to eq('en')
   end
 
+  it 'remembers user selection of default locale when browser prefers different language' do
+    get '/', params: { locale: 'es' }, headers: { 'HTTP_ACCEPT_LANGUAGE' => 'en' }
+    expect(response).to redirect_to('/')
+    follow_redirect!
+    expect(response.headers['Content-Language']).to eq('es')
+
+    get '/', headers: { 'HTTP_ACCEPT_LANGUAGE' => 'en' }
+    expect(response.headers['Content-Language']).to eq('es')
+  end
+
   it 'sets correct Content-Language via underscored locale param' do
     get '/', params: { locale: 'en_GB' }
     expect(response).to redirect_to('/')


### PR DESCRIPTION
## Relevant issue(s)

Fixes #9085

## What does this do?

Update locale cookie handling

Always persist the locale cookie as this is the only way to configure the users choice when the default locale doesn't match what their browser requests via the `HTTP_ACCEPT_LANGUAGE` header.
