### PR TITLE
Added fix to console error for masonry JS component

### DIFF
--- a/app/assets/javascripts/ati-masonry.js
+++ b/app/assets/javascripts/ati-masonry.js
@@ -1,10 +1,13 @@
 document.addEventListener('DOMContentLoaded', function() {
 
+
   const grid = document.querySelector('.js-gallery-grid');
+  const loadMoreBtn = document.getElementById('load-more');
+
+  if (!grid || !loadMoreBtn) return;
+
   const initialCards = parseInt(grid.getAttribute('masonry-initial-cards')) || 20;
   const cardsPerLoad = parseInt(grid.getAttribute('masonry-cards-per-load')) || 10;
-  const loadMoreBtn = document.getElementById('load-more');
-  if (!grid || !loadMoreBtn) return;
 
   const allCards = Array.from(grid.querySelectorAll('.gallery-grid--card'));
   let visibleCount = 0;


### PR DESCRIPTION
## Relevant issue(s)

Currently every page with no masonry grid is triggering this console error:

`TypeError: null is not an object (evaluating 'grid.getAttribute')`

https://github.com/mysociety/alaveteli/issues/8928#issuecomment-3870694394

## What does this do?

Moved conditional that checks `.js-gallery-grid` and `#load-more` elements exist right after both constant are declared. This prevents the consolore log error `Cannot read properties of null (reading 'getAttribute')` in every page that don't have those constant and their children.

<hr>

[skip changelog]
