### PR TITLE
[#8821] Add CensorRule#case_sensitive

### DIFF
--- a/app/controllers/admin_censor_rule_controller.rb
+++ b/app/controllers/admin_censor_rule_controller.rb
@@ -87,7 +87,8 @@ class AdminCensorRuleController < AdminController
   def censor_rule_params
     if params[:censor_rule]
       params.require(:censor_rule).
-        permit(:regexp, :text, :replacement, :last_edit_comment, :last_edit_editor)
+        permit(:regexp, :case_sensitive, :text, :replacement,
+               :last_edit_comment, :last_edit_editor)
     else
       {}
     end

--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -13,6 +13,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  regexp            :boolean          default(FALSE), not null
+#  case_sensitive    :boolean          default(TRUE), not null
 #
 
 # models/censor_rule.rb:
@@ -40,7 +41,7 @@ class CensorRule < ApplicationRecord
              inverse_of: :censor_rules,
              optional: true
 
-  validate :require_valid_regexp, if: proc { |rule| rule.regexp? == true }
+  validate :require_valid_regexp, if: -> { regexp? || !case_sensitive? }
 
   validates_presence_of :text,
                         :replacement,
@@ -121,7 +122,11 @@ class CensorRule < ApplicationRecord
   end
 
   def to_replace(encoding)
-    regexp? ? make_regexp(encoding) : encoded_text(encoding)
+    if regexp? || !case_sensitive?
+      make_regexp(encoding)
+    else
+      encoded_text(encoding)
+    end
   end
 
   def encoded_text(encoding)
@@ -129,10 +134,20 @@ class CensorRule < ApplicationRecord
   end
 
   def make_regexp(encoding)
+    pattern = encoded_text(encoding)
+    pattern = Regexp.escape(pattern) unless regexp?
+
     ::Warning.with_raised_warnings do
-      Regexp.new(encoded_text(encoding), Regexp::MULTILINE)
+      Regexp.new(pattern, regexp_options)
     end
   rescue RaisedWarning => e
     raise RegexpError, e.message.split('warning: ').last.chomp
+  end
+
+  def regexp_options
+    options = 0
+    options |= Regexp::IGNORECASE unless case_sensitive?
+    options |= Regexp::MULTILINE if regexp?
+    options
   end
 end

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -14,12 +14,21 @@
   </div>
 </div>
 
+<% if feature_enabled?(:censor_rule_case_sensitive) %>
+<div class="control-group">
+  <label for="censor_rule_case_sensitive" class="control-label">Case sensitive?</label>
+  <div class="controls">
+    <%= check_box 'censor_rule', 'case_sensitive' %>
+  </div>
+</div>
+<% end %>
+
 <div class="control-group">
   <label for="censor_rule_text" class="control-label">Text</label>
   <div class="controls">
     <%= text_field 'censor_rule', 'text', class: 'span6' %>
     <div class="help-block">
-      that you want to remove, case sensitive
+      that you want to remove, case sensitive by default
     </div>
   </div>
 </div>

--- a/db/migrate/20260409153250_add_case_sensitive_to_censor_rules.rb
+++ b/db/migrate/20260409153250_add_case_sensitive_to_censor_rules.rb
@@ -1,0 +1,6 @@
+class AddCaseSensitiveToCensorRules < ActiveRecord::Migration[8.0]
+  def change
+    add_column :censor_rules, :case_sensitive, :boolean,
+               default: true, null: false
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow censor rules to be case insensitive (Gareth Rees)
 * Add Content Security Policy with nonce-based script protection (Graeme
   Porteous)
 * Fix missing batch sent flash message after creating a batch (Graeme Porteous)
@@ -107,6 +108,12 @@
       # Change only a default mask's replacement
       AlaveteliTextMasker.replace_mask(:mobile_number, replacement: '[cell number]')
     end
+
+* _Optional:_ Censor rules can now be made case insensitive. This is disabled by
+  default while we beta test it before full release. Before then you can enable
+  it by running:
+
+    bin/rails runner "AlaveteliFeatures.backend.enable(:censor_rule_case_sensitive)"
 
 ### Changed Templates
 

--- a/spec/factories/censor_rules.rb
+++ b/spec/factories/censor_rules.rb
@@ -13,6 +13,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  regexp            :boolean          default(FALSE), not null
+#  case_sensitive    :boolean          default(TRUE), not null
 #
 
 FactoryBot.define do
@@ -40,6 +41,10 @@ FactoryBot.define do
     end
 
     factory :global_censor_rule do
+    end
+
+    trait :case_insensitive do
+      case_sensitive { false }
     end
   end
 end

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -13,6 +13,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  regexp            :boolean          default(FALSE), not null
+#  case_sensitive    :boolean          default(TRUE), not null
 #
 
 require 'spec_helper'
@@ -78,6 +79,36 @@ RSpec.describe CensorRule do
       Hidden private info
       --REMOVED
       EOF
+    end
+
+    context 'when case_sensitive is false with a non-regexp rule' do
+      let(:rule) do
+        FactoryBot.build(:censor_rule, :case_insensitive, text: 'Secret')
+      end
+
+      it 'applies to text regardless of case' do
+        expect(rule.apply_to_text('SECRET text')).to eq('[REDACTED] text')
+        expect(rule.apply_to_text('secret text')).to eq('[REDACTED] text')
+      end
+
+      it 'escapes regexp metacharacters in text' do
+        rule.text = 'foo.bar'
+        expect(rule.apply_to_text('fooXbar')).to eq('fooXbar')
+        expect(rule.apply_to_text('foo.bar')).to eq('[REDACTED]')
+      end
+    end
+
+    context 'when case_sensitive is false with regexp rule' do
+      let(:rule) do
+        FactoryBot.build(
+          :censor_rule, :case_insensitive, regexp: true, text: 'sec+ret'
+        )
+      end
+
+      it 'applies to text regardless of case' do
+        expect(rule.apply_to_text('SECRET text')).to eq('[REDACTED] text')
+        expect(rule.apply_to_text('secret text')).to eq('[REDACTED] text')
+      end
     end
   end
 
@@ -171,6 +202,36 @@ RSpec.describe CensorRule do
       xxxxxxxxxxxxxxxxxxxxxxxx
       xxxxxxxxxxxx
       EOF
+    end
+
+    context 'when case_sensitive is false with a non-regexp rule' do
+      let(:rule) do
+        FactoryBot.build(:censor_rule, :case_insensitive, text: 'Secret')
+      end
+
+      it 'applies to binary regardless of case' do
+        expect(rule.apply_to_binary('SECRET text')).to eq('xxxxxx text')
+        expect(rule.apply_to_binary('secret text')).to eq('xxxxxx text')
+      end
+
+      it 'escapes regexp metacharacters in binary' do
+        rule.text = 'foo.bar'
+        expect(rule.apply_to_binary('fooXbar')).to eq('fooXbar')
+        expect(rule.apply_to_binary('foo.bar')).to eq('xxxxxxx')
+      end
+    end
+
+    context 'when case_sensitive is false with a regexp rule' do
+      let(:rule) do
+        FactoryBot.build(
+          :censor_rule, :case_insensitive, regexp: true, text: 'sec+ret'
+        )
+      end
+
+      it 'applies to binary regardless of case' do
+        expect(rule.apply_to_binary('SECRET text')).to eq('xxxxxx text')
+        expect(rule.apply_to_binary('secret text')).to eq('xxxxxx text')
+      end
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Part of #8821
Fixes https://github.com/mysociety/alaveteli/issues/8302

## What does this do?

Allows censor rules to be case insensitive, whether using a plain text or regexp version.

## Why was this needed?

Annoying to have to create multiple rules for common variants where the only difference is case.

## Implementation notes

I was originally thinking we'd expose several regexp options, but since multiline is set by default the only other one that felt like it made sense was case insensitivity. As such I just went with a boolean column rather than storing the regexp opts as a string or bitmask, which makes everything a bit easier to understand. Not massively difficult to change though.

I opted to make case insensitivity apply to "non-regexp" rules so that non-technical admins would feel more confident in using the feature. It does convert the plain text to a regexp under the hood, but think this should be fine.

## Screenshots

### Text Rule

BEFORE

<img width="776" height="556" alt="Screenshot 2026-04-13 at 15 00 39" src="https://github.com/user-attachments/assets/4640d2e0-85de-4d0f-8db5-9103aea24a8b" />

RULE

Note lower-case in name

<img width="1005" height="252" alt="Screenshot 2026-04-13 at 15 01 14" src="https://github.com/user-attachments/assets/61abb63f-0306-4582-ad6f-151a3074d74d" />

AFTER

<img width="769" height="549" alt="Screenshot 2026-04-13 at 15 01 21" src="https://github.com/user-attachments/assets/98f652ea-1b7c-4d6a-ad9d-1fa061b53b41" />

### Regexp Rule

BEFORE

<img width="772" height="567" alt="Screenshot 2026-04-13 at 15 02 26" src="https://github.com/user-attachments/assets/108679d5-da5d-4eab-8e57-23954daed4d6" />

RULE

Note mixed case in name

<img width="1007" height="247" alt="Screenshot 2026-04-13 at 15 02 44" src="https://github.com/user-attachments/assets/ee38b1fc-d6e5-4cbc-b4a1-db27f477ba30" />

AFTER

<img width="765" height="480" alt="Screenshot 2026-04-13 at 15 02 50" src="https://github.com/user-attachments/assets/1c617ec2-f7c5-4256-9734-0f1da72ea5f5" />

### Binary

BEFORE

<img width="926" height="378" alt="Screenshot 2026-04-13 at 15 00 05" src="https://github.com/user-attachments/assets/710c1c54-5a7b-4925-9043-ecddf02c4fb9" />

RULE

Note lowercase "fs"

<img width="1005" height="231" alt="Screenshot 2026-04-13 at 14 59 32" src="https://github.com/user-attachments/assets/ddea96bc-d355-4892-a447-71290c71d189" />

AFTER

<img width="892" height="363" alt="Screenshot 2026-04-13 at 14 59 44" src="https://github.com/user-attachments/assets/edb567b8-f109-4cd8-9d61-ae1882328eba" />

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
