### PR TITLE
Move setSelect into the Jcrop init callback on the photo crop page

### DIFF
--- a/app/assets/javascripts/profile_photo.js
+++ b/app/assets/javascripts/profile_photo.js
@@ -28,9 +28,11 @@
       bounds = jcrop_api.getBounds();
       boundx = bounds[0];
       boundy = bounds[1];
+      // Has to live inside the init callback - jcrop_api isn't set yet
+      // outside it, and calling setSelect on undefined was killing the
+      // default crop box (#9196).
+      jcrop_api.setSelect([ l, t, initial, initial ]);
     });
-
-    jcrop_api.setSelect([ l, t, initial, initial ]);
 
     function showPreview(coords)
     {


### PR DESCRIPTION
Closes #9196.

`jcrop_api` only gets assigned inside the Jcrop init callback (`function(){ jcrop_api = this; ... }`), but `setSelect` was being called the next line down, before the callback had run. Browsers were throwing `Cannot read properties of undefined (reading 'setSelect')` and the default crop selection wasn't drawn, so users had to know to drag and select before they could save (this is exactly what @FOIMonkey hit).

Move the `setSelect` call inside the callback so it runs after the api object exists.