### PR TITLE
Stop bots indexing password change form

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Prevent external search indexing of password change form (Gareth Rees)
 * Allow customisation of text masks (Gareth Rees)
 * Strip ActionText attachments from Project rich text fields (Graeme Porteous)
 * Validate profile photo content type before ImageMagick processing

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -25,3 +25,4 @@ Disallow: */request/*/followups/new
 Disallow: */request/*/similar
 Disallow: */request/*/track
 Disallow: */request/*/upload
+Disallow: */profile/change_password/*


### PR DESCRIPTION
Unnecessary for them, and costs us resource usage and log noise.
