### PR TITLE
Show full sign in user agent

### DIFF
--- a/app/views/admin/users/_sign_in_table.html.erb
+++ b/app/views/admin/users/_sign_in_table.html.erb
@@ -67,9 +67,7 @@
 
                     <td>
                       <% if sign_in.user_agent %>
-                        <span title="<%= sign_in.user_agent %>">
-                          <%= truncate(sign_in.user_agent, length: 50) %>
-                        </span>
+                        <small><tt><%= sign_in.user_agent %></tt></small>
                       <% else %>
                         <em>Not recorded</em>
                       <% end %>


### PR DESCRIPTION
The truncation is annoying as often the more unique part of the string is towards the end.

Make it a bit smaller given the increased length.

<img width="926" height="115" alt="Screenshot 2026-04-10 at 12 04 32" src="https://github.com/user-attachments/assets/b2799512-8c1f-4e23-bb8f-d6c7579d8a14" />


Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
