### PR TITLE
Authenticator 2fa schema model changes

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@
 #  can_make_batch_requests           :boolean          default(FALSE), not null
 #  otp_enabled                       :boolean          default(FALSE), not null
 #  otp_secret_key                    :string
-#  otp_counter                       :integer          default(1)
+#  otp_counter                       :integer
 #  confirmed_not_spam                :boolean          default(FALSE), not null
 #  comments_count                    :integer          default(0), not null
 #  info_requests_count               :integer          default(0), not null
@@ -38,6 +38,10 @@
 #  user_messages_count               :integer          default(0), not null
 #  status_update_count               :integer          default(0), not null
 #  last_sign_in_at                   :datetime
+#  otp_last_used_at                  :integer
+#  otp_backup_codes                  :string           default([]), is an Array
+#  otp_enabled_at                    :datetime
+#  otp_backup_codes_generated_at     :datetime
 #
 
 class User < ApplicationRecord

--- a/app/models/user/one_time_password.rb
+++ b/app/models/user/one_time_password.rb
@@ -3,15 +3,41 @@ module User::OneTimePassword
   extend ActiveSupport::Concern
 
   included do
-    has_one_time_password counter_based: true
+    has_one_time_password after_column_name: :otp_last_used_at,
+                          one_time_backup_codes: true
 
     attr_accessor :entered_otp_code
 
     validate :verify_otp_code, if: :otp_enabled_and_required?
+    validate :otp_backup_codes_paired_with_timestamp
+
+    # The `before_create` hook in active_model_otp auto-generates backup codes
+    # if the `otp_backup_codes` column exists, but it has no awareness of the
+    # `otp_backup_codes_generated_at` column, so codes would be persisted
+    # without a matching issued-at timestamp. Codes are only meaningful
+    # alongside the timestamp, so suppress the auto-generation and let
+    # TOTP enrolment populate both columns together.
+    before_create -> { self.otp_backup_codes = [] }
+
+    # active_model_otp reads `otp_counter_based` from self in
+    # `authenticate_otp`, `otp_code` and `provisioning_uri`, so deriving it
+    # from the persisted counter dispatches each user to the right HOTP/TOTP
+    # branch without a separate mode column.
+    def otp_counter_based # rubocop:disable Naming/PredicateMethod
+      otp_counter.present?
+    end
   end
 
   def otp_enabled?
-    (otp_secret_key && otp_counter && otp_enabled) ? true : false
+    otp_secret_key.present? && otp_enabled
+  end
+
+  def hotp?
+    otp_enabled? && otp_counter.present?
+  end
+
+  def totp?
+    otp_enabled? && otp_counter.nil?
   end
 
   def enable_otp
@@ -41,6 +67,19 @@ module User::OneTimePassword
     otp_enabled? && require_otp?
   end
 
+  # Backup codes are only meaningful alongside a generated-at timestamp.
+  # Writing one without the other would mean e.g. the management page showing
+  # "last regenerated never" for a user who has codes.
+  # Enforce that they're set or cleared together.
+  def otp_backup_codes_paired_with_timestamp
+    has_codes = otp_backup_codes.present?
+    has_timestamp = otp_backup_codes_generated_at.present?
+    return if has_codes == has_timestamp
+
+    errors.add(:otp_backup_codes,
+               'must be set together with otp_backup_codes_generated_at')
+  end
+
   def verify_otp_code
     if entered_otp_code.nil? || !authenticate_otp(entered_otp_code)
       msg = _('Invalid one time password')
@@ -48,7 +87,7 @@ module User::OneTimePassword
       return false
     end
 
-    self.otp_counter += 1
+    self.otp_counter += 1 if otp_counter_based
     self.entered_otp_code = nil
   end
 end

