### PR TITLE
Add CSP with nonce-based script protection

### DIFF
--- a/app/views/alaveteli_pro/info_requests/index.html.erb
+++ b/app/views/alaveteli_pro/info_requests/index.html.erb
@@ -25,5 +25,5 @@
 
 </div>  <!-- .dashboard -->
 <% content_for :javascript do %>
- <%= javascript_include_tag 'alaveteli_pro/request-index.js' %>
+ <%= javascript_include_tag 'alaveteli_pro/request-index.js', nonce: true %>
 <% end %>

--- a/app/views/alaveteli_pro/plans/show.html.erb
+++ b/app/views/alaveteli_pro/plans/show.html.erb
@@ -1,14 +1,14 @@
 <% content_for :javascript_head do %>
-  <script src="https://js.stripe.com/v3/"></script>
+  <%= javascript_include_tag "https://js.stripe.com/v3/", nonce: true %>
 <% end %>
 
 <% content_for :javascript do %>
-  <%= javascript_tag do %>
+  <%= javascript_tag nonce: true do %>
     AlaveteliPro.stripe_publishable_key = '<%= AlaveteliConfiguration.stripe_publishable_key %>';
     AlaveteliPro.stripe_local = '<%= stripe_locale %>';
   <% end %>
 
-  <%= javascript_include_tag 'alaveteli_pro/stripe' %>
+  <%= javascript_include_tag 'alaveteli_pro/stripe', nonce: true %>
 <% end %>
 
 <div class="inner-canvas settings">

--- a/app/views/alaveteli_pro/projects/edit.html.erb
+++ b/app/views/alaveteli_pro/projects/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :javascript_head do %>
-  <script type="text/javascript" src="https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js"></script>
+  <%= javascript_include_tag "https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js", nonce: true %>
 <% end %>
 
 <div id="project-form" class="inner-canvas">

--- a/app/views/alaveteli_pro/projects/new.html.erb
+++ b/app/views/alaveteli_pro/projects/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :javascript_head do %>
-  <script type="text/javascript" src="https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js"></script>
+  <%= javascript_include_tag "https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js", nonce: true %>
 <% end %>
 
 <div id="project-form" class="inner-canvas">

--- a/app/views/alaveteli_pro/subscriptions/index.html.erb
+++ b/app/views/alaveteli_pro/subscriptions/index.html.erb
@@ -1,14 +1,14 @@
 <% content_for :javascript_head do %>
-  <script src="https://js.stripe.com/v3/"></script>
+  <%= javascript_include_tag "https://js.stripe.com/v3/", nonce: true %>
 <% end %>
 
 <% content_for :javascript do %>
-  <%= javascript_tag do %>
+  <%= javascript_tag nonce: true do %>
     AlaveteliPro.stripe_publishable_key = '<%= AlaveteliConfiguration.stripe_publishable_key %>';
     AlaveteliPro.stripe_local = '<%= stripe_locale %>';
   <% end %>
 
-  <%= javascript_include_tag 'alaveteli_pro/stripe' %>
+  <%= javascript_include_tag 'alaveteli_pro/stripe', nonce: true %>
 <% end %>
 
 <div class="inner-canvas settings">

--- a/app/views/application/_ga_code.html.erb
+++ b/app/views/application/_ga_code.html.erb
@@ -1,7 +1,9 @@
 <% unless AlaveteliConfiguration.ga_code.empty?  %>
