### PR TITLE
Always include ActiveJob::TestHelper

### DIFF
--- a/spec/integration/admin_censor_rule_spec.rb
+++ b/spec/integration/admin_censor_rule_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'integration/alaveteli_dsl'
 
 RSpec.describe 'Updating censor rules' do
-  include ActiveJob::TestHelper
-
   let!(:admin) do
     confirm(:admin_user)
     login(:admin_user)

--- a/spec/integration/incoming_mail_spec.rb
+++ b/spec/integration/incoming_mail_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'integration/alaveteli_dsl'
 
 RSpec.describe 'when handling incoming mail' do
-  include ActiveJob::TestHelper
-
   let(:info_request) { FactoryBot.create(:info_request) }
 
   it "receives incoming messages, sends email to requester, and shows them" do

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -26,8 +26,6 @@ require 'spec_helper'
 require 'models/concerns/message_prominence'
 
 RSpec.describe FoiAttachment do
-  include ActiveJob::TestHelper
-
   it_behaves_like 'concerns/message_prominence', :body_text
 
   describe '.binary' do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -1100,8 +1100,6 @@ RSpec.describe PublicBody, "when finding_by_tags" do
 end
 
 RSpec.describe PublicBody, " when saving" do
-  include ActiveJob::TestHelper
-
   before do
     @public_body = PublicBody.new
   end

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -11,8 +11,6 @@
 require 'spec_helper'
 
 RSpec.describe RawEmail do
-  include ActiveJob::TestHelper
-
   def roundtrip_data(raw_email, data)
     raw_email.data = data
     raw_email.save!

--- a/spec/models/xapian_spec.rb
+++ b/spec/models/xapian_spec.rb
@@ -62,8 +62,6 @@ RSpec.describe PublicBody, " when indexing public bodies with Xapian" do
 end
 
 RSpec.describe PublicBody, " when indexing requests by body they are to" do
-  include ActiveJob::TestHelper
-
   before(:each) do
     update_xapian_index
   end
@@ -120,8 +118,6 @@ RSpec.describe PublicBody, " when indexing requests by body they are to" do
 end
 
 RSpec.describe User, " when indexing requests by user they are from" do
-  include ActiveJob::TestHelper
-
   before(:each) do
     update_xapian_index
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,6 +34,7 @@ RSpec.configure do |config|
 
   config.infer_spec_type_from_file_location!
 
+  config.include ActiveJob::TestHelper
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Capybara::DSL, type: :request
   config.include ConfigHelper


### PR DESCRIPTION
We're increasingly relying on background jobs so make sure the test helper is available everywhere to avoid head-scratching about why the `perform_enqueued_jobs` method isn't working.

[skip changelog]
