### PR TITLE
Fix attachment rendering without main body parts

### DIFF
--- a/app/views/request/_attachments.html.erb
+++ b/app/views/request/_attachments.html.erb
@@ -74,7 +74,7 @@
   <% end %>
   <% if can?(:read, incoming_message.get_main_body_text_part) %>
     <%= incoming_message.get_body_for_html_display(@collapse_quotes) %>
-  <% elsif incoming_message.get_main_body_text_part.erased? %>
+  <% elsif incoming_message.get_main_body_text_part&.erased? %>
     <%= _('This message has been erased.') %>
   <% end %>
 <% end %>


### PR DESCRIPTION
When there isn't a main body part we can't call #erased? and this results in a exception: `undefined method 'erased?' for nil`.

Fixes #9206

<hr>

[skip changelog]