-  <script defer>Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);return t.trim().length>0&&(t+="; "),t+="_ga=GA1.1."+Math.floor(1e9*Math.random())+"."+Math.floor(1e9*Math.random())},set:function(t){t.trim().startsWith("_ga")||Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
-  <script defer src="https://www.googletagmanager.com/gtag/js?id=<%= AlaveteliConfiguration.ga_code %>"></script>
-  <script>
+  <%= javascript_tag defer: true, nonce: true do %>
+    Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);return t.trim().length>0&&(t+="; "),t+="_ga=GA1.1."+Math.floor(1e9*Math.random())+"."+Math.floor(1e9*Math.random())},set:function(t){t.trim().startsWith("_ga")||Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});
+  <% end %>
+  <%= javascript_include_tag "https://www.googletagmanager.com/gtag/js?id=#{AlaveteliConfiguration.ga_code}", defer: true, nonce: true %>
+  <%= javascript_tag nonce: true do %>
     var client_id = Math.floor(Math.random() * 1000000000) + '.' + Math.floor(Math.random() * 1000000000);
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
@@ -13,5 +15,5 @@
     <% else %>
       gtag('send', 'page_view');
     <% end %>
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/general/_localised_datepicker.html.erb
+++ b/app/views/general/_localised_datepicker.html.erb
@@ -1,5 +1,5 @@
 <% content_for :javascript  do %>
-  <script type="text/javascript">
+  <%= javascript_tag nonce: true do %>
   $(function() {
     $(".use-datepicker").datepicker(
       { closeText: '<%= j _("Done") %>',
@@ -15,5 +15,5 @@
         dateFormat: '<%= I18n.translate('date.formats.default').sub("%Y", "yy").sub("%m", "mm").sub("%d", "dd").gsub("-", "/") %>' }
     );
   });
-  </script>
+  <% end %>
 <% end %>

--- a/app/views/general/blog.html.erb
+++ b/app/views/general/blog.html.erb
@@ -78,7 +78,7 @@
     <% if AlaveteliConfiguration::twitter_widget_id %>
       <div id="twitter" class="twitter">
         <a class="twitter-timeline" data-dnt=true href="https://twitter.com/<%= AlaveteliConfiguration::twitter_username %>" data-widget-id="<%= AlaveteliConfiguration::twitter_widget_id %>">Tweets by @<%= AlaveteliConfiguration::twitter_username %></a>
-        <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+        <%= javascript_tag nonce: true do %>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");<% end %>
       </div>
     <% end %>
   <% end %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -8,11 +8,11 @@
       <%= @title ? "#{ @title } -" : "" %> <%= site_name %> admin
     </title>
 
-    <%= javascript_include_tag "admin" %>
+    <%= javascript_include_tag "admin", nonce: true %>
     <%= stylesheet_link_tag "admin", :title => "Main", :rel => "stylesheet" %>
     <%= stylesheet_link_tag 'admin/print', :rel => "stylesheet", :media => "print"  %>
 
-    <script type="text/javascript" src="https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js"></script>
+    <%= javascript_include_tag "https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js", nonce: true %>
 
     <%= render :partial => 'layouts/favicon' %>
     <%= content_for :javascript_head %>

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -38,11 +38,11 @@
     <%= render :partial => 'general/opengraph_tags' %>
     <%= render :partial => 'general/before_head_end' %>
     <!-- Replace the html tag's no-js class with js -->
-    <script>
+    <%= javascript_tag nonce: true do %>
       (function(H){
         H.className = H.className.replace(/\bno-js\b/,'js-loaded')
       })(document.documentElement);
-    </script>
+    <% end %>
     <%= content_for :javascript_head %>
   </head>
   <body class="<%= yield :body_class -%> <% if @in_pro_area %>alaveteli-pro<% end %>">
@@ -95,15 +95,15 @@
     <% unless @render_to_file %>
       <%= render partial: 'ga_code' unless @user&.is_admin? %>
 
-      <%= javascript_include_tag "application" %>
+      <%= javascript_include_tag "application", nonce: true %>
 
       <% if is_admin? %>
-        <%= javascript_include_tag "bootstrap-dropdown" %>
+        <%= javascript_include_tag "bootstrap-dropdown", nonce: true %>
       <% end %>
 
       <% if AlaveteliConfiguration::force_registration_on_new_request && !@user %>
