### PR TITLE
[#8821] Regexp `User#anonymise!` rule

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -49,6 +49,7 @@ class User < ApplicationRecord
   include AlaveteliFeatures::Helpers
   include AlaveteliPro::PhaseCounts
 
+  include User::Anonymisable
   include User::Authentication
   include User::InternalAdmin
   include User::LimitedProfile
@@ -464,18 +465,6 @@ class User < ApplicationRecord
         about_me: '',
         password: MySociety::Util.generate_token
       )
-    end
-  end
-
-  def anonymise!
-    return if info_requests.none? && comments.none?
-
-    current_name = read_attribute(:name)
-    [current_name, *previous_names].each do |name|
-      censor_rules.create!(text: name,
-                           replacement: _('[Name Removed]'),
-                           last_edit_editor: 'User#anonymise!',
-                           last_edit_comment: 'User#anonymise!')
     end
   end
 

--- a/app/models/user/anonymisable.rb
+++ b/app/models/user/anonymisable.rb
@@ -6,8 +6,9 @@ module User::Anonymisable
 
     current_name = read_attribute(:name)
     [current_name, *previous_names].each do |name|
-      censor_rules.create!(text: name,
+      censor_rules.create!(text: NamePattern.new(name).to_censor_rule_text,
                            replacement: _('[Name Removed]'),
+                           regexp: true,
                            case_sensitive: false,
                            last_edit_editor: 'User#anonymise!',
                            last_edit_comment: 'User#anonymise!')

--- a/app/models/user/anonymisable.rb
+++ b/app/models/user/anonymisable.rb
@@ -1,0 +1,15 @@
+module User::Anonymisable
+  extend ActiveSupport::Concern
+
+  def anonymise!
+    return if info_requests.none? && comments.none?
+
+    current_name = read_attribute(:name)
+    [current_name, *previous_names].each do |name|
+      censor_rules.create!(text: name,
+                           replacement: _('[Name Removed]'),
+                           last_edit_editor: 'User#anonymise!',
+                           last_edit_comment: 'User#anonymise!')
+    end
+  end
+end

--- a/app/models/user/anonymisable.rb
+++ b/app/models/user/anonymisable.rb
@@ -8,6 +8,7 @@ module User::Anonymisable
     [current_name, *previous_names].each do |name|
       censor_rules.create!(text: name,
                            replacement: _('[Name Removed]'),
+                           case_sensitive: false,
                            last_edit_editor: 'User#anonymise!',
                            last_edit_comment: 'User#anonymise!')
     end

--- a/app/models/user/anonymisable/name_pattern.rb
+++ b/app/models/user/anonymisable/name_pattern.rb
@@ -1,0 +1,76 @@
+# Split a name into parts to construct a pattern suitable for a Regexp
+# CensorRule#text
+class User::Anonymisable::NamePattern
+  DEFAULT_HONORIFICS = 'Mr|Mrs|Miss|Ms|Mx'
+  DEFAULT_PATTERN = /
+    \b
+    (?:
+      (?:%{honorifics})\.? \s+ (?:%{firstname}\s+)? %{surname}
+      |
+      %{firstname} (?: \s+ %{surname} | \s+ %{last_initial}\.? )?
+      |
+      %{first_initial}\.? \s* %{surname}
+      |
+      %{surname} ,\s+ (?: %{firstname} | %{first_initial}\.? )
+    )
+    (?!\w)
+  /x
+
+  cattr_accessor :honorifics, default: DEFAULT_HONORIFICS
+  cattr_accessor :pattern, default: DEFAULT_PATTERN
+
+  def initialize(name)
+    @name = name
+  end
+
+  def to_censor_rule_text
+    format(pattern_string, substitutions)
+  end
+
+  # Hash with Regexp-escaped values
+  # honorifics is a Regexp fragment so left unescaped
+  def substitutions
+    to_h.
+      except(:honorifics).
+      transform_values { |v| Regexp.escape(v) }.
+      merge(honorifics: honorifics)
+  end
+
+  def to_h
+    { firstname: firstname, surname: surname,
+      first_initial: first_initial, last_initial: last_initial,
+      honorifics: honorifics }
+  end
+
+  def firstname
+    parts.first
+  end
+
+  def surname
+    parts.last
+  end
+
+  def first_initial
+    parts.first.mb_chars.first.to_s
+  end
+
+  def last_initial
+    parts.last.mb_chars.first.to_s
+  end
+
+  protected
+
+  attr_reader :name
+
+  private
+
+  def pattern_string
+    return pattern unless pattern.is_a?(Regexp)
+    return pattern.source unless (pattern.options & Regexp::EXTENDED).nonzero?
+    "(?x:#{pattern.source})"
+  end
+
+  def parts
+    @parts ||= @name.strip.split(/\s+/)
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Use Regexp rule when anonymising users to catch common name variants (Gareth
+  Rees)
 * Fix email change confirmation which wasn't bound to confirmed target address
   (Graeme Porteous)
 * Ensure only readable requests can be added to a Project (Gareth Rees)

--- a/spec/models/user/anonymisable/name_pattern_spec.rb
+++ b/spec/models/user/anonymisable/name_pattern_spec.rb
@@ -1,0 +1,206 @@
+require 'spec_helper'
+
+RSpec.describe User::Anonymisable::NamePattern do
+  describe '.honorifics' do
+    subject { described_class.honorifics }
+    it { is_expected.to eq('Mr|Mrs|Miss|Ms|Mx') }
+  end
+
+  describe '.honorifics=' do
+    before { described_class.honorifics = 'Dr' }
+    after { described_class.honorifics = described_class::DEFAULT_HONORIFICS }
+
+    subject { described_class.honorifics }
+
+    it { is_expected.to eq('Dr') }
+  end
+
+  describe '.pattern' do
+    subject { described_class.pattern }
+
+    it { is_expected.to eq(described_class::DEFAULT_PATTERN) }
+
+    describe 'default matches common name variants' do
+      common_name_variants = [
+        'Bob Smith',
+        'Bob',
+        'B Smith',
+        'B. Smith',
+        'Bob S',
+        'Smith, Bob',
+        'Smith, B',
+        'Mr Smith',
+        'Mr. Smith',
+        'Mr B Smith',
+        'Mr B. Smith',
+        'Mr. B Smith',
+        'Mr Bob Smith',
+        'Mr. Bob Smith',
+        'Mrs Smith',
+        'Mrs. Smith',
+        'Mrs B Smith',
+        'Mrs B. Smith',
+        'Mrs. B Smith',
+        'Mrs Bob Smith',
+        'Mrs. Bob Smith',
+        'Miss Smith',
+        'Miss. Smith',
+        'Miss B Smith',
+        'Miss B. Smith',
+        'Miss. B Smith',
+        'Miss Bob Smith',
+        'Miss. Bob Smith',
+        'Ms Smith',
+        'Ms. Smith',
+        'Ms B Smith',
+        'Ms B. Smith',
+        'Ms. B Smith',
+        'Ms Bob Smith',
+        'Ms. Bob Smith',
+        'Mx Smith',
+        'Mx. Smith',
+        'Mx B Smith',
+        'Mx B. Smith',
+        'Mx. B Smith',
+        'Mx Bob Smith',
+        'Mx. Bob Smith'
+      ]
+
+      common_name_variants.each do |variant|
+        context "with name '#{variant}'" do
+          subject { variant }
+
+          let(:regexp) do
+            Regexp.new(described_class.new('Bob Smith').to_censor_rule_text)
+          end
+
+          it { is_expected.to match(regexp) }
+        end
+      end
+    end
+  end
+
+  describe '.pattern=' do
+    before { described_class.pattern = 'x' }
+    after { described_class.pattern = described_class::DEFAULT_PATTERN }
+
+    subject { described_class.pattern }
+
+    it { is_expected.to eq('x') }
+  end
+
+  describe '#firstname' do
+    subject { described_class.new(name).firstname }
+
+    context 'with a simple name' do
+      let(:name) { 'John Smith' }
+      it { is_expected.to eq('John') }
+    end
+  end
+
+  describe '#first_initial' do
+    subject { described_class.new(name).first_initial }
+
+    context 'with a simple name' do
+      let(:name) { 'John Smith' }
+      it { is_expected.to eq('J') }
+    end
+
+    context 'with a multibyte first character' do
+      let(:name) { 'Ångström Svensson' }
+      it { is_expected.to eq('Å') }
+    end
+  end
+
+  describe '#surname' do
+    subject { described_class.new(name).surname }
+
+    context 'with a two-part name' do
+      let(:name) { 'John Smith' }
+      it { is_expected.to eq('Smith') }
+    end
+
+    context 'with more than two parts' do
+      let(:name) { 'Mary Jane Watson' }
+      it { is_expected.to eq('Watson') }
+    end
+
+    context 'with a single word' do
+      let(:name) { 'Madonna' }
+      it { is_expected.to eq('Madonna') }
+    end
+  end
+
+  describe '#last_initial' do
+    subject { described_class.new(name).last_initial }
+
+    context 'with a simple name' do
+      let(:name) { 'John Smith' }
+      it { is_expected.to eq('S') }
+    end
+
+    context 'with a multibyte first character in the surname' do
+      let(:name) { 'John Ångström' }
+      it { is_expected.to eq('Å') }
+    end
+
+    context 'with a single character surname' do
+      let(:name) { 'Cédric O' }
+      it { is_expected.to eq('O') }
+    end
+  end
+
+  describe '#to_h' do
+    subject { described_class.new('John S-mith').to_h }
+
+    it do
+      is_expected.to eq(
+        firstname: 'John',
+        surname: 'S-mith',
+        first_initial: 'J',
+        last_initial: 'S',
+        honorifics: 'Mr|Mrs|Miss|Ms|Mx'
+      )
+    end
+  end
+
+  describe '#substitutions' do
+    subject { described_class.new('John S-mith').substitutions }
+
+    it do
+      is_expected.to eq(
+        firstname: 'John',
+        surname: 'S\\-mith',
+        first_initial: 'J',
+        last_initial: 'S',
+        honorifics: 'Mr|Mrs|Miss|Ms|Mx'
+      )
+    end
+  end
+
+  describe '#to_censor_rule_text' do
+    subject { described_class.new('Bob Smith').to_censor_rule_text }
+
+    it { is_expected.to eq("(?x:\n    \\b\n    (?:\n      (?:Mr|Mrs|Miss|Ms|Mx)\\.? \\s+ (?:Bob\\s+)? Smith\n      |\n      Bob (?: \\s+ Smith | \\s+ S\\.? )?\n      |\n      B\\.? \\s* Smith\n      |\n      Smith ,\\s+ (?: Bob | B\\.? )\n    )\n    (?!\\w)\n  )") }
+
+    context 'with a custom pattern' do
+      around do |example|
+        described_class.pattern = '%{firstname} %{first_initial} %{last_initial} %{surname}'
+        example.run
+        described_class.pattern = described_class::DEFAULT_PATTERN
+      end
+
+      it { is_expected.to eq('Bob B S Smith') }
+    end
+
+    context 'with custom honorifics' do
+      around do |example|
+        described_class.honorifics = 'Monsieur|M|Madame|Mme'
+        example.run
+        described_class.honorifics = described_class::DEFAULT_HONORIFICS
+      end
+
+      it { is_expected.to include('Monsieur|M|Madame|Mme') }
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1398,6 +1398,7 @@ RSpec.describe User do
         censor_rule = user.censor_rules.find { _1.text = user.name }
         expect(censor_rule).to_not be_nil
         expect(censor_rule.replacement).to eq('[Name Removed]')
+        expect(censor_rule.case_sensitive).to eq(false)
         expect(censor_rule.last_edit_editor).to eq('User#anonymise!')
         expect(censor_rule.last_edit_comment).to eq('User#anonymise!')
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1393,11 +1393,14 @@ RSpec.describe User do
     context 'when the user has info requests' do
       before { FactoryBot.create(:info_request, user: user) }
 
-      it 'creates a censor rule for user name' do
+      it 'creates a regexp censor rule for user name' do
         subject
-        censor_rule = user.censor_rules.find { _1.text = user.name }
+        expected_text =
+          User::Anonymisable::NamePattern.new('Bob Smith').to_censor_rule_text
+        censor_rule = user.censor_rules.find { _1.text == expected_text }
         expect(censor_rule).to_not be_nil
         expect(censor_rule.replacement).to eq('[Name Removed]')
+        expect(censor_rule.regexp).to eq(true)
         expect(censor_rule.case_sensitive).to eq(false)
         expect(censor_rule.last_edit_editor).to eq('User#anonymise!')
         expect(censor_rule.last_edit_comment).to eq('User#anonymise!')
@@ -1414,10 +1417,13 @@ RSpec.describe User do
         )
       end
 