--- a/db/migrate/20260511094217_add_totp_fields_to_users.rb
+++ b/db/migrate/20260511094217_add_totp_fields_to_users.rb
@@ -1,0 +1,10 @@
+class AddTotpFieldsToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :otp_last_used_at, :integer
+    add_column :users, :otp_backup_codes, :string, array: true, default: []
+    add_column :users, :otp_enabled_at, :datetime
+    add_column :users, :otp_backup_codes_generated_at, :datetime
+
+    change_column_default :users, :otp_counter, from: 1, to: nil
+  end
+end

--- a/db/migrate/20260511114052_null_stale_otp_counters.rb
+++ b/db/migrate/20260511114052_null_stale_otp_counters.rb
@@ -1,0 +1,19 @@
+class NullStaleOtpCounters < ActiveRecord::Migration[8.0]
+  # The matched set is the whole "never enrolled in 2FA" cohort, which
+  # is most of `users` on a typical install. Batched updates outside a
+  # wrapping transaction keep locks short and let a re-run resume from
+  # where a previous run left off — the filter is idempotent.
+  disable_ddl_transaction!
+
+  def up
+    User.where(otp_enabled: false).
+      where.not(otp_counter: nil).
+      in_batches(of: 1000) do |batch|
+        batch.update_all(otp_counter: nil)
+      end
+  end
+
+  def down
+    # Original counter values cannot be reconstructed.
+  end
+end

--- a/spec/controllers/one_time_passwords_controller_spec.rb
+++ b/spec/controllers/one_time_passwords_controller_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe OneTimePasswordsController do
     end
 
     it 'regenerates the otp_code' do
-      user = FactoryBot.create(:user, otp_enabled: true)
+      user = FactoryBot.create(:user, otp_enabled: true, otp_counter: 1)
       expected = ROTP::HOTP.new(user.otp_secret_key).at(2)
       sign_in user
       put :update

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -22,7 +22,7 @@
 #  can_make_batch_requests           :boolean          default(FALSE), not null
 #  otp_enabled                       :boolean          default(FALSE), not null
 #  otp_secret_key                    :string
-#  otp_counter                       :integer          default(1)
+#  otp_counter                       :integer
 #  confirmed_not_spam                :boolean          default(FALSE), not null
 #  comments_count                    :integer          default(0), not null
 #  info_requests_count               :integer          default(0), not null
@@ -38,6 +38,10 @@
 #  user_messages_count               :integer          default(0), not null
 #  status_update_count               :integer          default(0), not null
 #  last_sign_in_at                   :datetime
+#  otp_last_used_at                  :integer
+#  otp_backup_codes                  :string           default([]), is an Array
+#  otp_enabled_at                    :datetime
+#  otp_backup_codes_generated_at     :datetime
 #
 
 FactoryBot.define do

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -22,7 +22,7 @@
 #  can_make_batch_requests           :boolean          default(FALSE), not null
 #  otp_enabled                       :boolean          default(FALSE), not null
 #  otp_secret_key                    :string
-#  otp_counter                       :integer          default(1)
+#  otp_counter                       :integer
 #  confirmed_not_spam                :boolean          default(FALSE), not null
 #  comments_count                    :integer          default(0), not null
 #  info_requests_count               :integer          default(0), not null
@@ -38,6 +38,10 @@
 #  user_messages_count               :integer          default(0), not null
 #  status_update_count               :integer          default(0), not null
 #  last_sign_in_at                   :datetime
+#  otp_last_used_at                  :integer
+#  otp_backup_codes                  :string           default([]), is an Array
+#  otp_enabled_at                    :datetime
+#  otp_backup_codes_generated_at     :datetime
 #
 
 # If sample data has been loaded you can log in as any of these users with their

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,7 +22,7 @@
 #  can_make_batch_requests           :boolean          default(FALSE), not null
 #  otp_enabled                       :boolean          default(FALSE), not null
 #  otp_secret_key                    :string
-#  otp_counter                       :integer          default(1)
+#  otp_counter                       :integer
 #  confirmed_not_spam                :boolean          default(FALSE), not null
 #  comments_count                    :integer          default(0), not null
 #  info_requests_count               :integer          default(0), not null
