### PR TITLE
Mask attachment HTML text nodes only, not href/src attributes

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -47,7 +47,7 @@ class AttachmentsController < ApplicationController
       }
     )
 
-    html = @incoming_message.apply_masks(html, response.media_type)
+    html = mask_text_nodes(html, response.media_type)
 
     render html: html.html_safe
   end
@@ -181,6 +181,20 @@ class AttachmentsController < ApplicationController
     # when cached in cache_attachments above
     AlaveteliFileTypes.filename_to_mimetype(params[:file_name]) ||
       'application/octet-stream'
+  end
+
+  # Apply censor / email masks to the user-visible text in the rendered
+  # attachment HTML but not to attribute values like href and src, so the
+  # download link and the PDF viewer iframe URL don't get rewritten and 404
+  # (see #9139).
+  def mask_text_nodes(html, content_type)
+    doc = Nokogiri::HTML.parse(html)
+    doc.traverse do |node|
+      next unless node.text? && node.content.present?
+
+      node.content = @incoming_message.apply_masks(node.content, content_type)
+    end
+    doc.to_html
   end
 
   def attachment_is_public?


### PR DESCRIPTION
Closes #9139.

`apply_masks` runs as plain-text substitution, so it was rewriting parts of `href` and `src` values inside the rendered HTML when a censor rule matched a word in the request's `url_title`. The actual `RecordNotFound` @FOIMonkey saw on the PDF viewer was the iframe fetching the censored attachment URL.

Switched `show_as_html` to walk the rendered HTML with Nokogiri and apply the masks only to text-node content; attribute values get left alone so the iframe and download link stay valid.

The masking still happens for genuine text content (`@info_request.title` in the prefix partial, anything the text adapters extract from the document body), so the redaction story isn't changed for the user-facing parts.