### PR TITLE
Add explicit Referrer-Policy header

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -18,6 +18,9 @@
   # https://w3c.github.io/webappsec/specs/content-security-policy/
   config.csp = SecureHeaders::OPT_OUT
 
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Referrer-Policy
+  config.referrer_policy = 'strict-origin-when-cross-origin'
+
   # https://www.nwebsec.com/HttpHeaders/SecurityHeaders/XDownloadOptions
   config.x_download_options = SecureHeaders::OPT_OUT
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Add explicit Referrer-Policy header (Graeme Porteous)
 * Fix email change confirmation which wasn't bound to confirmed target address
   (Graeme Porteous)
 * Ensure only readable requests can be added to a Project (Gareth Rees)


### PR DESCRIPTION
The secure_headers gem defaults to origin-when-cross-origin which can cause browsers to send a null Origin header on form submissions when there is any scheme, host, or port mismatch. Rails then rejects the request with ActionController::InvalidAuthenticityToken.

Setting strict-origin-when-cross-origin explicitly avoids this while still protecting referrer information on cross-origin requests.

