### PR TITLE
Fix layout issues within `.view_html_prefix`

### DIFF
--- a/app/assets/stylesheets/responsive/_attachments_layout.scss
+++ b/app/assets/stylesheets/responsive/_attachments_layout.scss
@@ -33,41 +33,34 @@ body#wrapper_embed {
 }
 
 .view_html_prefix {
-  @include grid-column(12);
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.5rem;
+  column-gap: 2rem;
+
+  @include respond-min( $main_menu-mobile_menu_cutoff ){
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
   @include ie8{
-    padding-left: 0.9375em;
-    padding-right: 0.9375em;
+    padding-left: 1.875em;
+    padding-right: 1.875em;
     width: $main_menu-mobile_menu_cutoff;
   }
 
   .view_html_logo {
-    @include grid-column(12);
     @include respond-min( $main_menu-mobile_menu_cutoff ){
-      @include grid-column($columns:3);
-      @include ie8{
-        padding-right: 0.9375em;
-      }
+      max-width: 25%;
     }
   }
 
   .view_html_description {
-    @include grid-column(12);
-    @include respond-min($main_menu-mobile_menu_cutoff ){
-      @include grid-column($columns:7, $pull: 2);
-      @include ie8{
-        padding-left: 0.9375em;
-        padding-right: 0.9375em;
-      }
-    }
+    margin-bottom: 0;
   }
 
   .view_html_download_link {
-    @include grid-column(12);
-    @include respond-min( $main_menu-mobile_menu_cutoff ){
-      @include grid-column($columns:2, $push: 7);
-      @include ie8{
-        padding-left: 0.9375em;
-      }
-    }
+    order: 3;
   }
 }

--- a/app/assets/stylesheets/responsive/_attachments_style.scss
+++ b/app/assets/stylesheets/responsive/_attachments_style.scss
@@ -17,10 +17,15 @@
 
 .view_html_prefix {
   text-align:center;
+  padding:0.75em 1em;
+  font-size: 0.9rem;
+  line-height: 120%;
   @include respond-min( $main_menu-mobile_menu_cutoff ){
     text-align:left;
     min-height:3em;
-    padding:0.5em 1em;
+    font-size: 1rem;
+    padding-right: 1.875em;
+    padding-left: 1.875em;
   }
   border-bottom: 1px solid #5F5F5F;
 }

--- a/app/views/request/_view_html_stylesheet.html.erb
+++ b/app/views/request/_view_html_stylesheet.html.erb
@@ -7,7 +7,7 @@
 <![endif]-->
 
 <!--[if GT IE 8]><!-->
-<link href="/assets/responsive/application.css" media="all" rel="stylesheet" title="Main" type="text/css" charset="UTF-8" />
+<%= stylesheet_link_tag 'responsive/application', :title => "Main", :rel => "stylesheet", :media => "all" %>
 <!--<![endif]-->
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 


### PR DESCRIPTION
## Relevant issue(s)

Discovered it while working on https://github.com/mysociety/alaveteli/issues/9097

## What does this do?

- Fixes vertical alignment.
- Swap float positioning to flex display.
- Simplify CSS.
- Decreases height on mobile.
- Replaced hardcoded CSS path in `_view_html_stylesheet.html.erb` with `stylesheet_link_tag`

## Why was this needed?

## Implementation notes

## Screenshots
**Desktop**
<img width="1905" height="423" alt="Screenshot 2026-04-30 at 06 47 40" src="https://github.com/user-attachments/assets/b2275339-0c6a-47b9-beb2-8b70689b5220" />


**Mobile**
<img width="361" height="235" alt="Screenshot 2026-04-30 at 06 47 24" src="https://github.com/user-attachments/assets/a7363877-f8b3-4ee4-9955-21fb87623f2d" />


## Notes to reviewer

<hr>

[skip changelog]
