### PR TITLE
Remove docker-compose version attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:


### PR DESCRIPTION
As per output when running:

    $ dc run --rm app bin/rails c
    WARN[0000] /Users/gareth/src/mysociety/alaveteli/docker-compose.yml:
    the attribute `version` is obsolete, it will be ignored, please
    remove it to avoid potential confusion

[skip changelog]