@@ -38,6 +38,10 @@
 #  user_messages_count               :integer          default(0), not null
 #  status_update_count               :integer          default(0), not null
 #  last_sign_in_at                   :datetime
+#  otp_last_used_at                  :integer
+#  otp_backup_codes                  :string           default([]), is an Array
+#  otp_enabled_at                    :datetime
+#  otp_backup_codes_generated_at     :datetime
 #
 
 require 'spec_helper'

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -980,6 +980,16 @@ RSpec.describe User do
         user.valid?
         expect(user.otp_counter).to eq(counter + 1)
       end
+
+      it 'does not touch the otp_counter for a TOTP user' do
+        user = FactoryBot.build(:user)
+        user.enable_otp
+        user.otp_counter = nil
+        user.require_otp = true
+        user.entered_otp_code = user.otp_code
+        user.valid?
+        expect(user.otp_counter).to be_nil
+      end
     end
 
     context 'with otp disabled' do
@@ -1019,15 +1029,7 @@ RSpec.describe User do
       expect(user.otp_enabled?).to eq(false)
     end
 
-    it 'requires an otp_counter to be enabled' do
-      attrs = { otp_enabled: true,
-                otp_secret_key: '123',
-                otp_counter: nil }
-      user = User.new(attrs)
-      expect(user.otp_enabled?).to eq(false)
-    end
-
-    it 'requires an otp_enabled to be true to be enabled' do
+    it 'requires otp_enabled to be true to be enabled' do
       attrs = { otp_enabled: false,
                 otp_secret_key: '123',
                 otp_counter: 1 }
@@ -1035,12 +1037,78 @@ RSpec.describe User do
       expect(user.otp_enabled?).to eq(false)
     end
 
-    it 'requires otp_enabled, otp_secret_key and otp_counter to be enabled' do
+    it 'is true for a HOTP user (counter present)' do
       attrs = { otp_enabled: true,
                 otp_secret_key: '123',
                 otp_counter: 1 }
       user = User.new(attrs)
       expect(user.otp_enabled?).to eq(true)
+    end
+
+    it 'is true for a TOTP user (counter nil)' do
+      attrs = { otp_enabled: true,
+                otp_secret_key: '123',
+                otp_counter: nil }
+      user = User.new(attrs)
+      expect(user.otp_enabled?).to eq(true)
+    end
+  end
+
+  describe '#hotp?' do
+    it 'is true when otp is enabled and a counter is set' do
+      user = User.new(otp_enabled: true,
+                      otp_secret_key: 'secret',
+                      otp_counter: 1)
+      expect(user.hotp?).to eq(true)
+    end
+
+    it 'is false when the counter is nil (TOTP state)' do
+      user = User.new(otp_enabled: true,
+                      otp_secret_key: 'secret',
+                      otp_counter: nil)
+      expect(user.hotp?).to eq(false)
+    end
+
+    it 'is false when otp is not enabled, regardless of counter' do
+      user = User.new(otp_enabled: false,
+                      otp_secret_key: 'secret',
+                      otp_counter: 1)
+      expect(user.hotp?).to eq(false)
+    end
+  end
+
+  describe '#totp?' do
+    it 'is true when otp is enabled, the counter is nil, and a secret is set' do
+      user = User.new(otp_enabled: true,
+                      otp_secret_key: 'secret',
+                      otp_counter: nil)
+      expect(user.totp?).to eq(true)
+    end
+
+    it 'is false when the counter is present (HOTP state)' do
+      user = User.new(otp_enabled: true,
+                      otp_secret_key: 'secret',
+                      otp_counter: 1)
+      expect(user.totp?).to eq(false)
+    end
+
+    it 'is false when otp is not enabled' do
+      user = User.new(otp_enabled: false,
+                      otp_secret_key: 'secret',
+                      otp_counter: nil)
+      expect(user.totp?).to eq(false)
+    end
+  end
+
+  describe '#otp_counter_based' do
+    it 'is true when the counter is set (HOTP)' do
+      user = User.new(otp_counter: 1)
+      expect(user.otp_counter_based).to eq(true)
+    end
+
+    it 'is false when the counter is nil (TOTP)' do
+      user = User.new(otp_counter: nil)
+      expect(user.otp_counter_based).to eq(false)
     end
   end
 
