### PR TITLE
Prevent banned pros making requests

### DIFF
--- a/app/controllers/alaveteli_pro/info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/info_request_batches_controller.rb
@@ -5,6 +5,8 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
+  before_action :check_banned
+
   def new
     @draft_info_request_batch = load_draft
     load_data_from_draft(@draft_info_request_batch)
@@ -44,6 +46,13 @@ class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
   end
 
   private
+
+  def check_banned
+    if authenticated? && authenticated_user.suspended?
+      @details = authenticated_user.can_fail_html
+      render(template: 'user/banned') && return
+    end
+  end
 
   def rate_monitor
     @rate_monitor ||=

--- a/app/controllers/alaveteli_pro/info_requests_controller.rb
+++ b/app/controllers/alaveteli_pro/info_requests_controller.rb
@@ -9,6 +9,7 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   before_action :set_public_body, only: [:new]
   before_action :load_data_from_draft, only: [:preview, :create]
   before_action :check_public_body_is_requestable, only: [:preview, :create]
+  before_action :check_banned, only: [:new, :preview, :create]
 
   def index
     @request_filter = AlaveteliPro::RequestFilter.new
@@ -55,6 +56,13 @@ class AlaveteliPro::InfoRequestsController < AlaveteliPro::BaseController
   end
 
   private
+
+  def check_banned
+    if authenticated? && authenticated_user.suspended?
+      @details = authenticated_user.can_fail_html
+      render(template: 'user/banned') && return
+    end
+  end
 
   def show_errors
     # There'll be a duplicate error if the outgoing_message is invalid, so

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Prevent banned Pro subscribers creating requests (Gareth Rees)
 * Integrate ActionMailbox for better inbound email processing (Graeme Porteous)
 * Allow responses to be received from any source (Graeme Porteous)
 * Fix hidden request snippets appearing in embargoed batch lists (Gareth Rees)

--- a/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
@@ -1,6 +1,20 @@
 require 'spec_helper'
 
 shared_examples_for "an info_request_batch action" do
+  context 'if the current_user is banned' do
+    before do
+      user.update!(ban_text: 'banned')
+      sign_in user
+    end
+
+    it 'renders user/banned' do
+      with_feature_enabled(:alaveteli_pro) do
+        action
+        expect(response).to render_template('user/banned')
+      end
+    end
+  end
+
   it "sets @draft_info_request_batch from the draft_id param" do
     with_feature_enabled(:alaveteli_pro) do
       action

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe AlaveteliPro::InfoRequestsController do
     end
   end
 
+  describe 'GET #new' do
+    context 'if the current_user is banned' do
+      before do
+        pro_user.update!(ban_text: 'banned')
+        sign_in pro_user
+      end
+
+      it 'renders user/banned' do
+        with_feature_enabled(:alaveteli_pro) do
+          get :new
+          expect(response).to render_template('user/banned')
+        end
+      end
+    end
+  end
+
   describe "#preview" do
     let(:draft) do
       FactoryBot.create(:draft_info_request, body: nil, user: pro_user)
@@ -88,6 +104,20 @@ RSpec.describe AlaveteliPro::InfoRequestsController do
         end
       end
     end
+
+    context 'if the current_user is banned' do
+      before do
+        pro_user.update!(ban_text: 'banned')
+        sign_in pro_user
+      end
+
+      it 'renders user/banned' do
+        with_feature_enabled(:alaveteli_pro) do
+          post :preview, params: { draft_id: draft }
+          expect(response).to render_template('user/banned')
+        end
+      end
+    end
   end
 
   describe "#create" do
@@ -112,6 +142,20 @@ RSpec.describe AlaveteliPro::InfoRequestsController do
         with_feature_enabled(:alaveteli_pro) do
           post :preview
           expect(response).to redirect_to(new_alaveteli_pro_info_request_url)
+        end
+      end
+    end
+
+    context 'if the current_user is banned' do
+      before do
+        pro_user.update!(ban_text: 'banned')
+        sign_in pro_user
+      end
+
+      it 'renders user/banned' do
+        with_feature_enabled(:alaveteli_pro) do
+          post :create, params: { draft_id: draft }
+          expect(response).to render_template('user/banned')
         end
       end
     end

--- a/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_requests_controller_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe AlaveteliPro::InfoRequestsController do
       it 'redirects to new info request action' do
         sign_in pro_user
         with_feature_enabled(:alaveteli_pro) do
-          post :preview
+          post :create
           expect(response).to redirect_to(new_alaveteli_pro_info_request_url)
         end
       end


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Prevent banned pros making requests

## Why was this needed?

Mirror non-pro behaviour.

Banned users cannot sign up to pro, but once they have pro the ban does not enforce the usual prevention of requests. Easy for an admin to forget they need to deactivate pro (which is not desirable in all cases).

## Implementation notes

## Screenshots

<img width="1184" height="440" alt="Screenshot 2026-04-16 at 17 08 50" src="https://github.com/user-attachments/assets/88216b24-2803-44f3-a73e-542cd8fd0890" />

