### PR TITLE
Correctly namespace FoiAttachment::MaskJob

### DIFF
--- a/app/jobs/foi_attachment/mask_job.rb
+++ b/app/jobs/foi_attachment/mask_job.rb
@@ -3,9 +3,9 @@
 # be stored as FoiAttachment#file ActiveStorage association.
 #
 # Example:
-#   FoiAttachmentMaskJob.perform(FoiAttachment.first)
+#   FoiAttachment::MaskJob.perform(FoiAttachment.first)
 #
-class FoiAttachmentMaskJob < ApplicationJob
+class FoiAttachment::MaskJob < ApplicationJob
   queue_as :default
   unique :until_and_while_executing, on_conflict: :log
 

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -137,8 +137,8 @@ class FoiAttachment < ApplicationRecord
     end
 
     if persisted?
-      FoiAttachmentMaskJob.unlock!(self)
-      FoiAttachmentMaskJob.perform_now(self)
+      FoiAttachment::MaskJob.unlock!(self)
+      FoiAttachment::MaskJob.perform_now(self)
       return body unless destroyed?
     end
 

--- a/app/models/foi_attachment/maskable.rb
+++ b/app/models/foi_attachment/maskable.rb
@@ -25,7 +25,7 @@ module FoiAttachment::Maskable
   end
 
   def mask_later
-    FoiAttachmentMaskJob.perform_later(self)
+    FoiAttachment::MaskJob.perform_later(self)
   end
 
   private

--- a/lib/tasks/storage/storage.rb
+++ b/lib/tasks/storage/storage.rb
@@ -55,7 +55,7 @@ class Storage
         attachment = FoiAttachment.joins(:file_blob).
           find_by(active_storage_blobs: { id: blob })
         # Running the attachment masking will also mirror the file
-        FoiAttachmentMaskJob.set(queue: :low).perform_later(attachment)
+        FoiAttachment::MaskJob.set(queue: :low).perform_later(attachment)
       end
 
       print "#{prefix}: Mirrored #{index + 1}/#{count}"

--- a/spec/controllers/admin/foi_attachments/masks_controller_spec.rb
+++ b/spec/controllers/admin/foi_attachments/masks_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::FoiAttachments::MasksController do
 
       it 'queues the masking job' do
         expect { post :create, params: params }.
-          to have_enqueued_job(FoiAttachmentMaskJob).with(attachment)
+          to have_enqueued_job(FoiAttachment::MaskJob).with(attachment)
       end
 
       it 'sets a success notice' do

--- a/spec/jobs/foi_attachment/mask_job_spec.rb
+++ b/spec/jobs/foi_attachment/mask_job_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FoiAttachmentMaskJob, type: :job do
+RSpec.describe FoiAttachment::MaskJob, type: :job do
   let(:info_request) { FactoryBot.create(:info_request_with_html_attachment) }
   let(:incoming_message) { info_request.incoming_messages.first }
   let(:attachment) { incoming_message.foi_attachments.last }

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -244,8 +244,8 @@ RSpec.describe FoiAttachment do
           to receive(:download).and_raise(ActiveStorage::FileNotFoundError)
       end
 
-      it 'does not run FoiAttachmentMaskJob and raise error' do
-        expect(FoiAttachmentMaskJob).to_not receive(:perform_now)
+      it 'does not run FoiAttachment::MaskJob and raise error' do
+        expect(FoiAttachment::MaskJob).to_not receive(:perform_now)
         expect { foi_attachment.body }.
           to raise_error(ActiveStorage::FileNotFoundError)
       end
@@ -272,8 +272,8 @@ RSpec.describe FoiAttachment do
           to receive(:download).and_raise(ActiveStorage::FileNotFoundError)
       end
 
-      it 'calls the FoiAttachmentMaskJob now and return the masked body' do
-        expect(FoiAttachmentMaskJob).to receive(:perform_now).
+      it 'calls the FoiAttachment::MaskJob now and return the masked body' do
+        expect(FoiAttachment::MaskJob).to receive(:perform_now).
           with(foi_attachment).
           and_invoke(-> (_) {
             # mock the job
@@ -292,8 +292,8 @@ RSpec.describe FoiAttachment do
       end
       let(:foi_attachment) { incoming_message.foi_attachments.last }
 
-      it 'calls the FoiAttachmentMaskJob now and return the masked body' do
-        expect(FoiAttachmentMaskJob).to receive(:perform_now).
+      it 'calls the FoiAttachment::MaskJob now and return the masked body' do
+        expect(FoiAttachment::MaskJob).to receive(:perform_now).
           with(foi_attachment).
           and_invoke(-> (_) {
             # mock the job
@@ -315,7 +315,7 @@ RSpec.describe FoiAttachment do
       before do
         foi_attachment.update(hexdigest: '123')
 
-        expect(FoiAttachmentMaskJob).to receive(:perform_now).
+        expect(FoiAttachment::MaskJob).to receive(:perform_now).
           with(foi_attachment).
           and_invoke(-> (_) {
             # mock the job
@@ -905,7 +905,7 @@ RSpec.describe FoiAttachment do
 
     it 'enqueues the job' do
       expect { subject }.
-        to have_enqueued_job(FoiAttachmentMaskJob).with(foi_attachment)
+        to have_enqueued_job(FoiAttachment::MaskJob).with(foi_attachment)
     end
   end
 
@@ -1578,7 +1578,7 @@ RSpec.describe FoiAttachment do
       end
 
       it 'restores the original body' do
-        # ensure FoiAttachmentMaskJob isn't run when calling #body - it'll break
+        # ensure FoiAttachment::MaskJob isn't run when calling #body - it'll break
         # due to there being no associated incoming_message/info_request
         allow(foi_attachment).to receive(:masked?).and_return(true)
 
@@ -2116,7 +2116,7 @@ RSpec.describe FoiAttachment do
       end
 
       it 'resets body to original content' do
-        # ensure FoiAttachmentMaskJob isn't run when calling #body - it'll break
+        # ensure FoiAttachment::MaskJob isn't run when calling #body - it'll break
         # due to there being no associated incoming_message/info_request
         allow(foi_attachment).to receive(:masked?).and_return(true)
 


### PR DESCRIPTION
Correctly namespace FoiAttachment::MaskJob

https://github.com/mysociety/alaveteli/issues/8808
https://github.com/mysociety/alaveteli/pull/9138

[skip changelog]
