### PR TITLE
Update regexp to match Exim message IDs

### DIFF
--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -557,7 +557,7 @@ class OutgoingMessage < ApplicationRecord
                 try(:line)
     end
 
-    lines.compact.map { |line| line[/\w{6}-\w{6}-\w{2}/].strip }.compact
+    lines.compact.map { |line| line[/\b\w{6}-(?:\w{6}-\w{2}|\w{11}-\w{4})\b/].strip }.compact
   end
 
   def exim_mail_server_logs

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Update Exim message ID matching (Graeme Porteous)
 * Allow erasure of underlying raw email data (Graeme Porteous, Gareth Rees)
 * Restore logging of :email parameters (Gareth Rees)
 * Fix importing holidays from iCal feed (Gareth Rees)

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -1067,7 +1067,7 @@ RSpec.describe OutgoingMessage do
       end
 
       context 'a sent message' do
-        it 'returns one mta_id when a message has been sent once' do
+        it 'returns one mta_id when a message has older Exim message IDs' do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
@@ -1081,6 +1081,22 @@ RSpec.describe OutgoingMessage do
           EOF
 
           expect(message.mta_ids).to eq(['1ZsFHb-0004dK-SM'])
+        end
+
+        it 'returns one mta_id when a message has newer Exim message IDs' do
+          message = FactoryBot.create(:initial_request)
+          body_email = message.info_request.public_body.request_email
+          request_email = message.info_request.incoming_email
+          request_subject = message.info_request.email_subject_request(html: false)
+          smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
+
+          load_mail_server_logs <<-EOF.strip_heredoc
+          2026-02-04 09:28:16 [27817] 1vnK2E-00000002Cfc-2ahs => #{ body_email } F=<#{ request_email }> P=<#{ request_email }> R=dnslookup T=remote_smtp S=2297 H=cluster2.gsi.messagelabs.com [127.0.0.1]:25 X=TLS1.2:DHE_RSA_AES_128_CBC_SHA1:128 CV=no DN="C=US,ST=California,L=Mountain View,O=Symantec Corporation,OU=Symantec.cloud,CN=mail221.messagelabs.com" C="250 ok 1446233056 qp 26062 server-4.tower-221.messagelabs.com!1446233056!7679409!1" QT=1s DT=0s
+          2026-02-04 09:28:16 [27814] 1vnK2E-00000002Cfc-2ahs <= #{ request_email } U=alaveteli P=local S=2252 id=#{ smtp_message_id } T="#{ request_subject }" from <#{ request_email }> for #{ body_email } #{ body_email }
+          2026-02-04 09:28:15 [27814] cwd=/var/www/alaveteli/alaveteli 7 args: /usr/sbin/sendmail -i -t -f #{ request_email } -- #{ body_email }
+          EOF
+
+          expect(message.mta_ids).to eq(['1vnK2E-00000002Cfc-2ahs'])
         end
 
         it 'returns one mta_id when a message has syslog format logs' do


### PR DESCRIPTION
Format has changed to 6-11-4 in newer versions. Without this change an exception would be raised and prevented request pages from loading.

