### PR TITLE
Pick up replacement file's content_type before regenerating filename

### DIFF
--- a/app/models/foi_attachment/replaceable.rb
+++ b/app/models/foi_attachment/replaceable.rb
@@ -97,6 +97,15 @@ module FoiAttachment::Replaceable
   private
 
   def handle_replacements
+    if replacing? && replacement_file_changed? &&
+       replacement_file.respond_to?(:content_type) &&
+       replacement_file.content_type.present?
+      # Pick up the replacement's MIME type before we run filename= below;
+      # otherwise the old content_type tacks the original extension onto
+      # the new filename (e.g. .tsv becomes .tsv.docx, see #9016).
+      self.content_type = replacement_file.content_type
+    end
+
     if replacing? || (replaced? && replaced_filename_changed?)
       self.filename = replaced_filename.presence ||
                       replacement_file&.original_filename ||

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -1442,8 +1442,12 @@ RSpec.describe FoiAttachment do
 
       it 'sets the replaced filename' do
         subject
-        # FIXME: See https://github.com/mysociety/alaveteli/issues/9016
-        expect(foi_attachment.reload.filename).to eq('redacted.png.txt')
+        expect(foi_attachment.reload.filename).to eq('redacted.png')
+      end
+
+      it 'updates the content_type to match the replacement file' do
+        subject
+        expect(foi_attachment.reload.content_type).to eq('image/png')
       end
 
       it 'sets the replaced reason' do


### PR DESCRIPTION
Closes #9016.

@garethrees flagged that replacing a `.docx` attachment with a `.tsv` was ending up as `.tsv.docx`. `FoiAttachment#filename=` reads the current `content_type` to decide whether to append an extension, but at the point `handle_replacements` calls it, `content_type` is still the original `.docx` mime, so the new `.tsv` filename gets `.docx` tacked on.

Sync `content_type` from the replacement `UploadedFile` before the `self.filename = ...` line runs, so `filename=` sees the new mime and doesn't try to append the old extension.

The existing `#replace!` 'replacing with file' spec already tracked this as a FIXME pointing at #9016 (expecting `redacted.png.txt`); flipped that to assert the correct `redacted.png` and added a small assertion that the new `content_type` is the replacement's.