### PR TITLE
Add admin_columns table for raw email

### DIFF
--- a/app/views/admin_raw_email/show.html.erb
+++ b/app/views/admin_raw_email/show.html.erb
@@ -22,6 +22,21 @@
   </p>
 <% end %>
 
+<table class="table table-striped table-condensed">
+  <tbody>
+    <% @raw_email.for_admin_column do |name, value| %>
+      <tr>
+        <td>
+          <b><%= name.humanize %></b>
+        </td>
+        <td>
+          <%= admin_value(value) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
 <table class="table table-striped table-condensed table-hover">
   <thead>
     <tr>


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/8803

## What does this do?

Add the usual admin columns table for Raw Email

## Why was this needed?

Mainly to show the `erased_at` attribute for erased emails

## Implementation notes

Might be possible to extract the parsed headers into this DSL (we could add `delegate to: mail` for all of the values) but would have to handle the `address_list` formatting. Bit much faff for now but might come back to it later.

## Screenshots

Retained RawEmail

<img width="963" height="274" alt="Screenshot 2026-03-13 at 13 03 56" src="https://github.com/user-attachments/assets/bc4c41f5-05ed-4289-9f64-4ec0ffe0f526" />

Erased RawEmail

<img width="963" height="295" alt="Screenshot 2026-03-13 at 13 04 11" src="https://github.com/user-attachments/assets/9ea60440-3015-42b1-970a-4d57294ea71b" />


[skip changelog]
