### PR TITLE
[#7966] Fix indexing of multiple filetype values

### DIFF
--- a/app/models/incoming_message/attachments.rb
+++ b/app/models/incoming_message/attachments.rb
@@ -121,11 +121,12 @@ module IncomingMessage::Attachments
     cached_attachment_text_clipped
   end
 
-  # Returns space separated list of file extensions of attachments to this
-  # message. Defaults to the normal extension for known mime type, otherwise
-  # uses other extensions.
+  # Returns an Array of file extensions of attachments to this message.
+  # Defaults to the normal extension for known mime type, otherwise uses other
+  # extensions.
   def get_present_file_extensions # rubocop:disable Naming/AccessorMethodName
     ret = {}
+
     get_attachments_for_display.each do |attachment|
       ext = AlaveteliFileTypes.mimetype_to_extension(attachment.content_type)
       if ext.nil? && !attachment.filename.nil?
@@ -133,7 +134,8 @@ module IncomingMessage::Attachments
       end
       ret[ext] = 1 unless ext.nil?
     end
-    ret.keys.join(" ")
+
+    ret.keys
   end
 
   def locked?

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -612,7 +612,7 @@ class InfoRequestEvent < ApplicationRecord
 
       incoming_message.get_present_file_extensions
     else
-      ''
+      []
     end
   end
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix indexing of multiple filetype values (Gareth Rees)
 * Add explicit Referrer-Policy header (Graeme Porteous)
 * Use Regexp rule when anonymising users to catch common name variants (Gareth
   Rees)

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -880,24 +880,35 @@ RSpec.describe InfoRequestEvent do
           with_message(/event type is 'response' but no incoming message for event/)
       end
 
-      it 'should return a blank string if there are no attachments' do
+      it 'returns an empty array if there are no attachments' do
         info_request = ire.info_request
-        expect(ire.send(:filetype)).to eq('')
+        expect(ire.send(:filetype)).to eq([])
       end
 
-      it 'should return a space separated list of the attachment file types' do
+      it 'returns an array with the attachment file type' do
         info_request = ire.info_request
         incoming = FactoryBot.create(:incoming_message, :with_pdf_attachment,
                                      info_request: info_request)
         ire.incoming_message = incoming
-        expect(ire.send(:filetype)).to eq('pdf')
+        expect(ire.send(:filetype)).to eq(%w[pdf])
+      end
+
+      it 'returns separate entries for each attachment type' do
+        info_request = ire.info_request
+        incoming = FactoryBot.create(
+          :incoming_message,
+          foi_attachments_factories: [[:pdf_attachment], [:rtf_attachment]],
+          info_request: info_request
+        )
+        ire.incoming_message = incoming
+        expect(ire.send(:filetype)).to eq(%w[pdf rtf])
       end
     end
 
     context 'not a response event' do
-      it 'should return a blank string' do
+      it 'returns an empty array' do
         ire = FactoryBot.create(:info_request_event, event_type: 'comment')
-        expect(ire.send(:filetype)).to eq('')
+        expect(ire.send(:filetype)).to eq([])
       end
     end
   end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7966 
Part of #8820

## What does this do?

Prior to this commit the filetypes value was a space-separated string, meaning that IncomingMessages with multiple attachments could not be searched using the `filetype:` prefix. This is due to a search of `filetype:pdf` not being an exact match of "pdf csv html" or whatever was indexed.

We must supply an array of values to the acts_as_xapian term so that Xapian can match against any of the filetypes present.

## Why was this needed?

Can only search attachments by filetype if only a single attachment type exists on a message.

## Implementation notes

Note that this will only correctly index messages received from this point on. Older messages will need to be reindexed manually.

## Notes to reviewer

Need to figure out a reindexing strategy (if we want to bother, given search engine updates) for the changelog. In most cases it would probably be okay to just query for affected events and mark them for reindexing, but WDTK scale is obviously more challenging. Open to suggestion.

```rb
# WDTK:
InfoRequestEvent.
  where(event_type: 'response').
  joins(incoming_message: :foi_attachments).
  where.not(foi_attachments: { url_part_number: 1 }). # Exclude main body part
  group('info_request_events.id').
  having('COUNT(DISTINCT foi_attachments.content_type) > 1'). # Problem occurs only when multiple attachment filetypes are present
  count.
  size
# => 994253
```

## Screenshots

<img width="887" height="644" alt="Screenshot 2026-05-12 at 16 55 17" src="https://github.com/user-attachments/assets/dc1529c9-dc4d-4cf5-bc96-8dfec5fd9447" />

<img width="1043" height="205" alt="Screenshot 2026-05-12 at 16 55 23" src="https://github.com/user-attachments/assets/30f19ae2-6c15-466a-843a-318cf78545bc" />

