### PR TITLE
Fix pro authority search not displaying results

### DIFF
--- a/app/assets/javascripts/alaveteli_pro/authority_select.js
+++ b/app/assets/javascripts/alaveteli_pro/authority_select.js
@@ -72,7 +72,11 @@
       maxItems: 1,
       openOnFocus: false,
       render: {
-        option: function(body, escape) { return body.html; }
+        option: function(body, escape) {
+          return $(body.html).filter(function() {
+            return this.nodeType === Node.ELEMENT_NODE;
+          })[0].outerHTML;
+        }
       },
       onItemAdd: function(value, $item) {
         updateSalutation($item);


### PR DESCRIPTION
## What does this do?

Fix pro authority search not displaying results

## Why was this needed?

Rails' annotate_rendered_view_with_filenames wraps render_to_string output with HTML comment nodes. Selectize's render method does $(body.html) then returns html[0], which was the Comment node instead of the actual element. The dropdown rendered invisible content causing results to never display.

Filter the jQuery parse result to only Element nodes before returning outerHTML so Selectize always receives the actual element.

## Implementation notes

This was only an issue in development 

<hr>

[skip changelog]