@@ -1116,9 +1184,9 @@ RSpec.describe User do
   end
 
   describe '#otp_counter' do
-    it 'defaults to 1' do
+    it 'defaults to nil' do
       user = User.new
-      expect(user.otp_counter).to eq(1)
+      expect(user.otp_counter).to be_nil
     end
 
     it 'can be set on initialization' do
@@ -1130,6 +1198,43 @@ RSpec.describe User do
       user = User.new
       user.otp_counter = 200
       expect(user.otp_counter).to eq(200)
+    end
+  end
+
+  describe '#otp_backup_codes' do
+    it 'is empty on a newly created user' do
+      user = FactoryBot.create(:user)
+      expect(user.otp_backup_codes).to eq([])
+    end
+
+    it 'is valid when both codes and timestamp are blank' do
+      user = FactoryBot.build(:user,
+                              otp_backup_codes: [],
+                              otp_backup_codes_generated_at: nil)
+      expect(user).to be_valid
+    end
+
+    it 'is valid when both codes and timestamp are set' do
+      user = FactoryBot.build(:user,
+                              otp_backup_codes: ['abc123'],
+                              otp_backup_codes_generated_at: Time.current)
+      expect(user).to be_valid
+    end
+
+    it 'is invalid when codes are set without a timestamp' do
+      user = FactoryBot.build(:user,
+                              otp_backup_codes: ['abc123'],
+                              otp_backup_codes_generated_at: nil)
+      expect(user).not_to be_valid
+      expect(user.errors[:otp_backup_codes]).not_to be_empty
+    end
+
+    it 'is invalid when a timestamp is set without codes' do
+      user = FactoryBot.build(:user,
+                              otp_backup_codes: [],
+                              otp_backup_codes_generated_at: Time.current)
+      expect(user).not_to be_valid
+      expect(user.errors[:otp_backup_codes]).not_to be_empty
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/9241

## What does this do?

Gets the database schema and models ready to support running HOTP and TOTP side-by-side via [active_model_otp](https://github.com/heapsource/active_model_otp).

Adds four new columns to the `users` table, `otp_last_used_at` for token reuse prevention, `otp_backup_codes` for backup codes, `otp_enabled_at` for tracking when OTP is enabled, and `otp_backup_codes_generated_at` for tracking when backup codes were last generated. `otp_last_used_at` and `otp_backup_codes` are both used by active_model_otp, the two timestamps will be populated during TOTP enrolment in a future PR.

Includes a data migration to set `otp_counter` to `null` for all users with `otp_enabled = false`, so that only legacy HOTP users have an `otp_counter` value, and everyone else can be treated as disabled TOTP users.

## Why was this needed?

Schema and model changes to lay the groundwork for TOTP two-factor authentication, which will use these columns during TOTP registration and verification.

## Implementation notes

The `otp_counter` is nullable in the database, so if we set everyone that has `otp_enabled = false` to have `otp_counter = null` then only legacy HOTP users will have a non-null `otp_counter` value. The active_model_otp gem checks `otp_counter_based` dynamically, so we override that method to check for the presence of `otp_counter`, which means that active_model_otp can work in either HOTP or TOTP mode, depending on whether the user is a legacy HOTP user or not.

## Notes to reviewer

There shouldn't be any user-facing impacts from these changes, HOTP should continue to work as before.

This PR should be able to be deployed and the migrations run before any further 2FA changes are landed.

<!-- [skip changelog] -->
