### PR TITLE
Restrict visibility of hidden and requester-only requests in projects

### DIFF
--- a/app/controllers/projects/classifies_controller.rb
+++ b/app/controllers/projects/classifies_controller.rb
@@ -77,10 +77,17 @@ class Projects::ClassifiesController < Projects::BaseController
   end
 
   def load_info_request_from_queue
-    @info_request = (
-      @queue = Project::Queue.classifiable(@project, session)
-      @queue.next
-    )
+    @queue = Project::Queue.classifiable(@project, session)
+    @info_request = next_readable_request
+  end
+
+  def next_readable_request
+    request = @queue.next
+    while request && cannot?(:read, request)
+      @queue.skip(request)
+      request = @queue.next
+    end
+    request
   end
 
   def load_info_request_from_url_title

--- a/app/controllers/projects/dataset_controller.rb
+++ b/app/controllers/projects/dataset_controller.rb
@@ -8,7 +8,7 @@ class Projects::DatasetController < Projects::BaseController
 
   def show
     authorize! :export, @project
-    @export = Project::Export.new(@project)
+    @export = Project::Export.new(@project, user: current_user)
 
     respond_to do |format|
       format.html

--- a/app/controllers/projects/extracts_controller.rb
+++ b/app/controllers/projects/extracts_controller.rb
@@ -73,10 +73,17 @@ class Projects::ExtractsController < Projects::BaseController
   end
 
   def load_info_request_from_queue
-    @info_request = (
-      @queue = Project::Queue.extractable(@project, session)
-      @queue.next
-    )
+    @queue = Project::Queue.extractable(@project, session)
+    @info_request = next_readable_request
+  end
+
+  def next_readable_request
+    request = @queue.next
+    while request && cannot?(:read, request)
+      @queue.skip(request)
+      request = @queue.next
+    end
+    request
   end
 
   def load_info_request_from_url_title

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -103,9 +103,11 @@ class Ability
 
     # Reading requests with prominence or via a project or public token
     can :read, InfoRequest do |info_request|
-      can?(:_read, info_request) ||
-        (project&.member?(user) && project&.info_request?(info_request)) ||
-        (public_token && %w[normal backpage].include?(info_request.prominence))
+      next true if can?(:_read, info_request)
+      next true if public_token &&
+        %w[normal backpage].include?(info_request.prominence)
+
+      visible_to_project_member?(info_request)
     end
 
     can :manage, OutgoingMessage::Snippet do |_request|
@@ -252,6 +254,18 @@ class Ability
   end
 
   private
+
+  def visible_to_project_member?(info_request)
+    return false unless project
+    return false unless project.member?(user) &&
+      project.info_request?(info_request)
+
+    return false if info_request.prominence == 'hidden'
+    return false if info_request.prominence == 'requester_only' &&
+      !info_request.is_owning_user?(user)
+
+    true
+  end
 
   def can_update_request_state?(request)
     (user && request.is_old_unclassified?) || request.is_owning_user?(user) ||

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -41,7 +41,10 @@ class Project < ApplicationRecord
            source_type: 'InfoRequestBatch'
 
   has_many :info_requests,
-           ->(project) { unscope(:where).for_project(project) },
+           ->(project) {
+             unscope(:where).for_project(project).
+               where.not(prominence: 'hidden')
+           },
            extend: Project::InfoRequestExtension
 
   has_one :key_set, class_name: 'Dataset::KeySet', as: :resource

--- a/app/models/project/export.rb
+++ b/app/models/project/export.rb
@@ -21,6 +21,15 @@ class Project::Export
     end
   end
 
+  def has_embargoed_requests?
+    project.info_requests.embargoed.exists?
+  end
+
+  def has_requester_only_requests?
+    project.info_requests.
+      where(prominence: 'requester_only').exists?
+  end
+
   def ability
     @ability ||= Ability.new(user, project: project)
   end

--- a/app/models/project/export.rb
+++ b/app/models/project/export.rb
@@ -7,17 +7,22 @@ class Project::Export
   include DownloadHelper
   include ActionView::Helpers::TagHelper
 
-  attr_reader :project
+  attr_reader :project, :user
   protected :project
 
-  def initialize(project)
+  def initialize(project, user: nil)
     @project = project
+    @user = user
   end
 
   def data
-    @data ||= project.info_requests.map do |info_request|
+    @data ||= visible_requests.map do |info_request|
       Project::Export::InfoRequest.new(project, info_request).data
     end
+  end
+
+  def ability
+    @ability ||= Ability.new(user, project: project)
   end
 
   def data_for_web
@@ -61,5 +66,11 @@ class Project::Export
       csv << header.keys.map(&:to_s) if header
       data_for_csv.each { |row| csv << row.values }
     end
+  end
+
+  private
+
+  def visible_requests
+    project.info_requests.select { |r| ability.can?(:read, r) }
   end
 end

