### PR TITLE
Removed "Medium" as a share option on request page

### DIFF
--- a/app/views/request/_act.html.erb
+++ b/app/views/request/_act.html.erb
@@ -17,16 +17,6 @@
   </a>
 </div>
 
-<div class="act_link">
-  <i class="act-link-icon act-link-icon--medium"></i>
-  <%= link_to _("Write about this on Medium"),
-              "http://medium.com/",
-              :onclick => track_analytics_event(
-                AnalyticsEvent::Category::OUTBOUND,
-                AnalyticsEvent::Action::MEDIUM_EXIT,
-                :label => "Request sidebar") %>
-</div>
-
 <% if AlaveteliConfiguration::enable_widgets %>
   <div class="act_link">
     <i class="act-link-icon act-link-icon--widget"></i>


### PR DESCRIPTION
## Relevant issue(s)
Fixes part of #8589

## What does this do?

Removes "Medium" as a share option on request pages. 

## Why was this needed?

## Implementation notes

## Screenshots

<img width="1163" height="393" alt="Screenshot 2026-03-04 at 06 49 23" src="https://github.com/user-attachments/assets/86d92c4f-0716-4692-9048-9aa3368d1d6c" />

## Notes to reviewer

<hr>

[skip changelog]
