### PR TITLE
Fix transient batch notification test failure

### DIFF
--- a/spec/views/notification_mailer/info_request_batches/_info_request_batch.text.erb_spec.rb
+++ b/spec/views/notification_mailer/info_request_batches/_info_request_batch.text.erb_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe(
 
   it "renders the authority list partial" do
     expected_partial = "alaveteli_pro/info_request_batches/authority_list"
-    expected_locals = { public_bodies: [public_body_1, public_body_2] }
+    expected_locals = { public_bodies: batch_request.public_bodies }
     expect(response).
       to render_template(partial: expected_partial, locals: expected_locals)
   end


### PR DESCRIPTION
Remove hardcoded expected order of public bodies. This would cause the
test to fail when the Factory Bot sequence goes from 9 to 10 resulting
in the second Public Body being order before the first.

[skip changelog]