-        <%= javascript_include_tag 'fancybox.js' %>
-        <script type="text/javascript">
+        <%= javascript_include_tag 'fancybox.js', nonce: true %>
+        <%= javascript_tag nonce: true do %>
           $(document).ready(function() {
             $("#make-request-link").fancybox({
               'modal': false,
@@ -119,7 +119,7 @@
               }
             });
           });
-        </script>
+        <% end %>
       <% end %>
 
       <%= content_for :javascript %>

--- a/app/views/layouts/no_chrome.html.erb
+++ b/app/views/layouts/no_chrome.html.erb
@@ -12,7 +12,7 @@
       <% end %>
     </title>
 
-    <%= javascript_include_tag "application" %>
+    <%= javascript_include_tag "application", nonce: true %>
 
     <%= render :partial => 'general/responsive_stylesheets' %>
     <%= render :partial => 'layouts/favicon' %>

--- a/app/views/projects/dataset/edit.html.erb
+++ b/app/views/projects/dataset/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :javascript_head do %>
-  <script type="text/javascript" src="https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js"></script>
+  <%= javascript_include_tag "https://unpkg.com/trix@2.0.8/dist/trix.umd.min.js", nonce: true %>
 <% end %>
 
 <div id="project-form" class="inner-canvas">

--- a/app/views/request/new.html.erb
+++ b/app/views/request/new.html.erb
@@ -1,6 +1,6 @@
 <% unless @batch %>
   <% content_for :javascript do %>
-    <script type="text/javascript">
+    <%= javascript_tag nonce: true do %>
       $(document).ready(function(){
         // Avoid triggering too often (on each keystroke) by using the
         // debounce jQuery plugin:
@@ -60,7 +60,7 @@
         // is focused.
         questionInputs.filter(':checked').click()
       });
-    </script>
+    <% end %>
   <% end %>
 <% end %>
 
@@ -287,6 +287,6 @@
 
 <% if @batch %>
   <% content_for :javascript do %>
-    <%= javascript_include_tag 'new-request.js' %>
+    <%= javascript_include_tag 'new-request.js', nonce: true %>
   <% end %>
 <% end %>

--- a/app/views/request/select_authorities.html.erb
+++ b/app/views/request/select_authorities.html.erb
@@ -76,5 +76,5 @@
 </div>
 
 <% content_for :javascript do %>
-  <%= javascript_include_tag 'select-authorities.js' %>
+  <%= javascript_include_tag 'select-authorities.js', nonce: true %>
 <% end %>

--- a/app/views/request/select_authority.html.erb
+++ b/app/views/request/select_authority.html.erb
@@ -1,5 +1,5 @@
 <% content_for :javascript do %>
-  <script type="text/javascript">
+  <%= javascript_tag nonce: true do %>
   $(document).ready(function() {
     // Avoid triggering too often (on each keystroke) by using the debounce
     // jQuery plugin:
@@ -13,7 +13,7 @@
       $('#query').removeAttr('required');
     }
   });
-  </script>
+  <% end %>
 <% end %>
 
 <% @title = _("Find an authority")  %>

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -89,5 +89,5 @@
 <% end %>
 
 <%= content_for :javascript do %>
-  <%= javascript_include_tag 'request-attachments.js' %>
+  <%= javascript_include_tag 'request-attachments.js', nonce: true %>
 <% end %>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -137,15 +137,15 @@
   </div>
 
   <% content_for :javascript do %>
-    <script type="text/javascript">
+    <%= javascript_tag nonce: true do %>
       var graphs_data = <%= @public_bodies.to_json.html_safe %>;
-    </script>
-    <!--[if lte IE 8]><%= javascript_include_tag "excanvas.min.js" %><![endif]-->
-    <%= javascript_include_tag "stats" %>
+    <% end %>
+    <!--[if lte IE 8]><%= javascript_include_tag "excanvas.min.js", nonce: true %><![endif]-->
+    <%= javascript_include_tag "stats", nonce: true %>
 
