### PR TITLE
Fix signup crash for non-Latin usernames

### DIFF
--- a/app/models/user/slug.rb
+++ b/app/models/user/slug.rb
@@ -28,7 +28,8 @@ module User::Slug
       value = read_attribute(:name)
       return super('user') if value =~ /^[\d_\.]+$/
 
-      super(value).gsub('-', '_')
+      result = super(value).gsub('-', '_')
+      result.presence || super('user')
     end
 
     def to_param

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Fix signup crash when user name contains only non-Latin characters
+  (Guy Freeman)
 * Fix censor rules not being applied to attachment filenames in downloads
   (Gareth Rees)
 * Add ability to erase attachments (Graeme Porteous)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -89,6 +89,12 @@ RSpec.describe User, "making up the URL name" do
     @user.valid?
     expect(@user.url_name).to eq('user')
   end
+
+  it 'should fall back to "user" for non-Latin names' do
+    @user.name = '邢佳兴'
+    @user.valid?
+    expect(@user.url_name).to eq('user')
+  end
 end
 
 RSpec.describe User, "banning the user" do


### PR DESCRIPTION
## Summary

- **Bug**: When a user signs up with a purely non-Latin name (e.g. Chinese characters "邢佳兴"), Rails' `parameterize` strips all non-Latin characters and produces an empty string. FriendlyId then sets `url_name` to nil, causing a `PG::NotNullViolation` on the `users` table.
- **Fix**: After parameterizing the name, check if the result is blank and fall back to `'user'` — the same fallback already used for all-numeric names. The `sequentially_slugged` FriendlyId module automatically appends a numeric suffix (`user_2`, `user_3`, ...) to handle duplicate `'user'` slugs.
- This bug has been latent since FriendlyId was added to User in April 2023.

## Changes

- `app/models/user/slug.rb`: In `normalize_friendly_id`, store the parameterized result and return `super('user')` if it is blank.
- `spec/models/user_spec.rb`: Add a test for non-Latin names in the "making up the URL name" describe block.

## Test plan

- [ ] `bundle exec rspec spec/models/user_spec.rb` — new test passes, existing slug tests still green
- [ ] Manual test: create a user with a non-Latin name (e.g. "邢佳兴") and confirm signup succeeds with `url_name` set to `"user"`
- [ ] Create a second user with a non-Latin name and confirm `url_name` is `"user_2"` (sequential slug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)