### PR TITLE
Fix missing render post sending batch

### DIFF
--- a/app/controllers/alaveteli_pro/info_request_batches_controller.rb
+++ b/app/controllers/alaveteli_pro/info_request_batches_controller.rb
@@ -36,6 +36,7 @@ class AlaveteliPro::InfoRequestBatchesController < AlaveteliPro::BaseController
 
       @info_request_batch.save!
       @draft_info_request_batch.destroy
+      flash[:batch_sent] = true
       redirect_to show_alaveteli_pro_batch_request_path(id: @info_request_batch.id)
     elsif all_models_valid?(ignore_existing_batch: true)
       render 'alaveteli_pro/info_requests/preview'

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix missing batch sent flash message after creating a batch (Graeme Porteous)
 * Render public body category notes (Gareth Rees)
 * Prevent external search indexing of password change form (Gareth Rees)
 * Allow customisation of text masks (Gareth Rees)

--- a/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/info_request_batches_controller_spec.rb
@@ -238,6 +238,13 @@ RSpec.describe AlaveteliPro::InfoRequestBatchesController do
         end
       end
 
+      it "sets batch_sent flash" do
+        with_feature_enabled(:alaveteli_pro) do
+          action
+          expect(flash[:batch_sent]).to eq(true)
+        end
+      end
+
       it "redirects to show the batch" do
         with_feature_enabled(:alaveteli_pro) do
           action


### PR DESCRIPTION
The 'batch_sent' partial isn't rendered after a batch is been created and the user redirected to `InfoRequestBatchController#show`. This is due to the flash variable not being set.