--- a/app/views/projects/dataset/show.html.erb
+++ b/app/views/projects/dataset/show.html.erb
@@ -33,7 +33,27 @@
               project_dataset_path(@project, format: :csv),
               class: 'button' %>
       </p>
+    </div>
 
+    <% if @export.has_embargoed_requests? %>
+      <div class="row">
+        <p class="notice">
+          <%= _('This project includes private requests. ' \
+                'These will be included in the export.') %>
+        </p>
+      </div>
+    <% end %>
+
+    <% if @export.has_requester_only_requests? %>
+      <div class="row">
+        <p class="notice">
+          <%= _('This project includes requests only visible to the requester. ' \
+                'These will not be included in the export.') %>
+        </p>
+      </div>
+    <% end %>
+
+    <div class="row">
       <table class="dataset">
         <% @export.data_for_web.each_with_index do |web, index| %>
           <% data = @export.data[index] %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Restrict visibility of hidden and requester-only requests in projects (Gareth
+  Rees, Graeme Porteous)
 * Prevent banned Pro subscribers creating requests (Gareth Rees)
 * Integrate ActionMailbox for better inbound email processing (Graeme Porteous)
 * Allow responses to be received from any source (Graeme Porteous)

--- a/spec/controllers/projects/classifies_controller_spec.rb
+++ b/spec/controllers/projects/classifies_controller_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Projects::ClassifiesController, spec_meta do
       before do
         sign_in user
         ability.can :read, project
+        ability.can :read, InfoRequest
         project.requests << FactoryBot.create(:awaiting_description)
         get :show, params: { project_id: project.id }
       end
@@ -55,6 +56,26 @@ RSpec.describe Projects::ClassifiesController, spec_meta do
 
       it 'renders the project template' do
         expect(response).to render_template('projects/classifies/show')
+      end
+    end
+
+    context 'when the next request is not readable by the user' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:unreadable) do
+        FactoryBot.create(:awaiting_description, prominence: 'requester_only')
+      end
+
+      before do
+        sign_in user
+        ability.can :read, project
+        ability.can :read, InfoRequest
+        ability.cannot :read, unreadable
+        project.requests << unreadable
+        get :show, params: { project_id: project.id }
+      end
+
+      it 'does not assign the unreadable request' do
+        expect(assigns[:info_request]).not_to eq(unreadable)
       end
     end
 

--- a/spec/controllers/projects/dataset_controller_spec.rb
+++ b/spec/controllers/projects/dataset_controller_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe Projects::DatasetController, spec_meta do
       include_context 'when authorised to export project'
 
       before do
-        allow(Project::Export).to receive(:new).with(project).and_return(
-          double(to_csv: 'CSV_DATA', name: 'NAME')
-        )
+        allow(Project::Export).to receive(:new).
+          with(project, user: user).
+          and_return(double(to_csv: 'CSV_DATA', name: 'NAME'))
         show
       end
 

--- a/spec/controllers/projects/extracts_controller_spec.rb
+++ b/spec/controllers/projects/extracts_controller_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe Projects::ExtractsController, spec_meta do
       before do
         sign_in user
         ability.can :read, project
+        ability.can :read, InfoRequest
         get :show, params: { project_id: project.id }
       end
 
@@ -62,6 +63,31 @@ RSpec.describe Projects::ExtractsController, spec_meta do
 
       it 'renders the project template' do
         expect(response).to render_template('projects/extracts/show')
+      end
+    end
+
+    context 'when the next request is not readable by the user' do
+      let(:user) { FactoryBot.create(:user) }
+      let(:unreadable) do
+        FactoryBot.create(
+          :info_request,
+          prominence: 'requester_only',
+          awaiting_description: false,
+          described_state: 'successful'
+        )
+      end
+
+      before do
+        sign_in user
+        ability.can :read, project
+        ability.can :read, InfoRequest
+        ability.cannot :read, unreadable
+        project.requests << unreadable
+        get :show, params: { project_id: project.id }
+      end
+
+      it 'does not assign the unreadable request' do
+        expect(assigns[:info_request]).not_to eq(unreadable)
       end
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -292,6 +292,34 @@ RSpec.describe Ability do
             expect(user_with_token).not_to be_able_to(:read, resource)
           end
         end
+
+        context 'with project' do
+          let(:project_owner) { FactoryBot.create(:user) }
+          let(:contributor) { FactoryBot.create(:user) }
+
+          let(:project) do
+            project = FactoryBot.create(:project, owner: project_owner)
+            project.requests << resource
+            project.contributors << contributor
+            project
+          end
+
+          it 'should return false for the project owner' do
+            ability = Ability.new(project_owner, project: project)
+            expect(ability).not_to be_able_to(:read, resource)
+          end
+
+          it 'should return false for a project contributor' do
+            ability = Ability.new(contributor, project: project)
+            expect(ability).not_to be_able_to(:read, resource)
+          end
+
+          it 'should return true for a project member who is the requester' do
+            project.contributors << resource.user
+            ability = Ability.new(resource.user, project: project)
+            expect(ability).to be_able_to(:read, resource)
+          end
+        end
       end
 
       context 'if the prominence is normal' do
