### PR TITLE
Allow AlaveteliTextMasker masks to be customised

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow customisation of text masks (Gareth Rees)
 * Strip ActionText attachments from Project rich text fields (Graeme Porteous)
 * Validate profile photo content type before ImageMagick processing
   (Graeme Porteous)
@@ -60,6 +61,28 @@
 
     Rails.application.config.after_initialize do
       AtiNetworkController.showcase_enabled = false
+    end
+
+* _Optional:_ Text masks can now be customised to allow fine tuning of the
+  default redactions that Alaveteli applies. Here are some examples of how to
+  add, remove or change masks using the new API.
+
+    # THEME/lib/model_patches.rb
+    Rails.configuration.to_prepare do
+      # Add a new mask specific to your site
+      AlaveteliTextMasker.add_mask(:reference_number, pattern: /\d{9} replacement: '[reference number]')
+
+      # Remove a default mask (not recommended!)
+      AlaveteliTextMasker.remove_mask(:email_address)
+
+      # Change a default mask
+      AlaveteliTextMasker.replace_mask(:mobile_number, pattern: /\d+/, replacement: '[cell number]')
+
+      # Change only a default mask's regexp pattern
+      AlaveteliTextMasker.replace_mask(:mobile_number, pattern: /\d+/)
+
+      # Change only a default mask's replacement
+      AlaveteliTextMasker.replace_mask(:mobile_number, replacement: '[cell number]')
     end
 
 ### Changed Templates

--- a/lib/alaveteli_text_masker.rb
+++ b/lib/alaveteli_text_masker.rb
@@ -47,6 +47,35 @@ module AlaveteliTextMasker
     end
   end
 
+  def masks
+    @masks ||= default_text_masks
+  end
+
+  def add_mask(name, pattern:, replacement:)
+    name = name.to_sym
+    raise ArgumentError, "Mask already exists with name :#{name}" if
+      masks.key?(name)
+
+    masks[name] = { to_replace: pattern, replacement: replacement }
+  end
+
+  def remove_mask(name)
+    raise ArgumentError, "No mask found with name :#{name}" unless
+      masks.delete(name)
+  end
+
+  def replace_mask(name, pattern: nil, replacement: nil)
+    raise ArgumentError, "No mask found with name :#{name}" unless
+      masks.key?(name)
+
+    masks[name][:to_replace] = pattern if pattern
+    masks[name][:replacement] = replacement if replacement
+  end
+
+  def reset_masks!
+    @masks = nil
+  end
+
   private
 
   def uncompress_pdf(text)
@@ -153,23 +182,23 @@ module AlaveteliTextMasker
     text
   end
 
-  # Remove any email addresses, login links and mobile phone numbers
   def default_text_masks
-    [{ to_replace: MySociety::Validate.email_find_regexp,
-       replacement: "[#{_("email address")}]" },
-     { to_replace: /(Mobile|Mob)([\s\/]*(Fax|Tel))*\s*:?[\s\d]*\d/,
-       replacement: "[#{_("mobile number")}]" },
-     { to_replace: /https?:\/\/#{AlaveteliConfiguration.domain}\/c\/[^\s]+/,
-       replacement: "[#{_("{{site_name}} login link",
-                          site_name: site_name)}]" }]
+    {
+      email_address: { to_replace: MySociety::Validate.email_find_regexp,
+                       replacement: "[#{_('email address')}]" },
+      mobile_number: { to_replace: /(Mobile|Mob)([\s\/]*(Fax|Tel))*\s*:?[\s\d]*\d/,
+                       replacement: "[#{_('mobile number')}]" },
+      login_link:    { to_replace: /https?:\/\/#{AlaveteliConfiguration.domain}\/c\/[^\s]+/,
+                       replacement: "[#{_('{{site_name}} login link',
+                                          site_name: site_name)}]" }
+    }.with_indifferent_access.deep_symbolize_keys
   end
 
   def apply_text_masks(text, options = {})
-    masks = options[:masks] || []
-    masks += default_text_masks
+    all_masks = (options[:masks] || []) + masks.values
     censor_rules = options[:censor_rules] || []
 
-    text = masks.inject(text) do |memo, mask|
+    text = all_masks.inject(text) do |memo, mask|
       memo.gsub(mask[:to_replace], mask[:replacement])
     end
 

--- a/lib/alaveteli_text_masker.rb
+++ b/lib/alaveteli_text_masker.rb
@@ -5,6 +5,22 @@ module AlaveteliTextMasker
   include ConfigHelper
 
   extend self
