### PR TITLE
Move setSelect into the Jcrop init callback

### DIFF
--- a/app/assets/javascripts/profile_photo.js
+++ b/app/assets/javascripts/profile_photo.js
@@ -28,9 +28,8 @@
       bounds = jcrop_api.getBounds();
       boundx = bounds[0];
       boundy = bounds[1];
+      jcrop_api.setSelect([ l, t, initial, initial ]);
     });
-
-    jcrop_api.setSelect([ l, t, initial, initial ]);
 
     function showPreview(coords)
     {

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Fix Jcrop init race so the initial selection appears on the profile photo
+  crop page (Charlie Tonneslan)
 * Fix email change confirmation which wasn't bound to confirmed target address
   (Graeme Porteous)
 * Ensure only readable requests can be added to a Project (Gareth Rees)


### PR DESCRIPTION
## Relevant issue(s)

Closes #9196.

## What does this do?

Moves the `jcrop_api.setSelect(...)` call into the Jcrop init callback so the initial centred crop box appears again on the profile photo crop page.

## Why was this needed?

Jcrop's init is async, so on a fresh load `jcrop_api` was still undefined when `setSelect` ran on the next line, throwing `Uncaught TypeError: Cannot read properties of undefined (reading 'setSelect')`. Drag-select still worked, which is why the bug was minor in practice, but the default selection was missing.

## Implementation notes

Just moved the single line inside the callback that already assigns `jcrop_api = this`.

## Screenshots

n/a, console-only

## Notes to reviewer

Added a CHANGES.md entry under develop. Happy to drop the author attribution if you prefer a different format.