@@ -1939,6 +1967,46 @@ RSpec.describe Ability, 'with project' do
 
     it 'does not allow a non-contributor to read a hidden request not in the project' do
       expect(non_contributor_ability).not_to be_able_to(:read, hidden_request)
+    end
+  end
+
+  describe 'read hidden requests in the project' do
+    let(:hidden_request) do
+      FactoryBot.create(:info_request, prominence: 'hidden')
+    end
+
+    before { project.requests << hidden_request }
+
+    it 'does not allow a project owner to read a hidden project request' do
+      expect(owner_ability).not_to be_able_to(:read, hidden_request)
+    end
+
+    it 'does not allow a project contributor to read a hidden project request' do
+      expect(contributor_ability).not_to be_able_to(:read, hidden_request)
+    end
+  end
+
+  describe 'read requester_only requests in the project' do
+    let(:requester_only_request) do
+      FactoryBot.create(:info_request, prominence: 'requester_only')
+    end
+
+    before { project.requests << requester_only_request }
+
+    it 'does not allow the project owner who is not the requester' do
+      expect(owner_ability).not_to be_able_to(:read, requester_only_request)
+    end
+
+    it 'does not allow a project contributor who is not the requester' do
+      expect(contributor_ability).not_to be_able_to(:read, requester_only_request)
+    end
+
+    it 'allows the requester who is a project member' do
+      project.contributors << requester_only_request.user
+      requester_ability = Ability.new(
+        requester_only_request.user, project: project
+      )
+      expect(requester_ability).to be_able_to(:read, requester_only_request)
     end
   end
 end

--- a/spec/models/project/export_spec.rb
+++ b/spec/models/project/export_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 RSpec.describe Project::Export do
   let(:project) { instance_double('Project') }
-  let(:instance) { described_class.new(project) }
+  let(:instance) { described_class.new(project, user: user) }
+  let(:user) { nil }
 
   describe '#data' do
     subject { instance.data }
@@ -11,7 +12,7 @@ RSpec.describe Project::Export do
     let(:info_request_b) { instance_double('InfoRequest') }
 
     before do
-      allow(project).to receive_message_chain(:info_requests).
+      allow(instance).to receive(:visible_requests).
         and_return([info_request_a, info_request_b])
     end
 
@@ -24,6 +25,58 @@ RSpec.describe Project::Export do
         and_return(double(data: { header: 'DATA B' }))
 
       is_expected.to match_array [{ header: 'DATA A' }, { header: 'DATA B' }]
+    end
+  end
+
+  describe 'requester_only filtering', feature: :projects do
+    let(:owner) { FactoryBot.create(:pro_user) }
+    let(:project) { FactoryBot.create(:project, owner: owner) }
+    let(:normal_request) { FactoryBot.create(:successful_request) }
+    let(:requester_only_request) do
+      FactoryBot.create(:successful_request, prominence: 'requester_only')
+    end
+
+    before do
+      project.requests << [normal_request, requester_only_request]
+    end
+
+    context 'when user is the project owner' do
+      let(:user) { owner }
+
+      it 'excludes requester_only requests' do
+        titles = instance.data.map { |d| d[:info_request] }
+        expect(titles).not_to include(requester_only_request)
+        expect(titles).to include(normal_request)
+      end
+    end
+
+    context 'when user is a pro admin' do
+      let(:user) { FactoryBot.create(:pro_admin_user) }
+
+      it 'includes requester_only requests' do
+        titles = instance.data.map { |d| d[:info_request] }
+        expect(titles).to include(requester_only_request)
+      end
+    end
+
+    context 'when user is nil (public export)' do
+      let(:user) { nil }
+
+      it 'excludes requester_only requests' do
+        titles = instance.data.map { |d| d[:info_request] }
+        expect(titles).not_to include(requester_only_request)
+        expect(titles).to include(normal_request)
+      end
+    end
+
+    context 'when user is a non-owner' do
+      let(:user) { FactoryBot.create(:user) }
+
+      it 'excludes requester_only requests' do
+        titles = instance.data.map { |d| d[:info_request] }
+        expect(titles).not_to include(requester_only_request)
+        expect(titles).to include(normal_request)
+      end
     end
   end
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -170,6 +170,12 @@ RSpec.describe Project, type: :model, feature: :projects do
       it 'excludes non-project batch requests' do
         is_expected.not_to include(*other_batch.info_requests)
       end
+
+      it 'excludes hidden requests' do
+        hidden = FactoryBot.create(:info_request, :hidden)
+        project.requests << hidden
+        is_expected.not_to include(hidden)
+      end
     end
 
     it 'has one key set' do


### PR DESCRIPTION
Contributors shouldn't see hidden or requester_only requests.

The tests for this are a bit confusing and not currently passing.

