### PR TITLE
Stop relying on contributor order in update_contributors spec

### DIFF
--- a/spec/controllers/alaveteli_pro/projects_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/projects_controller_spec.rb
@@ -591,7 +591,7 @@ RSpec.describe AlaveteliPro::ProjectsController, type: :controller do
         format: :turbo_stream
       expect(assigns(:contributor_ids)).to_not include(contributor2.id)
       project.contributors.reload
-      expect(project.contributors).to eq([contributor1, contributor2])
+      expect(project.contributors).to contain_exactly(contributor1, contributor2)
     end
 
     it 'renders the edit_contributors template' do


### PR DESCRIPTION
Refs #9216.

`has_many :through` doesn't promise an order, so `eq([contributor1, contributor2])` was flipping when the rows came back in the other order, which is what @garethrees was seeing in the transient failure. Swapped to `contain_exactly`, matching what the assigns checks earlier in the same describe block already do.