### PR TITLE
Disable the docker compose menu

### DIFF
--- a/docker/server
+++ b/docker/server
@@ -6,6 +6,7 @@ cd "$(dirname "$0")/.."
 
 if [ -z "$DOCKER" ]; then
   . docker/env
+  export COMPOSE_MENU=${COMPOSE_MENU:-0}
   docker compose up
   exit
 fi


### PR DESCRIPTION
This menu is really annoying so disable it by default. Can be re-enabled by prefixing the command with/exporting the env var `COMPOSE_MENU=1`.

BEFORE

<img width="902" height="153" alt="Screenshot 2026-03-11 at 15 54 37" src="https://github.com/user-attachments/assets/b2db4a06-74c9-45a0-b54d-1ee8464b1f33" />

AFTER

<img width="900" height="103" alt="Screenshot 2026-03-11 at 15 54 51" src="https://github.com/user-attachments/assets/cec5b860-0165-4f99-aff1-35e6b52220b0" />

OPTIONAL

`COMPOSE_MENU=1 docker/server`
<img width="903" height="121" alt="Screenshot 2026-03-11 at 15 55 13" src="https://github.com/user-attachments/assets/a9d4e346-3b2d-4919-b743-c848e3b06014" />


[skip changelog]
