### PR TITLE
Add 2FA admin section

### DIFF
--- a/app/controllers/admin/two_factor_controller.rb
+++ b/app/controllers/admin/two_factor_controller.rb
@@ -1,0 +1,20 @@
+# Admin-only summary of 2FA enrolment state across the user base.
+class Admin::TwoFactorController < AdminController
+  def show
+    @all_counts = counts_for(User)
+    @admin_counts = counts_for(User.with_role(:admin))
+    @hotp_users = User.with_hotp.
+      order(User.arel_table[:last_sign_in_at].desc.nulls_last)
+  end
+
+  private
+
+  def counts_for(scope)
+    {
+      total: scope.count,
+      none: scope.without_two_factor.count,
+      hotp: scope.with_hotp.count,
+      totp: scope.with_totp.count
+    }
+  end
+end

--- a/app/models/user/one_time_password.rb
+++ b/app/models/user/one_time_password.rb
@@ -8,6 +8,10 @@ module User::OneTimePassword
 
     attr_accessor :entered_otp_code
 
+    scope :without_two_factor, -> { where(otp_enabled: false) }
+    scope :with_hotp, -> { where(otp_enabled: true).where.not(otp_counter: nil) }
+    scope :with_totp, -> { where(otp_enabled: true, otp_counter: nil) }
+
     validate :verify_otp_code, if: :otp_enabled_and_required?
     validate :otp_backup_codes_paired_with_timestamp
 

--- a/app/views/admin/two_factor/show.html.erb
+++ b/app/views/admin/two_factor/show.html.erb
@@ -1,0 +1,70 @@
+<% @title = 'Two factor authentication' %>
+
+<div class="row">
+  <div class="span12">
+    <h1><%= @title %></h1>
+    <p>Enrolment state across the user base. HOTP is the legacy single-shared-code scheme; TOTP is authenticator-app based.</p>
+  </div>
+</div>
+
+<div class="row">
+  <div class="span8">
+    <table class="table table-condensed">
+      <thead>
+        <tr>
+          <th>Mode</th>
+          <th class="text-right">All users</th>
+          <th class="text-right">Admins</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% [[:none, 'No 2FA'], [:hotp, 'HOTP (legacy)'], [:totp, 'TOTP']].each do |key, label| %>
+          <tr>
+            <td><%= label %></td>
+            <td class="text-right"><%= number_with_delimiter(@all_counts[key]) %></td>
+            <td class="text-right"><%= number_with_delimiter(@admin_counts[key]) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+      <tfoot>
+        <tr>
+          <th>Total</th>
+          <th class="text-right"><%= number_with_delimiter(@all_counts[:total]) %></th>
+          <th class="text-right"><%= number_with_delimiter(@admin_counts[:total]) %></th>
+        </tr>
+      </tfoot>
+    </table>
+  </div>
+</div>
+
+<% if @hotp_users.any? %>
+  <div class="row">
+    <div class="span12">
+      <h2>HOTP users</h2>
+      <p>Users still on the legacy HOTP scheme, ordered by most recent sign-in.</p>
+
+      <table class="table table-striped table-condensed">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Last sign-in</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @hotp_users.each do |user| %>
+            <tr>
+              <td><%= link_to user.name, admin_user_path(user) %></td>
+              <td>
+                <% if user.last_sign_in_at %>
+                  <%= time_ago_in_words(user.last_sign_in_at) %> ago
+                <% else %>
+                  <span class="muted">never</span>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+<% end %>

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -67,6 +67,8 @@
               <li class="divider"></li>
 
               <li><%= link_to 'Tags', admin_tags_path(model_type: 'User') %></li>
+              <li class="divider"></li>
+              <li><%= link_to 'Two factor', admin_two_factor_path %></li>
             </ul>
           </li>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -604,6 +604,12 @@ Rails.application.routes.draw do
   end
   ####
 
+  #### Admin::TwoFactor controller
+  namespace :admin do
+    resource :two_factor, only: :show, controller: 'two_factor'
+  end
+  ####
+
   #### AdminPublicBody controller
   scope '/admin', :as => 'admin' do
     resources :bodies,

--- a/spec/controllers/admin/two_factor_controller_spec.rb
+++ b/spec/controllers/admin/two_factor_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+RSpec.describe Admin::TwoFactorController do
+  before(:each) { basic_auth_login(@request) }
+
+  describe 'GET #show' do
+    let!(:hotp_user)  { FactoryBot.create(:user, :enable_otp) }
+    let!(:totp_user)  { FactoryBot.create(:user, :enable_totp) }
+    let!(:hotp_admin) { FactoryBot.create(:admin_user, :enable_otp) }
+    let!(:totp_admin) { FactoryBot.create(:admin_user, :enable_totp) }
+
+    it 'returns a successful response' do
+      get :show
+      expect(response).to be_successful
+    end
+
+    it 'renders the show template' do
+      get :show
+      expect(response).to render_template(:show)
+    end
+
+    it 'counts HOTP and TOTP users across all users' do
+      get :show
+      expect(assigns[:all_counts]).to include(hotp: 2, totp: 2)
+    end
+
+    it 'counts HOTP and TOTP users scoped to admins' do
+      get :show
+      expect(assigns[:admin_counts]).to include(hotp: 1, totp: 1)
+    end
+
+    it 'assigns the HOTP user cohort' do
+      get :show
+      expect(assigns[:hotp_users]).to match_array([hotp_user, hotp_admin])
+    end
+
+    it 'orders HOTP users by last_sign_in_at desc with nils last' do
+      hotp_admin.update!(last_sign_in_at: 1.day.ago)
+      hotp_user.update!(last_sign_in_at: 1.year.ago)
+      never = FactoryBot.create(:user, :enable_otp, last_sign_in_at: nil)
+
+      get :show
+      expect(assigns[:hotp_users].map(&:id)).
+        to eq([hotp_admin.id, hotp_user.id, never.id])
+    end
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -97,6 +97,13 @@ FactoryBot.define do
       after(:build, &:enable_otp)
     end
 
+    trait :enable_totp do
+      after(:build) do |user|
+        user.enable_otp
+        user.otp_counter = nil
+      end
+    end
+
     trait :unconfirmed do
       email_confirmed { false }
     end


### PR DESCRIPTION
Gives admins an overview of how many users have no 2FA vs HOTP vs TOTP, and also gives a list of HOTP users with how recently they've signed in. Should be useful to monitor the HOTP -> TOTP migration.

Part of https://github.com/mysociety/alaveteli/issues/9241

<img width="816" height="517" alt="image" src="https://github.com/user-attachments/assets/8ff5be9b-d3d1-419f-a7e4-423acaa41edf" />


<!-- [skip changelog] -->
