### PR TITLE
[#9099] Add background job exception notifications

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,6 +1,18 @@
 class ApplicationJob < ActiveJob::Base # :nodoc:
+  # Site-wide access to configuration settings
+  include ConfigHelper
+
   # Automatically retry jobs that encountered a deadlock
   retry_on ActiveRecord::Deadlocked
+
+  # Automatically retry jobs 5 times then send exception notification
+  retry_on StandardError, wait: :polynomially_longer, attempts: 5 do |job, err|
+    next unless job.send_exception_notifications?
+
+    ExceptionNotifier.notify_exception(
+      err, data: { job: job.class.to_s, job_id: job.job_id }
+    )
+  end
 
   # Most jobs are safe to ignore if the underlying records are no longer
   # available

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add exception notifications to background job failures (Graeme Porteous)
 * Fix visibility check for attachments when downloading a batch request as a zip
   file (Gareth Rees)
 * Fix censor rules not being applied to attachment filenames in downloads

--- a/spec/jobs/application_job_spec.rb
+++ b/spec/jobs/application_job_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe ApplicationJob, type: :job do
+  include ActiveJob::TestHelper
+
+  before do
+    stub_const('FailingJob', Class.new(ApplicationJob) do
+      def perform(*_args)
+        raise StandardError, 'test error'
+      end
+    end)
+  end
+
+  describe 'retry_on StandardError' do
+    context 'when exception notifications are enabled' do
+      before do
+        allow(AlaveteliConfiguration).to receive(:exception_notifications_from).
+          and_return('from@example.com')
+        allow(AlaveteliConfiguration).to receive(:exception_notifications_to).
+          and_return('to@example.com')
+      end
+
+      it 'sends exception notification once after all 5 retries exhausted' do
+        attempts = 0
+
+        allow_any_instance_of(FailingJob).to receive(:perform).
+          and_wrap_original do
+            attempts += 1
+            raise StandardError, 'test error'
+          end
+        allow_any_instance_of(FailingJob).to receive(:job_id).and_return(123456)
+
+        expected_data = { job: 'FailingJob', job_id: 123456 }
+
+        expect(ExceptionNotifier).to receive(:notify_exception).
+          with(instance_of(StandardError), data: expected_data).once
+
+        perform_enqueued_jobs { FailingJob.perform_later('arg1', 'arg2') }
+
+        expect(attempts).to eq(5)
+      end
+    end
+
+    context 'when exception notifications are disabled' do
+      before do
+        allow(AlaveteliConfiguration).to receive(:exception_notifications_from).
+          and_return('')
+        allow(AlaveteliConfiguration).to receive(:exception_notifications_to).
+          and_return('')
+      end
+
+      it 'does not send exception notification' do
+        expect(ExceptionNotifier).not_to receive(:notify_exception)
+
+        perform_enqueued_jobs { FailingJob.perform_later('arg1', 'arg2') }
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #9099

## What does this do?

After background jobs have retried 5 times give up and send notification using the existing exception notifier.

## Why was this needed?

If some jobs fail we might need to take manual action to ensure data is purged - for example when dealing with PII/GDPR requests. This change will notify us when jobs aren't successful.