### PR TITLE
Redirect on attachment admin action failure

### DIFF
--- a/app/controllers/admin/foi_attachments/locks_controller.rb
+++ b/app/controllers/admin/foi_attachments/locks_controller.rb
@@ -10,20 +10,19 @@ class Admin::FoiAttachments::LocksController < AdminController
       )
       @foi_attachment.expire
 
-      if @foi_attachment.locked? && !@foi_attachment.masked?
-        flash[:notice] = <<~TXT.squish
+      flash[:notice] = if @foi_attachment.locked? && !@foi_attachment.masked?
+        <<~TXT.squish
           Attachment locked. Please wait for masking to complete before adding
           additional censor rules.
         TXT
       else
-        flash[:notice] = 'Attachment locked.'
+        'Attachment locked.'
       end
-
-      redirect_to edit_admin_foi_attachment_path(@foi_attachment)
     else
-      flash.now[:error] = @foi_attachment.errors.full_messages.to_sentence
-      render 'admin/foi_attachments/edit'
+      flash[:error] = @foi_attachment.errors.full_messages.to_sentence
     end
+
+    redirect_to edit_admin_foi_attachment_path(@foi_attachment)
   end
 
   def destroy
@@ -33,12 +32,12 @@ class Admin::FoiAttachments::LocksController < AdminController
       )
       @foi_attachment.expire
 
-      redirect_to edit_admin_foi_attachment_path(@foi_attachment),
-                  notice: 'Attachment unlocked.'
+      flash[:notice] = 'Attachment unlocked.'
     else
-      flash.now[:error] = @foi_attachment.errors.full_messages.to_sentence
-      render 'admin/foi_attachments/edit'
+      flash[:error] = @foi_attachment.errors.full_messages.to_sentence
     end
+
+    redirect_to edit_admin_foi_attachment_path(@foi_attachment)
   end
 
   private

--- a/app/controllers/admin/foi_attachments/prominence_controller.rb
+++ b/app/controllers/admin/foi_attachments/prominence_controller.rb
@@ -11,12 +11,12 @@ class Admin::FoiAttachments::ProminenceController < AdminController
 
       @foi_attachment.expire
 
-      redirect_to edit_admin_foi_attachment_path(@foi_attachment),
-                  notice: 'Prominence updated.'
+      flash[:notice] = 'Prominence updated.'
     else
-      flash.now[:error] = @foi_attachment.errors.full_messages.to_sentence
-      render 'admin/foi_attachments/edit'
+      flash[:error] = @foi_attachment.errors.full_messages.to_sentence
     end
+
+    redirect_to edit_admin_foi_attachment_path(@foi_attachment)
   end
 
   private

--- a/app/controllers/admin/foi_attachments/replacements_controller.rb
+++ b/app/controllers/admin/foi_attachments/replacements_controller.rb
@@ -10,20 +10,19 @@ class Admin::FoiAttachments::ReplacementsController < AdminController
       )
       @foi_attachment.expire
 
-      if @foi_attachment.locked? && !@foi_attachment.masked?
-        flash[:notice] = <<~TXT.squish
+      flash[:notice] = if @foi_attachment.locked? && !@foi_attachment.masked?
+        <<~TXT.squish
           Attachment successfully updated and locked. Please wait for masking to
           complete before adding additional censor rules.
         TXT
       else
-        flash[:notice] = 'Attachment successfully updated.'
+        'Attachment successfully updated.'
       end
-      redirect_to edit_admin_foi_attachment_path(@foi_attachment)
-
     else
-      flash.now[:error] = @foi_attachment.errors.full_messages.to_sentence
-      render 'admin/foi_attachments/edit'
+      flash[:error] = @foi_attachment.errors.full_messages.to_sentence
     end
+
+    redirect_to edit_admin_foi_attachment_path(@foi_attachment)
   end
 
   private

--- a/spec/controllers/admin/foi_attachments/locks_controller_spec.rb
+++ b/spec/controllers/admin/foi_attachments/locks_controller_spec.rb
@@ -98,9 +98,11 @@ RSpec.describe Admin::FoiAttachments::LocksController do
         expect(flash[:error]).to eq('Something went wrong')
       end
 
-      it 'renders the edit template' do
+      it 'redirects to the attachment edit page' do
         post :create, params: params
-        expect(response).to render_template('admin/foi_attachments/edit')
+        expect(response).to redirect_to(
+          edit_admin_foi_attachment_path(attachment)
+        )
       end
     end
 
@@ -201,9 +203,11 @@ RSpec.describe Admin::FoiAttachments::LocksController do
         expect(flash[:error]).to eq('Cannot unlock')
       end
 
-      it 'renders the edit template' do
-        delete :destroy, params: params
-        expect(response).to render_template('admin/foi_attachments/edit')
+      it 'redirects to the attachment edit page' do
+        post :create, params: params
+        expect(response).to redirect_to(
+          edit_admin_foi_attachment_path(attachment)
+        )
       end
     end
 

--- a/spec/controllers/admin/foi_attachments/prominence_controller_spec.rb
+++ b/spec/controllers/admin/foi_attachments/prominence_controller_spec.rb
@@ -101,9 +101,11 @@ RSpec.describe Admin::FoiAttachments::ProminenceController do
         expect(flash[:error]).to eq('Prominence is not included in the list')
       end
 
-      it 'renders the edit template' do
+      it 'redirects to the attachment edit page' do
         patch :update, params: params
-        expect(response).to render_template('admin/foi_attachments/edit')
+        expect(response).to redirect_to(
+          edit_admin_foi_attachment_path(attachment)
+        )
       end
     end
 

--- a/spec/controllers/admin/foi_attachments/replacements_controller_spec.rb
+++ b/spec/controllers/admin/foi_attachments/replacements_controller_spec.rb
@@ -185,6 +185,7 @@ RSpec.describe Admin::FoiAttachments::ReplacementsController do
       before do
         allow(FoiAttachment).to receive(:find).and_return(attachment)
         allow(attachment).to receive(:update_and_log_event).and_return(false)
+        attachment.errors.add(:base, 'Cannot replace.')
       end
 
       it 'assigns the attachment' do
@@ -197,9 +198,16 @@ RSpec.describe Admin::FoiAttachments::ReplacementsController do
         post :create, params: params
       end
 
-      it 'renders the edit template' do
+      it 'sets an error flash' do
         post :create, params: params
-        expect(response).to render_template(:edit)
+        expect(flash[:error]).to eq('Cannot replace.')
+      end
+
+      it 'redirects to the attachment edit page' do
+        post :create, params: params
+        expect(response).to redirect_to(
+          edit_admin_foi_attachment_path(attachment)
+        )
       end
     end
 


### PR DESCRIPTION
In all of these cases we're not handling form errors in the usual way, so rendering the edit template doesn't really work as expected and in the case of locking, can show an incorrect lock status.

Instead just redirect on both success and failure with the general error message.

Also adds a missing test for displaying the error flash on replacement failure.

See https://github.com/mysociety/alaveteli/pull/9083#pullrequestreview-3710281012

In service of https://github.com/mysociety/alaveteli/issues/8803.

[skip changelog]
