### PR TITLE
[#8822] Add CensorRule#diacritics_insensitive

### DIFF
--- a/app/controllers/admin_censor_rule_controller.rb
+++ b/app/controllers/admin_censor_rule_controller.rb
@@ -87,7 +87,8 @@ class AdminCensorRuleController < AdminController
   def censor_rule_params
     if params[:censor_rule]
       params.require(:censor_rule).
-        permit(:regexp, :case_sensitive, :text, :replacement,
+        permit(:text, :replacement, :regexp,
+               :case_sensitive, :ignore_diacritics,
                :last_edit_comment, :last_edit_editor)
     else
       {}

--- a/app/models/censor_rule.rb
+++ b/app/models/censor_rule.rb
@@ -14,6 +14,7 @@
 #  updated_at        :datetime         not null
 #  regexp            :boolean          default(FALSE), not null
 #  case_sensitive    :boolean          default(TRUE), not null
+#  ignore_diacritics :boolean          default(FALSE), not null
 #
 
 # models/censor_rule.rb:
@@ -41,7 +42,11 @@ class CensorRule < ApplicationRecord
              inverse_of: :censor_rules,
              optional: true
 
-  validate :require_valid_regexp, if: -> { regexp? || !case_sensitive? }
+  validate :require_valid_regexp,
+           if: -> { regexp? || !case_sensitive? || ignore_diacritics? }
+
+  validate :regexp_ignore_diacritics,
+           if: -> { regexp? && ignore_diacritics? }
 
   validates_presence_of :text,
                         :replacement,
@@ -122,7 +127,7 @@ class CensorRule < ApplicationRecord
   end
 
   def to_replace(encoding)
-    if regexp? || !case_sensitive?
+    if regexp? || !case_sensitive? || ignore_diacritics?
       make_regexp(encoding)
     else
       encoded_text(encoding)
@@ -134,8 +139,14 @@ class CensorRule < ApplicationRecord
   end
 
   def make_regexp(encoding)
-    pattern = encoded_text(encoding)
-    pattern = Regexp.escape(pattern) unless regexp?
+    pattern =
+      if ignore_diacritics?
+        diacritic_expander.expand(encoded_text(encoding))
+      else
+        encoded_text(encoding)
+      end
+
+    pattern = Regexp.escape(pattern) unless regexp? || ignore_diacritics?
 
     ::Warning.with_raised_warnings do
       Regexp.new(pattern, regexp_options)
@@ -149,5 +160,14 @@ class CensorRule < ApplicationRecord
     options |= Regexp::IGNORECASE unless case_sensitive?
     options |= Regexp::MULTILINE if regexp?
     options
+  end
+
+  def diacritic_expander
+    DiacriticExpander.new(case_sensitive: case_sensitive?)
+  end
+
+  def regexp_ignore_diacritics
+    msg = 'Cannot use regexp and ignore diacritics option together'
+    errors.add(:text, msg)
   end
 end

--- a/app/models/censor_rule/diacritic_expander.rb
+++ b/app/models/censor_rule/diacritic_expander.rb
@@ -1,0 +1,66 @@
+# Maps characters to a regexp covering its diacritic variants.
+class CensorRule::DiacriticExpander
+  # Maps each character to cover diacritic variants. Separate lowercase and
+  # uppercase entries preserve the original case of the input — when
+  # case_sensitive is false Regexp::IGNORECASE covers the other case without
+  # enumerating both in each class.
+  #
+  # Reusers can replace or extend this for their locale:
+  #   CensorRule::DiacriticExpander.character_map = { ... }
+  DEFAULT_CHARACTER_MAP = {
+    'a' => '[aàáâãäåā]', 'A' => '[AÀÁÂÃÄÅĀ]',
+    'c' => '[cçćč]',     'C' => '[CÇĆČ]',
+    'e' => '[eèéêëēě]',  'E' => '[EÈÉÊËĒĚ]',
+    'i' => '[iìíîïī]',   'I' => '[IÌÍÎÏĪ]',
+    'l' => '[lłĺļľ]',    'L' => '[LŁĹĻĽ]',
+    'n' => '[nñńň]',     'N' => '[NÑŃŇ]',
+    'o' => '[oòóôõöøō]', 'O' => '[OÒÓÔÕÖØŌ]',
+    'r' => '[rŕř]',      'R' => '[RŔŘ]',
+    's' => '[sśš]',      'S' => '[SŚŠ]',
+    'u' => '[uùúûüūů]',  'U' => '[UÙÚÛÜŪŮ]',
+    'y' => '[yýÿ]',      'Y' => '[YÝŸ]',
+    'z' => '[zźżž]',     'Z' => '[ZŹŻŽ]'
+  }.freeze
+
+  cattr_accessor :character_map, default: DEFAULT_CHARACTER_MAP
+
+  def initialize(case_sensitive: true)
+    @case_sensitive = case_sensitive
+  end
+
+  def expand(text, encoding: 'UTF-8')
+    text.mb_chars.each_char.map { expand_character(it) }.join.encode(encoding)
+  end
+
+  def case_sensitive?
+    @case_sensitive
+  end
+
+  private
+
+  def expand_character(char)
+    map = character_map_case_insensitive || character_map
+
+    map[char] ||
+      map[ActiveSupport::Inflector.transliterate(char)] ||
+      char
+  end
+
+  def character_map_case_insensitive
+    return if case_sensitive?
+
+    lowercase_keys = character_map.each_key.select { |k| k == k.downcase }
+
+    lowercase_keys.each_with_object({}) do |lower, combined_map|
+      upper = lower.upcase
+
+      lower_chars = character_map.fetch(lower)[1...-1]
+      upper_chars = character_map.fetch(upper)[1...-1]
+
+      combined = "[#{lower_chars}#{upper_chars}]"
+
+      combined_map[lower] = combined
+      combined_map[upper] = combined
+    end
+  end
+end

--- a/app/models/censor_rule/diacritic_expander.rb
+++ b/app/models/censor_rule/diacritic_expander.rb
@@ -19,7 +19,9 @@ class CensorRule::DiacriticExpander
     's' => '[sśš]',      'S' => '[SŚŠ]',
     'u' => '[uùúûüūů]',  'U' => '[UÙÚÛÜŪŮ]',
     'y' => '[yýÿ]',      'Y' => '[YÝŸ]',
-    'z' => '[zźżž]',     'Z' => '[ZŹŻŽ]'
+    'z' => '[zźżž]',     'Z' => '[ZŹŻŽ]',
+    'œ' => '(œ|oe)',     'Œ' => '(Œ|OE)',
+    'æ' => '(æ|ae)',     'Æ' => '(Æ|AE)'
   }.freeze
 
   cattr_accessor :character_map, default: DEFAULT_CHARACTER_MAP

--- a/app/views/admin_censor_rule/_form.html.erb
+++ b/app/views/admin_censor_rule/_form.html.erb
@@ -23,6 +23,18 @@
 </div>
 <% end %>
 
+<% if feature_enabled?(:censor_rule_ignore_diacritics) %>
+<div class="control-group">
+  <label for="censor_rule_ignore_diacritics" class="control-label">Ignore diacritics?</label>
+  <div class="controls">
+    <%= check_box 'censor_rule', 'ignore_diacritics' %>
+    <div class="help-block">
+      Automatically matches accented variants, e.g. "ecole" will also match "école"
+    </div>
+  </div>
+</div>
+<% end %>
+
 <div class="control-group">
   <label for="censor_rule_text" class="control-label">Text</label>
   <div class="controls">

--- a/db/migrate/20260417123353_add_ignore_diacritics_to_censor_rules.rb
+++ b/db/migrate/20260417123353_add_ignore_diacritics_to_censor_rules.rb
@@ -1,0 +1,6 @@
+class AddIgnoreDiacriticsToCensorRules < ActiveRecord::Migration[8.0]
+  def change
+    add_column :censor_rules, :ignore_diacritics, :boolean,
+               default: false, null: false
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow censor rules to ignore diacritics (Gareth Rees)
 * Allow censor rules to be case insensitive (Gareth Rees)
 * Add Content Security Policy with nonce-based script protection (Graeme
   Porteous)
@@ -114,6 +115,12 @@
   it by running:
 
     bin/rails runner "AlaveteliFeatures.backend.enable(:censor_rule_case_sensitive)"
+
+* _Optional:_ Censor rules can now ignore diacritics. This is disabled by
+  default while we beta test it before full release. Before then you can enable
+  it by running:
+
+    bin/rails runner "AlaveteliFeatures.backend.enable(:censor_rule_ignore_diacritics)"
 
 ### Changed Templates
 

--- a/spec/factories/censor_rules.rb
+++ b/spec/factories/censor_rules.rb
@@ -14,6 +14,7 @@
 #  updated_at        :datetime         not null
 #  regexp            :boolean          default(FALSE), not null
 #  case_sensitive    :boolean          default(TRUE), not null
+#  ignore_diacritics :boolean          default(FALSE), not null
 #
 
 FactoryBot.define do
@@ -45,6 +46,10 @@ FactoryBot.define do
 
     trait :case_insensitive do
       case_sensitive { false }
+    end
+
+    trait :ignore_diacritics do
+      ignore_diacritics { true }
     end
   end
 end

--- a/spec/models/censor_rule/diacritic_expander_spec.rb
+++ b/spec/models/censor_rule/diacritic_expander_spec.rb
@@ -1,0 +1,115 @@
+require 'spec_helper'
+
+RSpec.describe CensorRule::DiacriticExpander do
+  describe '.character_map' do
+    subject { described_class.character_map }
+
+    after do
+      described_class.character_map = described_class::DEFAULT_CHARACTER_MAP
+    end
+
+    context 'with the default map' do
+      it { is_expected.to eq(described_class::DEFAULT_CHARACTER_MAP) }
+    end
+
+    context 'with a custom map' do
+      let(:custom_map) do
+        { 'x' => '[xxyz]', 'X' => '[XXYZ]' }
+      end
+
+      before { described_class.character_map = custom_map }
+
+      it { is_expected.to eq(custom_map) }
+    end
+  end
+
+  describe '#expand' do
+    context 'with default case-sensitive mode' do
+      subject(:expander) { described_class.new }
+
+      it 'expands lowercase characters with diacritics to character classes' do
+        expect(expander.expand('a')).to eq('[aàáâãäåā]')
+      end
+
+      it 'expands uppercase characters with diacritics to character classes' do
+        expect(expander.expand('A')).to eq('[AÀÁÂÃÄÅĀ]')
+      end
+
+      it 'preserves characters without diacritic variants' do
+        expect(expander.expand('b')).to eq('b')
+      end
+
+      it 'ignores non-mapped characters' do
+        expect(expander.expand('123')).to eq('123')
+        expect(expander.expand('!@*')).to eq('!@*')
+      end
+
+      it 'handles multi-character strings' do
+        expect(expander.expand('café')).to eq('[cçćč][aàáâãäåā]f[eèéêëēě]')
+      end
+
+      it 'handles mixed mapped and non-mapped characters' do
+        expect(expander.expand('a1b2c')).to eq('[aàáâãäåā]1b2[cçćč]')
+      end
+
+      it 'handles diacritic characters themselves' do
+        expect(expander.expand('á')).to eq('[aàáâãäåā]')
+        expect(expander.expand('Á')).to eq('[AÀÁÂÃÄÅĀ]')
+      end
+
+      it 'handles strings with spaces and punctuation' do
+        expected =
+          '[cçćč][aàáâãäåā]f[eèéêëēě] ' \
+          '[aàáâãäåā][uùúûüūů] ' \
+          '[lłĺļľ][aàáâãäåā][iìíîïī]t'
+
+        expect(expander.expand('café au lait')).to eq(expected)
+      end
+
+      it 'handles empty strings' do
+        expect(expander.expand('')).to eq('')
+      end
+    end
+
+    context 'with case-insensitive mode' do
+      subject(:expander) { described_class.new(case_sensitive: false) }
+
+      it 'merges character classes for both cases' do
+        expect(expander.expand('a')).to eq('[aàáâãäåāAÀÁÂÃÄÅĀ]')
+        expect(expander.expand('A')).to eq('[aàáâãäåāAÀÁÂÃÄÅĀ]')
+      end
+
+      it 'handles mixed case strings' do
+        expect(expander.expand('Café')).
+          to eq('[cçćčCÇĆČ][aàáâãäåāAÀÁÂÃÄÅĀ]f[eèéêëēěEÈÉÊËĒĚ]')
+      end
+
+      it 'handles strings with only uppercase' do
+        expect(expander.expand('CAFÉ')).
+          to eq('[cçćčCÇĆČ][aàáâãäåāAÀÁÂÃÄÅĀ]F[eèéêëēěEÈÉÊËĒĚ]')
+      end
+
+      it 'ignores non-mapped characters the same as case-sensitive' do
+        expect(expander.expand('123')).to eq('123')
+        expect(expander.expand('!@*')).to eq('!@*')
+      end
+
+      it 'handles diacritic characters in case-insensitive mode' do
+        expect(expander.expand('á')).to eq('[aàáâãäåāAÀÁÂÃÄÅĀ]')
+        expect(expander.expand('Á')).to eq('[aàáâãäåāAÀÁÂÃÄÅĀ]')
+      end
+    end
+  end
+
+  describe '#case_sensitive?' do
+    it 'returns true by default' do
+      expander = described_class.new
+      expect(expander.case_sensitive?).to eq(true)
+    end
+
+    it 'returns false when case_sensitive is set to false' do
+      expander = described_class.new(case_sensitive: false)
+      expect(expander.case_sensitive?).to eq(false)
+    end
+  end
+end

--- a/spec/models/censor_rule/diacritic_expander_spec.rb
+++ b/spec/models/censor_rule/diacritic_expander_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe CensorRule::DiacriticExpander do
         expect(expander.expand('Á')).to eq('[AÀÁÂÃÄÅĀ]')
       end
 
+      it 'handles multi-character diacritics' do
+        expect(expander.expand('œ')).to eq('(œ|oe)')
+        expect(expander.expand('Œ')).to eq('(Œ|OE)')
+      end
+
       it 'handles strings with spaces and punctuation' do
         expected =
           '[cçćč][aàáâãäåā]f[eèéêëēě] ' \

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -14,6 +14,7 @@
 #  updated_at        :datetime         not null
 #  regexp            :boolean          default(FALSE), not null
 #  case_sensitive    :boolean          default(TRUE), not null
+#  ignore_diacritics :boolean          default(FALSE), not null
 #
 
 require 'spec_helper'
@@ -98,6 +99,25 @@ RSpec.describe CensorRule do
       end
     end
 
+    context 'when sensitive to both diacritics and case' do
+      let(:rule) do
+        FactoryBot.build(
+          :censor_rule,
+          ignore_diacritics: false,
+          case_sensitive: true,
+          text: 'ecole'
+        )
+      end
+
+      it 'only matches the given text' do
+        expect(rule.apply_to_text('ecole text')).to eq('[REDACTED] text')
+        expect(rule.apply_to_text('école text')).to eq('école text')
+        expect(rule.apply_to_text('Ecole text')).to eq('Ecole text')
+        expect(rule.apply_to_text('ECOLE text')).to eq('ECOLE text')
+        expect(rule.apply_to_text('ÉCOLE text')).to eq('ÉCOLE text')
+      end
+    end
+
     context 'when case_sensitive is false with regexp rule' do
       let(:rule) do
         FactoryBot.build(
@@ -108,6 +128,48 @@ RSpec.describe CensorRule do
       it 'applies to text regardless of case' do
         expect(rule.apply_to_text('SECRET text')).to eq('[REDACTED] text')
         expect(rule.apply_to_text('secret text')).to eq('[REDACTED] text')
+      end
+    end
+
+    context 'when ignore_diacritics is true' do
+      let(:rule) do
+        FactoryBot.build(:censor_rule, :ignore_diacritics, text: 'ecole')
+      end
+
+      it 'matches diacritic variants of the same case' do
+        expect(rule.apply_to_text('ecole text')).to eq('[REDACTED] text')
+        expect(rule.apply_to_text('école text')).to eq('[REDACTED] text')
+      end
+
+      it 'handles multiple diacritics in the text' do
+        rule.text = 'maçã'
+        expect(rule.apply_to_text('Uma maçã por dia')).
+          to eq('Uma [REDACTED] por dia')
+      end
+
+      it 'does not match the opposite case' do
+        expect(rule.apply_to_text('Ecole text')).to eq('Ecole text')
+        expect(rule.apply_to_text('ECOLE text')).to eq('ECOLE text')
+        expect(rule.apply_to_text('ÉCOLE text')).to eq('ÉCOLE text')
+      end
+    end
+
+    context 'when ignoring diacritics and case' do
+      let(:rule) do
+        FactoryBot.build(
+          :censor_rule,
+          :ignore_diacritics,
+          :case_insensitive,
+          text: 'ecole'
+        )
+      end
+
+      it 'matches diacritic variants in any case' do
+        expect(rule.apply_to_text('ecole text')).to eq('[REDACTED] text')
+        expect(rule.apply_to_text('école text')).to eq('[REDACTED] text')
+        expect(rule.apply_to_text('Ecole text')).to eq('[REDACTED] text')
+        expect(rule.apply_to_text('ECOLE text')).to eq('[REDACTED] text')
+        expect(rule.apply_to_text('ÉCOLE text')).to eq('[REDACTED] text')
       end
     end
   end
@@ -221,6 +283,25 @@ RSpec.describe CensorRule do
       end
     end
 
+    context 'when sensitive to both diacritics and case' do
+      let(:rule) do
+        FactoryBot.build(
+          :censor_rule,
+          ignore_diacritics: false,
+          case_sensitive: true,
+          text: 'ecole'
+        )
+      end
+
+      it 'only matches the given text' do
+        expect(rule.apply_to_binary('ecole text')).to eq('xxxxx text')
+        expect(rule.apply_to_binary('école text')).to eq('école text')
+        expect(rule.apply_to_binary('Ecole text')).to eq('Ecole text')
+        expect(rule.apply_to_binary('ECOLE text')).to eq('ECOLE text')
+        expect(rule.apply_to_binary('ÉCOLE text')).to eq('ÉCOLE text')
+      end
+    end
+
     context 'when case_sensitive is false with a regexp rule' do
       let(:rule) do
         FactoryBot.build(
@@ -231,6 +312,42 @@ RSpec.describe CensorRule do
       it 'applies to binary regardless of case' do
         expect(rule.apply_to_binary('SECRET text')).to eq('xxxxxx text')
         expect(rule.apply_to_binary('secret text')).to eq('xxxxxx text')
+      end
+    end
+
+    context 'when ignore_diacritics is true' do
+      let(:rule) do
+        FactoryBot.build(:censor_rule, :ignore_diacritics, text: 'ecole')
+      end
+
+      it 'matches diacritic variants of the same case in binary' do
+        expect(rule.apply_to_binary('école text')).to eq('xxxxxx text')
+      end
+
+      it 'handles multiple diacritics in the text' do
+        rule.text = 'maçã'
+        expect(rule.apply_to_binary('Uma maçã por dia')).
+          to eq('Uma xxxxxx por dia')
+      end
+
+      it 'does not match the opposite case in binary' do
+        expect(rule.apply_to_binary('École text')).to eq('École text')
+      end
+    end
+
+    context 'when ignoring diacritics and case' do
+      let(:rule) do
+        FactoryBot.build(
+          :censor_rule,
+          :ignore_diacritics,
+          :case_insensitive,
+          text: 'ecole'
+        )
+      end
+
+      it 'matches diacritic variants in any case in binary' do
+        expect(rule.apply_to_binary('ECOLE text')).to eq('xxxxx text')
+        expect(rule.apply_to_binary('école text')).to eq('xxxxxx text')
       end
     end
   end
@@ -368,6 +485,42 @@ RSpec.describe 'when validating rules' do
     censor_rule = CensorRule.new
     censor_rule.valid?
     expect(censor_rule.errors[:last_edit_comment].size).to eq(1)
+  end
+
+  describe 'when validating an ignore_diacritics rule' do
+    let(:rule) do
+      CensorRule.new(ignore_diacritics: true,
+                     text: 'ecole',
+                     replacement: '[REDACTED]',
+                     last_edit_comment: 'test',
+                     last_edit_editor: 'rspec')
+    end
+
+    it 'is valid' do
+      expect(rule).to be_valid
+    end
+  end
+
+  describe 'when validating a regexp with ignore_diacritics rule' do
+    let(:rule) do
+      CensorRule.new(regexp: true,
+                     ignore_diacritics: true,
+                     text: 'ecole',
+                     replacement: '[REDACTED]',
+                     last_edit_comment: 'test',
+                     last_edit_editor: 'rspec')
+    end
+
+    it 'is not valid' do
+      expect(rule).not_to be_valid
+    end
+
+    it 'adds an error on text' do
+      rule.valid?
+      expect(rule.errors[:text]).to include(
+        'Cannot use regexp and ignore diacritics option together'
+      )
+    end
   end
 
   describe 'when validating a regexp rule' do

--- a/spec/models/censor_rule_spec.rb
+++ b/spec/models/censor_rule_spec.rb
@@ -147,6 +147,12 @@ RSpec.describe CensorRule do
           to eq('Uma [REDACTED] por dia')
       end
 
+      it 'handles multi-letter diacritics' do
+        rule.text = 'œuf'
+        expect(rule.apply_to_text('Un œuf, des oeufs')).
+          to eq('Un [REDACTED], des [REDACTED]s')
+      end
+
       it 'does not match the opposite case' do
         expect(rule.apply_to_text('Ecole text')).to eq('Ecole text')
         expect(rule.apply_to_text('ECOLE text')).to eq('ECOLE text')
@@ -328,6 +334,12 @@ RSpec.describe CensorRule do
         rule.text = 'maçã'
         expect(rule.apply_to_binary('Uma maçã por dia')).
           to eq('Uma xxxxxx por dia')
+      end
+
+      it 'handles multi-letter diacritics' do
+        rule.text = 'œuf'
+        expect(rule.apply_to_binary('Un œuf, des oeufs')).
+          to eq('Un xxxx, des xxxxs')
       end
 
       it 'does not match the opposite case in binary' do


### PR DESCRIPTION
## Relevant issue(s)

Part of #8822 
Requires https://github.com/mysociety/alaveteli/pull/9209/

## What does this do?

Add CensorRule#diacritics_insensitive

## Why was this needed?

Annoying to have to enter multiple censor rules / create a regexp for common accented words.

## Implementation notes

Limitations:

* Only works when `CensorRule#regexp` is `false`. I did look at removing this constraint but it adds complexity and probably isn't a very typical case.
* Only handles single-letter diacritics (e.g. É -> E). Does not handle characters that would get mapped to multiple Ascii characters (e.g. æ -> ae).

## Screenshots

<img width="764" height="298" alt="Screenshot 2026-04-17 at 17 15 37" src="https://github.com/user-attachments/assets/b40d3be6-85b2-40d1-853c-b2a58242147b" />

<img width="975" height="545" alt="Screenshot 2026-04-17 at 17 15 55" src="https://github.com/user-attachments/assets/15067e73-0ddc-4459-b06d-afbb87241752" />

<img width="765" height="302" alt="Screenshot 2026-04-17 at 17 16 00" src="https://github.com/user-attachments/assets/ab0033a8-0ddd-441c-a984-9043ead3a653" />