-      it 'creates a censor rules for previous names' do
+      it 'creates a regexp censor rule for previous names' do
         subject
-        censor_rule = user.censor_rules.find { _1.text == previous_name }
+        expected_text =
+          User::Anonymisable::NamePattern.new(previous_name).to_censor_rule_text
+        censor_rule = user.censor_rules.find { _1.text == expected_text }
         expect(censor_rule).to_not be_nil
+        expect(censor_rule.regexp).to eq(true)
         expect(censor_rule.replacement).to eq('[Name Removed]')
         expect(censor_rule.last_edit_editor).to eq('User#anonymise!')
         expect(censor_rule.last_edit_comment).to eq('User#anonymise!')
@@ -1427,10 +1433,13 @@ RSpec.describe User do
     context 'when the user has annotations' do
       before { FactoryBot.create(:comment, user: user) }
 
-      it 'creates a censor rule for user name' do
+      it 'creates a regexp censor rule for user name' do
         subject
-        censor_rule = user.censor_rules.find { _1.text == user.name }
+        expected_text =
+          User::Anonymisable::NamePattern.new('Bob Smith').to_censor_rule_text
+        censor_rule = user.censor_rules.find { _1.text == expected_text }
         expect(censor_rule).to_not be_nil
+        expect(censor_rule.regexp).to be true
         expect(censor_rule.replacement).to eq('[Name Removed]')
         expect(censor_rule.last_edit_editor).to eq('User#anonymise!')
         expect(censor_rule.last_edit_comment).to eq('User#anonymise!')
