### PR TITLE
Prevent banned users uploading responses

### DIFF
--- a/app/controllers/upload_response_controller.rb
+++ b/app/controllers/upload_response_controller.rb
@@ -2,10 +2,11 @@
 class UploadResponseController < RequestController
   read_only only: [:new]
 
+  before_action :set_info_request
+  before_action :check_banned
+
   def new
     AlaveteliLocalization.with_locale(locale) do
-      @info_request = InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
-
       @reason_params = {
         web: _('To upload a response, you must be logged in using an ' \
                'email address from {{authority_name}}',
@@ -73,5 +74,19 @@ class UploadResponseController < RequestController
       redirect_to request_url(@info_request)
       nil
     end
+  end
+
+  private
+
+  def set_info_request
+    @info_request =
+      InfoRequest.not_embargoed.find_by_url_title!(params[:url_title])
+  end
+
+  def check_banned
+    return unless authenticated_user&.suspended?
+
+    msg = _('Banned users cannot upload responses.')
+    redirect_to request_url(@info_request), error: msg
   end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Prevent banned users replying through the response upload form (Gareth Rees)
 * Allow censor rules to be case insensitive (Gareth Rees)
 * Add Content Security Policy with nonce-based script protection (Graeme
   Porteous)

--- a/spec/controllers/upload_response_controller_spec.rb
+++ b/spec/controllers/upload_response_controller_spec.rb
@@ -20,6 +20,35 @@ RSpec.describe UploadResponseController, type: :controller do
       @foi_officer_user.save!
     end
 
+    context 'when the user is banned' do
+      before do
+        @foi_officer_user.update!(ban_text: 'Banned')
+        sign_in @foi_officer_user
+      end
+
+      let(:slug) { 'why_do_you_have_such_a_fancy_dog' }
+
+      it 'prevents form access' do
+        get :new, params: {
+          url_title: 'why_do_you_have_such_a_fancy_dog'
+        }
+
+        expect(response).to redirect_to(show_request_path(url_title: slug))
+        expect(flash[:error]).to match(/Banned users cannot/)
+      end
+
+      it 'prevents submissions' do
+        post :new, params: {
+          url_title: 'why_do_you_have_such_a_fancy_dog',
+          body: 'malicious',
+          submitted_upload_response: 1
+        }
+
+        expect(response).to redirect_to(show_request_path(url_title: slug))
+        expect(flash[:error]).to match(/Banned users cannot/)
+      end
+    end
+
     context 'when the request is embargoed' do
       let(:embargoed_request) { FactoryBot.create(:embargoed_request) }
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes https://github.com/mysociety/alaveteli-security/issues/44

## What does this do?

Prevent banned users uploading responses

## Why was this needed?

Banned users could change their email to an authority email to get upload response access

## Screenshots

BEFORE

<img width="1201" height="639" alt="Screenshot 2026-05-15 at 12 08 19" src="https://github.com/user-attachments/assets/1e75d447-2d71-4617-8fe5-9b443bc60a94" />

AFTER

<img width="1201" height="617" alt="Screenshot 2026-05-15 at 12 08 38" src="https://github.com/user-attachments/assets/3e00119e-59b6-4ffe-8007-252a6385a9ae" />

