### PR TITLE
Colourise admin todo list labels

### DIFF
--- a/app/helpers/admin/to_do_list_helper.rb
+++ b/app/helpers/admin/to_do_list_helper.rb
@@ -1,0 +1,42 @@
+# Helpers for rendering admin to-do list labels
+module Admin::ToDoListHelper
+  PRIORITY_IMPORTANT = %w[
+    attention-messages
+    embargoed-attention-messages
+    attention-comments
+    embargoed-attention-comments
+    requires-admin
+  ]
+
+  PRIORITY_WARNING = %w[
+    embargoed-requires-admin
+    error-messages
+    embargoed-error-messages
+    holding-pen
+  ]
+
+  PRIORITY_INFO = %w[
+    new-authorities
+    update-authorities
+  ]
+
+  PRIORITY_NONE = %w[
+    blank-contacts
+    unclassified
+  ]
+
+  def todo_list_label_style(id)
+    case id
+    when *PRIORITY_NONE
+      ''
+    when *PRIORITY_INFO
+      'label-info'
+    when *PRIORITY_WARNING
+      'label-warning'
+    when *PRIORITY_IMPORTANT
+      'label-important'
+    else
+      'label-important'
+    end
+  end
+end

--- a/app/views/admin_general/_to_do_list.html.erb
+++ b/app/views/admin_general/_to_do_list.html.erb
@@ -3,7 +3,7 @@
   <div class="accordion-group">
     <div class="accordion-heading">
       <a class="accordion-toggle" href="#<%= id %>" data-toggle="collapse" data-parent="<%= parent %>">
-        <span class="label label-important">
+        <span class="label <%= todo_list_label_style(id) %>">
           <%= count %>
         </span>
         <%= chevron_right %> <%= label %>

--- a/app/views/admin_general/index.html.erb
+++ b/app/views/admin_general/index.html.erb
@@ -82,7 +82,7 @@
       <div class="accordion-group">
         <div class="accordion-heading">
           <a class="accordion-toggle" href="#new-authorities" data-toggle="collapse" data-parent="authority-things-to-do">
-            <span class="label label-important">
+            <span class="label <%= todo_list_label_style('new-authorities') %>">
               <%= @new_body_requests.size %>
             </span>
             <%= chevron_right %> Add new authorities
@@ -116,7 +116,7 @@
       <div class="accordion-group">
         <div class="accordion-heading">
           <a class="accordion-toggle" href="#update-authorities" data-toggle="collapse" data-parent="authority-things-to-do">
-            <span class="label label-important">
+            <span class="label <%= todo_list_label_style('update-authorities') %>">
               <%= @body_update_requests.size %>
             </span>
             <%= chevron_right %> Update authorities

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add prioritisation indication of admin summary todos (Gareth Rees)
 * Update Exim message ID matching (Graeme Porteous)
 * Allow erasure of underlying raw email data (Graeme Porteous, Gareth Rees)
 * Restore logging of :email parameters (Gareth Rees)

--- a/spec/helpers/admin/to_do_list_helper_spec.rb
+++ b/spec/helpers/admin/to_do_list_helper_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe Admin::ToDoListHelper, type: :helper do
+  include Admin::ToDoListHelper
+
+  describe '#todo_list_label' do
+    subject { todo_list_label_style(id) }
+
+    context 'when the id is important' do
+      let(:id) { described_class::PRIORITY_IMPORTANT.first }
+      it { is_expected.to eq('label-important') }
+    end
+
+    context 'when the id is warning' do
+      let(:id) { described_class::PRIORITY_WARNING.first }
+      it { is_expected.to eq('label-warning') }
+    end
+
+    context 'when the id is info' do
+      let(:id) { described_class::PRIORITY_INFO.first }
+      it { is_expected.to eq('label-info') }
+    end
+
+    context 'when the id is none' do
+      let(:id) { described_class::PRIORITY_NONE.first }
+      it { is_expected.to eq('') }
+    end
+
+    context 'when the id is not a set priority' do
+      let(:id) { 'foo' }
+      it { is_expected.to eq('label-important') }
+    end
+  end
+end


### PR DESCRIPTION
Help admins identify generally higher priority tasks.

<img width="587" height="555" alt="Screenshot 2026-01-27 at 15 00 03" src="https://github.com/user-attachments/assets/a821e7b0-d02a-4e2b-9405-79af9079a9ce" />