@@ -1441,6 +1450,24 @@ RSpec.describe User do
       it 'does not create a censor rule' do
         subject
         expect(user.censor_rules).to be_empty
+      end
+    end
+
+    context 'when NamePattern.pattern is customised' do
+      around do |example|
+        original = User::Anonymisable::NamePattern.pattern
+        User::Anonymisable::NamePattern.pattern = '(?i)%{firstname}'
+        example.run
+        User::Anonymisable::NamePattern.pattern = original
+      end
+
+      before { FactoryBot.create(:info_request, user: user) }
+
+      it 'uses the custom regexp pattern' do
+        subject
+        censor_rule = user.censor_rules.find { _1.text == '(?i)Bob' }
+        expect(censor_rule).to_not be_nil
+        expect(censor_rule.regexp).to eq(true)
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1403,7 +1403,7 @@ RSpec.describe User do
       end
     end
 
-    context 'when the user has info requests which uses an different name' do
+    context 'when the user has info requests that use a different name' do
       let(:previous_name) { 'Bob' }
 
       before do


### PR DESCRIPTION
## Relevant issue(s)

Requires https://github.com/mysociety/alaveteli/pull/9209
Part of #8821

## What does this do?

Creates a regexp rule to handle common name variants during user anonymisation

## Why was this needed?

Just using the account name alone usually doesn't capture the variety of names used during correspondence.

## Implementation notes

## Screenshots

BEFORE

<img width="686" height="971" alt="Screenshot 2026-04-16 at 11 44 32" src="https://github.com/user-attachments/assets/08fc6980-065a-4290-96d6-a1c7a00e33ec" />

RULE CREATION

<img width="696" height="239" alt="Screenshot 2026-04-16 at 11 40 00" src="https://github.com/user-attachments/assets/e70841fc-4c5f-4c30-9df8-d1f7954f8187" />

AFTER

<img width="697" height="974" alt="Screenshot 2026-04-16 at 11 44 09" src="https://github.com/user-attachments/assets/53c0ac6a-d494-4035-af23-c6ef74ffbe8d" />


## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