-    <%= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.12/d3.min.js" %>
-    <%= javascript_include_tag "time_series" %>
-    <script type="text/javascript">
+    <%= javascript_include_tag "https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.12/d3.min.js", nonce: true %>
+    <%= javascript_include_tag "time_series", nonce: true %>
+    <%= javascript_tag nonce: true do %>
       if (typeof d3TimeSeries == 'function') {
         d3.json("<%= statistics_url(:format => 'json') %>", function(data) {
           d3TimeSeries(
@@ -165,6 +165,6 @@
           table.className += ' visually-hidden';
         }
       }
-    </script>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/user/set_crop_profile_photo.html.erb
+++ b/app/views/user/set_crop_profile_photo.html.erb
@@ -1,6 +1,6 @@
 <% @title = _("Change profile photo") %>
 <% content_for :javascript do %>
-  <%= javascript_include_tag "profile-photos" %>
+  <%= javascript_include_tag "profile-photos", nonce: true %>
   <%= stylesheet_link_tag "jquery.Jcrop.min.css" %>
 <% end %>
 

--- a/app/views/user/set_draft_profile_photo.html.erb
+++ b/app/views/user/set_draft_profile_photo.html.erb
@@ -31,9 +31,9 @@
     <p>
       <%= hidden_field_tag 'submitted_draft_profile_photo', 1 %>
 
-      <script type="text/javascript" charset="utf-8">
+      <%= javascript_tag nonce: true do %>
         document.write('<%= submit_tag _("Next, crop your photo &gt;&gt;") %>');
-      </script>
+      <% end %>
     </p>
 
     <noscript>

--- a/app/views/users/sessions/show.html.erb
+++ b/app/views/users/sessions/show.html.erb
@@ -2,10 +2,10 @@
   <%= _("You're in. <a href=\"#\" id=\"send-request\">Continue sending your request</a>") %>
 </div>
 
-<script type="text/javascript">
+<%= javascript_tag nonce: true do %>
   parent.modal_signin_successful = true;
 
   $("#send-request").click(function() {
     parent.$.fancybox.close(); return false;
   });
-</script>
+<% end %>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,22 +4,23 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self, :https
+    policy.font_src    :self, :https, :data
+    policy.img_src     :self, :https, :data
+    policy.object_src  :none
+    policy.script_src  :self, :strict_dynamic
+    policy.style_src   :self, :https, :unsafe_inline
+
+    # Specify URI for violation reports
+    # policy.report_uri "/csp-violation-report-endpoint"
+  end
+
+  # Generate session nonces for permitted importmap and inline scripts.
+  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+  config.content_security_policy_nonce_directives = %w(script-src)
+
+  # Report violations without enforcing the policy.
+  config.content_security_policy_report_only = false
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Add Content Security Policy with nonce-based script protection (Graeme
+  Porteous)
 * Render public body category notes (Gareth Rees)
 * Prevent external search indexing of password change form (Gareth Rees)
 * Allow customisation of text masks (Gareth Rees)
@@ -65,6 +67,19 @@
       AtiNetworkController.showcase_enabled = false
     end
 
+* **Note:** A Content Security Policy (CSP) has been enabled with nonce-based
+  script protection. If your theme includes any inline `<script>` tags, replace
+  them with Rails helpers that include `nonce: true`:
+
+  For inline scripts, use `javascript_tag` with `nonce: true`:
+
+      <%= javascript_tag nonce: true do %>
+        // your JavaScript here
+      <% end %>
+
+  For external scripts, use `javascript_include_tag` with `nonce: true`:
+
+      <%= javascript_include_tag "https://example.com/script.js", nonce: true %>
 * _Optional:_ Text masks can now be customised to allow fine tuning of the
   default redactions that Alaveteli applies. Here are some examples of how to
   add, remove or change masks using the new API.


### PR DESCRIPTION
- Configure CSP initializer with strict_dynamic for scripts
- Update views to use `javascript_tag`/`javascript_include_tag` with `nonce: true` instead of raw `<script>` tags.

Scripts from external sources are automatically trusted via "strict_dynamic" when loaded by nonced scripts.