### PR TITLE
Move `CensorRule` request expiry to callback

### DIFF
--- a/app/controllers/admin_censor_rule_controller.rb
+++ b/app/controllers/admin_censor_rule_controller.rb
@@ -19,7 +19,7 @@ class AdminCensorRuleController < AdminController
   def create
     if @censor_rule.save
       flash[:notice] = 'Censor rule was successfully created.'
-      expire_requests_and_redirect
+      redirect_to_subject
     else
       render action: 'new'
     end
@@ -31,7 +31,7 @@ class AdminCensorRuleController < AdminController
   def update
     if @censor_rule.update(censor_rule_params)
       flash[:notice] = 'Censor rule was successfully updated.'
-      expire_requests_and_redirect
+      redirect_to_subject
     else
       render action: 'edit'
     end
@@ -44,7 +44,7 @@ class AdminCensorRuleController < AdminController
 
     flash[:notice] = "Censor rule was successfully destroyed."
 
-    expire_requests_and_redirect
+    redirect_to_subject
   end
 
   private
@@ -93,9 +93,7 @@ class AdminCensorRuleController < AdminController
     end
   end
 
-  def expire_requests_and_redirect
-    @censor_rule.expire_requests
-
+  def redirect_to_subject
     if @censor_rule.info_request
       redirect_to admin_request_url(@censor_rule.info_request)
     elsif @censor_rule.user

--- a/app/jobs/info_request/expire_job.rb
+++ b/app/jobs/info_request/expire_job.rb
@@ -3,11 +3,11 @@
 # a collection of requests through an model associations.
 #
 # Examples:
-#   InfoRequestExpireJob.perform(InfoRequest.first)
-#   InfoRequestExpireJob.perform(InfoRequest, :all)
-#   InfoRequestExpireJob.perform(PublicBody.first, :info_requests)
+#   InfoRequest::ExpireJob.perform(InfoRequest.first)
+#   InfoRequest::ExpireJob.perform(InfoRequest, :all)
+#   InfoRequest::ExpireJob.perform(PublicBody.first, :info_requests)
 #
-class InfoRequestExpireJob < ApplicationJob
+class InfoRequest::ExpireJob < ApplicationJob
   queue_as :xapian
 
   def perform(object, method = nil)

--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -77,14 +77,14 @@ class CensorRule < ApplicationRecord
 
   def expire_requests
     if info_request
-      InfoRequestExpireJob.perform_later(info_request)
+      InfoRequest::ExpireJob.perform_later(info_request)
       NotifyCacheJob.perform_later(info_request)
     elsif user
-      InfoRequestExpireJob.perform_later(user, :info_requests)
+      InfoRequest::ExpireJob.perform_later(user, :info_requests)
     elsif public_body
-      InfoRequestExpireJob.perform_later(public_body, :info_requests)
+      InfoRequest::ExpireJob.perform_later(public_body, :info_requests)
     else # global rule
-      InfoRequestExpireJob.perform_later(InfoRequest, :all)
+      InfoRequest::ExpireJob.perform_later(InfoRequest, :all)
     end
   end
 

--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -57,6 +57,8 @@ class CensorRule < ApplicationRecord
                  instance_writer: false,
                  default: DEFAULT_CANNED_REPLACEMENTS.dup
 
+  after_commit :expire_requests
+
   def apply_to_text(text_to_censor)
     return nil if text_to_censor.nil?
 

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -505,7 +505,7 @@ class PublicBody < ApplicationRecord
   end
 
   def expire_requests
-    InfoRequestExpireJob.perform_later(self, :info_requests)
+    InfoRequest::ExpireJob.perform_later(self, :info_requests)
   end
 
   def self.where_clause_for_stats(minimum_requests, total_column)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -340,7 +340,7 @@ class User < ApplicationRecord
   end
 
   def expire_requests
-    InfoRequestExpireJob.perform_later(self, :info_requests)
+    InfoRequest::ExpireJob.perform_later(self, :info_requests)
   end
 
   def expire_comments

--- a/spec/controllers/admin_censor_rule_controller_spec.rb
+++ b/spec/controllers/admin_censor_rule_controller_spec.rb
@@ -202,16 +202,6 @@ RSpec.describe AdminCensorRuleController do
       end
 
       context 'successfully saving the censor rule' do
