### PR TITLE
Cache request count on frontpage

### DIFF
--- a/app/controllers/general_controller.rb
+++ b/app/controllers/general_controller.rb
@@ -19,7 +19,9 @@ class GeneralController < ApplicationController
     successful_query = InfoRequestEvent.make_query_from_params( latest_status: ['successful'] )
     @request_events, @request_events_all_successful = InfoRequest.recent_requests
     @track_thing = TrackThing.create_track_for_search_query(successful_query)
-    @number_of_requests = InfoRequest.is_searchable.count
+    @number_of_requests = Rails.cache.fetch(
+      'frontpage/info_request_count', expires_in: 1.hour
+    ) { InfoRequest.is_searchable.count }
     @number_of_authorities = PublicBody.visible.count
     @feed_autodetect = [ { url: do_track_url(@track_thing, 'feed'),
                            title: _('Successful requests'),

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Cache total requests count on the front page for 1 hour (Chris Mytton)
 * Fix email change confirmation which wasn't bound to confirmed target address
   (Graeme Porteous)
 * Ensure only readable requests can be added to a Project (Gareth Rees)


### PR DESCRIPTION
The `InfoRequest.is_searchable.count` call takes ~600ms on the WDTK DB, so caching the result for an hour should speed up the frontpage load time a bit.

This does mean that the request count on the homepage will no longer be "realtime", but seems like a reasonable trade-off for the speed gain.