+
+  DEFAULT_TEXT_MASKS = {
+    email_address: {
+      to_replace: MySociety::Validate.email_find_regexp,
+      replacement: "[#{_('email address')}]"
+    },
+    mobile_number: {
+      to_replace: /(Mobile|Mob)([\s\/]*(Fax|Tel))*\s*:?[\s\d]*\d/,
+      replacement: "[#{_('mobile number')}]"
+    },
+    login_link: {
+      to_replace: /https?:\/\/#{AlaveteliConfiguration.domain}\/c\/[^\s]+/,
+      replacement: "[#{_('{{site_name}} login link', site_name: site_name)}]"
+    }
+  }.with_indifferent_access.deep_symbolize_keys.freeze
+
   DoNotBinaryMask = [ 'image/tiff',
                       'image/gif',
                       'image/jpeg',
@@ -48,7 +64,7 @@ module AlaveteliTextMasker
   end
 
   def masks
-    @masks ||= default_text_masks
+    @masks ||= DEFAULT_TEXT_MASKS.dup
   end
 
   def add_mask(name, pattern:, replacement:)
@@ -180,18 +196,6 @@ module AlaveteliTextMasker
     raise "internal error in apply_binary_masks" if text.bytesize != orig_size
 
     text
-  end
-
-  def default_text_masks
-    {
-      email_address: { to_replace: MySociety::Validate.email_find_regexp,
-                       replacement: "[#{_('email address')}]" },
-      mobile_number: { to_replace: /(Mobile|Mob)([\s\/]*(Fax|Tel))*\s*:?[\s\d]*\d/,
-                       replacement: "[#{_('mobile number')}]" },
-      login_link:    { to_replace: /https?:\/\/#{AlaveteliConfiguration.domain}\/c\/[^\s]+/,
-                       replacement: "[#{_('{{site_name}} login link',
-                                          site_name: site_name)}]" }
-    }.with_indifferent_access.deep_symbolize_keys
   end
 
   def apply_text_masks(text, options = {})

--- a/spec/lib/alaveteli_text_masker_spec.rb
+++ b/spec/lib/alaveteli_text_masker_spec.rb
@@ -212,4 +212,82 @@ RSpec.describe AlaveteliTextMasker do
       end
     end
   end
+
+  describe '.masks' do
+    after { described_class.reset_masks! }
+
+    it 'returns the three built-in masks' do
+      expect(described_class.masks.keys).
+        to eq(%i[email_address mobile_number login_link])
+    end
+  end
+
+  describe '.add_mask' do
+    after { described_class.reset_masks! }
+
+    it 'appends a new mask' do
+      described_class.add_mask(:reference, pattern: /\d/, replacement: '[ref]')
+      expect(described_class.masks.keys.last).to eq(:reference)
+    end
+
+    it 'raises ArgumentError when a mask with the same name already exists' do
+      expect {
+        described_class.
+          add_mask(:email_address, pattern: /.@./, replacement: '[x]')
+      }.to raise_error(ArgumentError, /email_address/)
+    end
+  end
+
+  describe '.remove_mask' do
+    after { described_class.reset_masks! }
+
+    it 'removes a built-in mask so it is no longer applied' do
+      described_class.remove_mask(:mobile_number)
+      expect(described_class.masks.keys).to eq(%i[email_address login_link])
+    end
+
+    it 'raises ArgumentError when the name does not exist' do
+      expect { described_class.remove_mask(:nonexistent) }.
+        to raise_error(ArgumentError, /nonexistent/)
+    end
+  end
+
+  describe '.replace_mask' do
+    after { described_class.reset_masks! }
+
+    it 'replaces the pattern but keeps the existing replacement' do
+      original_replacement = described_class.masks[:mobile_number][:replacement]
+
+      described_class.replace_mask(:mobile_number, pattern: /Cell \d+/)
+
+      mobile_number = described_class.masks[:mobile_number]
+      expect(mobile_number[:to_replace]).to eq(/Cell \d+/)
+      expect(mobile_number[:replacement]).to eq(original_replacement)
+    end
+
+    it 'replaces the replacement but keeps the existing pattern' do
+      original_pattern = described_class.masks[:mobile_number][:to_replace]
+
+      described_class.replace_mask(:mobile_number, replacement: '[phone]')
+
+      mobile_number = described_class.masks[:mobile_number]
+      expect(mobile_number[:to_replace]).to eq(original_pattern)
+      expect(mobile_number[:replacement]).to eq('[phone]')
+    end
+
+    it 'replaces both pattern and replacement' do
+      described_class.
+        replace_mask(:mobile_number, pattern: /Cell \d+/, replacement: '[cell]')
+
+      mobile_number = described_class.masks[:mobile_number]
+
+      expect(mobile_number[:to_replace]).to eq(/Cell \d+/)
+      expect(mobile_number[:replacement]).to eq('[cell]')
+    end
+
+    it 'raises ArgumentError when the name does not exist' do
+      expect { described_class.replace_mask(:nonexistent, pattern: /x/) }.
+        to raise_error(ArgumentError, /nonexistent/)
+    end
+  end
 end


### PR DESCRIPTION
Part of https://github.com/mysociety/alaveteli/issues/8822.

Expose an API to add to, remove from or modify the default text masks to
better suit site specific contexts.