-        it 'calls expire_requests on the new censor_rule' do
-          censor_rule = FactoryBot.build(:global_censor_rule)
-          allow(CensorRule).to receive(:new) { censor_rule }
-          allow(censor_rule).to receive(:expire_requests)
-
-          create_censor_rule
-
-          expect(censor_rule).to have_received(:expire_requests)
-        end
-
         it 'redirects to the censor rules index' do
           create_censor_rule
           expect(response).to redirect_to(
@@ -298,23 +288,6 @@ RSpec.describe AdminCensorRuleController do
           expect(flash[:notice]).to eq(msg)
         end
 
-        it 'calls expire_requests on the new censor_rule' do
-          allow(InfoRequest).to receive(:find).and_return(info_request)
-          censor_rule_spy = FactoryBot.build(:info_request_censor_rule,
-                                             info_request: info_request)
-          allow(info_request.censor_rules).to receive(:build).
-            and_return(censor_rule_spy)
-
-          allow(censor_rule_spy).to receive(:expire_requests)
-
-          post :create, params: {
-                          censor_rule: censor_rule_params,
-                          request_id: info_request.id
-                        }
-
-          expect(censor_rule_spy).to have_received(:expire_requests)
-        end
-
         it 'redirects to the associated info request' do
           post :create, params: {
                           censor_rule: censor_rule_params,
@@ -387,18 +360,6 @@ RSpec.describe AdminCensorRuleController do
       end
 
       context 'successfully saving the censor rule' do
-        it 'calls expire_requests on the new censor_rule' do
-          allow(User).to receive(:find) { user }
-          censor_rule = FactoryBot.build(:user_censor_rule,
-                                         user: user)
-          allow(user.censor_rules).to receive(:build) { censor_rule }
-          allow(censor_rule).to receive(:expire_requests)
-
-          create_censor_rule
-
-          expect(censor_rule).to have_received(:expire_requests)
-        end
-
         it 'redirects to the associated info request' do
           create_censor_rule
           expect(response).to redirect_to(
@@ -480,21 +441,6 @@ RSpec.describe AdminCensorRuleController do
                         }
           msg = 'Censor rule was successfully created.'
           expect(flash[:notice]).to eq(msg)
-        end
-
-        it 'calls expire_requests on the new censor_rule' do
-          allow(PublicBody).to receive(:find) { public_body }
-          censor_rule = FactoryBot.build(:public_body_censor_rule,
-                                         public_body: public_body)
-          allow(public_body.censor_rules).to receive(:build) { censor_rule }
-          allow(censor_rule).to receive(:expire_requests)
-
-          post :create, params: {
-                          censor_rule: censor_rule_params,
-                          body_id: public_body.id
-                        }
-
-          expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated public body' do
@@ -651,17 +597,6 @@ RSpec.describe AdminCensorRuleController do
           expect(flash[:notice]).to eq(msg)
         end
 
-        it 'calls expire_requests on the censor_rule' do
-          allow(CensorRule).to receive(:find) { censor_rule }
-          allow(censor_rule).to receive(:expire_requests)
-          put :update, params: {
-                         id: censor_rule.id,
-                         censor_rule: { text: 'different text' }
-                       }
-
-          expect(censor_rule).to have_received(:expire_requests)
-        end
-
         it 'redirects to the censor rule index' do
           put :update, params: {
                          id: censor_rule.id,
@@ -735,17 +670,6 @@ RSpec.describe AdminCensorRuleController do
                        }
           msg = 'Censor rule was successfully updated.'
           expect(flash[:notice]).to eq(msg)
-        end
-
-        it 'calls expire_requests on the censor_rule' do
-          allow(CensorRule).to receive(:find) { censor_rule }
-          allow(censor_rule).to receive(:expire_requests)
-          put :update, params: {
-                         id: censor_rule.id,
-                         censor_rule: { text: 'different text' }
-                       }
-
-          expect(censor_rule).to have_received(:expire_requests)
         end
 
         it 'redirects to the associated info request' do
@@ -825,17 +749,6 @@ RSpec.describe AdminCensorRuleController do
           expect(flash[:notice]).to eq(msg)
         end
 
-        it 'calls expire_requests on the censor_rule' do
-          allow(CensorRule).to receive(:find) { censor_rule }
-          allow(censor_rule).to receive(:expire_requests)
-          put :update, params: {
-                         id: censor_rule.id,
-                         censor_rule: { text: 'different text' }
-                       }
-
-          expect(censor_rule).to have_received(:expire_requests)
-        end
-
         it 'redirects to the associated info request' do
           put :update, params: {
                          id: censor_rule.id,
@@ -913,17 +826,6 @@ RSpec.describe AdminCensorRuleController do
           expect(flash[:notice]).to eq(msg)
         end
 
-        it 'calls expire_requests on the censor_rule' do
-          allow(CensorRule).to receive(:find) { censor_rule }
-          allow(censor_rule).to receive(:expire_requests)
-          put :update, params: {
-                         id: censor_rule.id,
-                         censor_rule: { text: 'different text' }
-                       }
-
-          expect(censor_rule).to have_received(:expire_requests)
-        end
-
         it 'redirects to the associated public body' do
           put :update, params: {
                          id: censor_rule.id,
@@ -997,14 +899,6 @@ RSpec.describe AdminCensorRuleController do
         expect(flash[:notice]).to eq(msg)
       end
 
-      it 'calls expire_requests on the censor rule' do
-        expect(CensorRule).to receive(:find) { censor_rule }
-        allow(censor_rule).to receive(:expire_requests)
-        delete :destroy, params: { id: censor_rule.id }
-
-        expect(censor_rule).to have_received(:expire_requests)
-      end
-
       it 'redirects to the associated info request' do
         delete :destroy, params: { id: censor_rule.id }
         expect(response).
@@ -1026,14 +920,6 @@ RSpec.describe AdminCensorRuleController do
         expect(flash[:notice]).to eq(msg)
       end
 
-      it 'calls expire_requests on the censor rule' do
-        expect(CensorRule).to receive(:find) { censor_rule }
-        allow(censor_rule).to receive(:expire_requests)
-        delete :destroy, params: { id: censor_rule.id }
-
-        expect(censor_rule).to have_received(:expire_requests)
-      end
-
       it 'redirects to the associated info request' do
         delete :destroy, params: { id: censor_rule.id }
         expect(response).to redirect_to(admin_user_path(censor_rule.user))
@@ -1052,14 +938,6 @@ RSpec.describe AdminCensorRuleController do
         delete :destroy, params: { id: censor_rule.id }
         msg = 'Censor rule was successfully destroyed.'
         expect(flash[:notice]).to eq(msg)
-      end
-
-      it 'calls expire_requests on the censor rule' do
-        expect(CensorRule).to receive(:find) { censor_rule }
-        allow(censor_rule).to receive(:expire_requests)
-        delete :destroy, params: { id: censor_rule.id }
-
-        expect(censor_rule).to have_received(:expire_requests)
       end
 
       it 'redirects to the associated public body' do

--- a/spec/jobs/info_request_expire_job_spec.rb
+++ b/spec/jobs/info_request_expire_job_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe InfoRequestExpireJob, type: :job do
+RSpec.describe InfoRequest::ExpireJob, type: :job do
   let(:args) { [] }
   subject(:perform) { described_class.new.perform(*args) }
 

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -18,6 +18,28 @@
 require 'spec_helper'
 
 RSpec.describe CensorRule do
+  describe 'after_commit callbacks' do
+    it 'expires requests after create' do
+      rule = FactoryBot.create(:global_censor_rule)
+      expect(rule).to receive(:expire_requests)
+      rule.run_callbacks(:commit)
+    end
+
+    it 'expires requests after update' do
+      rule = FactoryBot.create(:global_censor_rule)
+      rule.update!(text: 'updated text')
+      expect(rule).to receive(:expire_requests)
+      rule.run_callbacks(:commit)
+    end
+
+    it 'expires requests after destroy' do
+      rule = FactoryBot.create(:global_censor_rule)
+      rule.destroy!
+      expect(rule).to receive(:expire_requests)
+      rule.run_callbacks(:commit)
+    end
+  end
+
   describe '#apply_to_text' do
     it 'applies the rule to the text' do
       rule = FactoryBot.build(:censor_rule, text: 'secret')

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe CensorRule do
       request = FactoryBot.create(:info_request)
       rule = FactoryBot.create(:info_request_censor_rule,
                                info_request: request)
-      expect(InfoRequestExpireJob).to receive(:perform_later).with(request)
+      expect(InfoRequest::ExpireJob).to receive(:perform_later).with(request)
       expect(NotifyCacheJob).to receive(:perform_later).with(request)
       rule.expire_requests
     end
@@ -165,7 +165,7 @@ RSpec.describe CensorRule do
     it 'create expire job for the user if it is a user rule' do
       user = FactoryBot.create(:user)
       rule = FactoryBot.create(:user_censor_rule, user: user)
-      expect(InfoRequestExpireJob).to receive(:perform_later).
+      expect(InfoRequest::ExpireJob).to receive(:perform_later).
         with(user, :info_requests)
       rule.expire_requests
     end
@@ -173,14 +173,14 @@ RSpec.describe CensorRule do
     it 'create expire job for the public body if it is a public body rule' do
       body = FactoryBot.create(:public_body)
       rule = FactoryBot.create(:public_body_censor_rule, public_body: body)
-      expect(InfoRequestExpireJob).to receive(:perform_later).
+      expect(InfoRequest::ExpireJob).to receive(:perform_later).
         with(body, :info_requests)
       rule.expire_requests
     end
 
     it 'create expire job for all requests if it is a global rule' do
       rule = FactoryBot.build(:global_censor_rule)
-      expect(InfoRequestExpireJob).to receive(:perform_later).
+      expect(InfoRequest::ExpireJob).to receive(:perform_later).
         with(InfoRequest, :all)
       rule.expire_requests
     end

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -175,36 +175,53 @@ RSpec.describe CensorRule do
   end
 
   describe '#expire_requests' do
-    it 'create expire job for the request if it is a request rule' do
-      request = FactoryBot.create(:info_request)
-      rule = FactoryBot.create(:info_request_censor_rule,
-                               info_request: request)
-      expect(InfoRequest::ExpireJob).to receive(:perform_later).with(request)
-      expect(NotifyCacheJob).to receive(:perform_later).with(request)
-      rule.expire_requests
+    subject { rule.expire_requests }
+
+    let(:job) { InfoRequest::ExpireJob }
+
+    context 'with a request rule' do
+      let(:request) { FactoryBot.create(:info_request) }
+      let!(:rule) { FactoryBot.create(:censor_rule, info_request: request) }
+
+      it 'expires the requests' do
+        expect { subject }.to have_enqueued_job(job).with(request)
+      end
+
+      it 'notifies the cache when configured' do
+        allow(AlaveteliConfiguration).to receive(:varnish_hosts).and_return('x')
+        expect { subject }.to have_enqueued_job(NotifyCacheJob).with(request)
+      end
+
+      it 'does not notify the cache when not configured' do
+        allow(AlaveteliConfiguration).to receive(:varnish_hosts).and_return('')
+        expect { subject }.not_to have_enqueued_job(NotifyCacheJob).with(request)
+      end
     end
 
-    it 'create expire job for the user if it is a user rule' do
-      user = FactoryBot.create(:user)
-      rule = FactoryBot.create(:user_censor_rule, user: user)
-      expect(InfoRequest::ExpireJob).to receive(:perform_later).
-        with(user, :info_requests)
-      rule.expire_requests
+    context 'with a user rule' do
+      let(:user) { FactoryBot.create(:user) }
+      let!(:rule) { FactoryBot.create(:censor_rule, user: user) }
+
+      it 'expires the requests' do      
+        expect { subject }.to have_enqueued_job(job).with(user, :info_requests)
+      end
     end
 
-    it 'create expire job for the public body if it is a public body rule' do
-      body = FactoryBot.create(:public_body)
-      rule = FactoryBot.create(:public_body_censor_rule, public_body: body)
-      expect(InfoRequest::ExpireJob).to receive(:perform_later).
-        with(body, :info_requests)
-      rule.expire_requests
+    context 'with a public body rule' do
+      let(:body) { FactoryBot.create(:public_body) }
+      let!(:rule) { FactoryBot.create(:censor_rule, public_body: body) }
+
+      it 'expires the requests' do
+        expect { subject }.to have_enqueued_job(job).with(body, :info_requests)
+      end
     end
 
-    it 'create expire job for all requests if it is a global rule' do
-      rule = FactoryBot.build(:global_censor_rule)
-      expect(InfoRequest::ExpireJob).to receive(:perform_later).
-        with(InfoRequest, :all)
-      rule.expire_requests
+    context 'with a global rule' do
+      let!(:rule) { FactoryBot.create(:global_censor_rule) }
+
+      it 'expires the requests' do
+        expect { subject }.to have_enqueued_job(job).with(InfoRequest, :all)
+      end
     end
   end
 

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -767,7 +767,7 @@ RSpec.describe PublicBody do
   describe '#expire_requests' do
     it 'create expire job for the public body' do
       public_body = FactoryBot.build(:public_body)
-      expect(InfoRequestExpireJob).to receive(:perform_later).
+      expect(InfoRequest::ExpireJob).to receive(:perform_later).
         with(public_body, :info_requests)
       public_body.expire_requests
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -899,7 +899,7 @@ RSpec.describe User do
   describe '#expire_requests' do
     it 'create expire job for the user' do
       user = FactoryBot.build(:user)
-      expect(InfoRequestExpireJob).to receive(:perform_later).
+      expect(InfoRequest::ExpireJob).to receive(:perform_later).
         with(user, :info_requests)
       user.expire_requests
     end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/8808
https://github.com/mysociety/alaveteli/pull/9138

## What does this do? / Why was this needed?

Extract CensorRule request expiry to callback 

Currently, callers that create or modify censor rules must remember to
call `expire_requests` themselves. The `AdminCensorRuleController` does
this explicitly via `expire_requests_and_redirect`. `User#anonymise!`
incorrectly omits this call.

Expiry should be the CensorRule's own responsibility. Adding lifecycle
callbacks ensures requests are always expired when a rule changes,
regardless of where in the codebase the rule is created, updated, or
destroyed.

## Implementation notes

Would have been nice to extract `expire_requests` to a concern since its very similar for all models that define it. Annoyingly we can't quite get there easily for `CensorRule` due to the global rule case. Something to review in future.

[skip changelog]
