### PR TITLE
Upgrade to jQuery v3 

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -1,5 +1,5 @@
 // ...
-//= require jquery
+//= require jquery3
 //= require jquery-ui/widgets/tabs
 //= require jquery-ui/widgets/sortable
 //= require jquery-ui/effects/effect-highlight

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,5 @@
 // ...
-//= require jquery
+//= require jquery3
 //= require jquery_ujs
 //= require jquery-ui/widgets/datepicker
 //= require jquery-ui/position

--- a/app/assets/javascripts/general.js
+++ b/app/assets/javascripts/general.js
@@ -63,7 +63,7 @@ $('#standard-popup .js-popup__close').click(function() {
   // Chrome workaround
   $("widgetbox").mouseup(function() {
     // Prevent further mouseup intervention
-    $this.unbind("mouseup");
+    $this.off("mouseup");
     return false;
   });
 

--- a/app/assets/javascripts/stats-graphs.js
+++ b/app/assets/javascripts/stats-graphs.js
@@ -87,7 +87,7 @@ $(document).ready(function() {
         dataset,
         options);
 
-        graph_div.bind("plotclick", function(event, pos, item) {
+        graph_div.on("plotclick", function(event, pos, item) {
           var i, pb, url, name;
           if (item) {
             i = item.dataIndex;
@@ -114,7 +114,7 @@ $(document).ready(function() {
           }).appendTo("body").fadeIn(200);
         }
 
-        graph_div.bind("plothover", function (event, pos, item) {
+        graph_div.on("plothover", function (event, pos, item) {
           var escapedName, x, y;
           if (item) {
             if (previousPoint != item.dataIndex) {

--- a/app/assets/javascripts/wizard.js
+++ b/app/assets/javascripts/wizard.js
@@ -301,13 +301,13 @@
       $(this).data("refusalWizard", instance);
       return $(this);
     } else if (!instance) {
-      $.error(
+      throw new Error(
         "Plugin must be initialised before using method: " + methodOrOptions
       );
     } else if (methodOrOptions.indexOf("_") == 0) {
-      $.error("Method " + methodOrOptions + " is private!");
+      throw new Error("Method " + methodOrOptions + " is private!");
     } else {
-      $.error("Method " + methodOrOptions + " does not exist.");
+      throw new Error("Method " + methodOrOptions + " does not exist.");
     }
   };
 
@@ -360,16 +360,16 @@
   // work out what hashes we're looking for
   var IDs = [];
 
-  $("#help_unhappy h2[ID]").each(function(){ 
-    IDs.push(this.id); 
+  $("#help_unhappy h2[ID]").each(function(){
+    IDs.push(this.id);
   });
-  
+
   function checkHashes(hash) {
     if(IDs.includes(hash.slice(1))) {
       $(hash + ' + details' ).attr('open', '').addClass('flash');
     }
   }
- 
+
   // show unrolled details tag if they've come to the page with a known location hash
   checkHashes(window.location.hash);
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Upgrade jQuery from 1.12.4 to 3.7.1 (Graeme Porteous)
 * Add explicit Referrer-Policy header (Graeme Porteous)
 * Use Regexp rule when anonymising users to catch common name variants (Gareth
   Rees)

--- a/vendor/assets/javascripts/alaveteli_pro/selectize.js
+++ b/vendor/assets/javascripts/alaveteli_pro/selectize.js
@@ -1377,7 +1377,7 @@
 	
 			$input.attr('tabindex', -1).hide().after(self.$wrapper);
 	
-			if ($.isArray(settings.items)) {
+			if (Array.isArray(settings.items)) {
 				self.setValue(settings.items);
 				delete settings.items;
 			}
@@ -2205,7 +2205,7 @@
 				option      = self.options[results.items[i].id];
 				option_html = self.render('option', option);
 				optgroup    = option[self.settings.optgroupField] || '';
-				optgroups   = $.isArray(optgroup) ? optgroup : [optgroup];
+				optgroups   = Array.isArray(optgroup) ? optgroup : [optgroup];
 	
 				for (j = 0, k = optgroups && optgroups.length; j < k; j++) {
 					optgroup = optgroups[j];
@@ -2318,7 +2318,7 @@
 		addOption: function(data) {
 			var i, n, value, self = this;
 	
-			if ($.isArray(data)) {
+			if (Array.isArray(data)) {
 				for (i = 0, n = data.length; i < n; i++) {
 					self.addOption(data[i]);
 				}
@@ -2565,7 +2565,7 @@
 		 * @param {boolean} silent
 		 */
 		addItems: function(values, silent) {
-			var items = $.isArray(values) ? values : [values];
+			var items = Array.isArray(values) ? values : [values];
 			for (var i = 0, n = items.length; i < n; i++) {
 				this.isPending = (i < n - 1);
 				this.addItem(items[i], silent);
@@ -3441,7 +3441,7 @@
 						var arr = optionsMap[value][field_optgroup];
 						if (!arr) {
 							optionsMap[value][field_optgroup] = group;
-						} else if (!$.isArray(arr)) {
+						} else if (!Array.isArray(arr)) {
 							optionsMap[value][field_optgroup] = [arr, group];
 						} else {
 							arr.push(group);

--- a/vendor/assets/javascripts/dropit.js
+++ b/vendor/assets/javascripts/dropit.js
@@ -75,7 +75,7 @@
     } else if (typeof method === 'object' || !method) {
       return methods.init.apply(this, arguments);
     } else {
-      $.error( 'Method "' +  method + '" does not exist in dropit plugin!');
+      throw new Error( 'Method "' +  method + '" does not exist in dropit plugin!');
     }
 
   };

--- a/vendor/assets/javascripts/jquery.flot.errorbars.js
+++ b/vendor/assets/javascripts/jquery.flot.errorbars.js
@@ -302,7 +302,7 @@ shadowSize and lineWidth are derived as well from the points series.
             if (err.upperCap == '-'){
                 if (err.err=='x') drawPath(ctx, [[upper,y - radius],[upper,y + radius]] );
                 else drawPath(ctx, [[x - radius,upper],[x + radius,upper]] );
-            } else if ($.isFunction(err.upperCap)){
+            } else if (typeof err.upperCap === 'function'){
                 if (err.err=='x') err.upperCap(ctx, upper, y, radius);
                 else err.upperCap(ctx, x, upper, radius);
             }
@@ -312,7 +312,7 @@ shadowSize and lineWidth are derived as well from the points series.
             if (err.lowerCap == '-'){
                 if (err.err=='x') drawPath(ctx, [[lower,y - radius],[lower,y + radius]] );
                 else drawPath(ctx, [[x - radius,lower],[x + radius,lower]] );
-            } else if ($.isFunction(err.lowerCap)){
+            } else if (typeof err.lowerCap === 'function'){
                 if (err.err=='x') err.lowerCap(ctx, lower, y, radius);
                 else err.lowerCap(ctx, x, lower, radius);
             }

--- a/vendor/assets/javascripts/jquery.flot.js
+++ b/vendor/assets/javascripts/jquery.flot.js
@@ -1701,7 +1701,7 @@ Licensed under the MIT license.
                 };
             }
 
-            if ($.isFunction(opts.tickFormatter))
+            if (typeof opts.tickFormatter === 'function')
                 axis.tickFormatter = function (v, axis) { return "" + opts.tickFormatter(v, axis); };
 
             if (opts.alignTicksWithAxis != null) {
@@ -1748,7 +1748,7 @@ Licensed under the MIT license.
             if (oticks == null || (typeof oticks == "number" && oticks > 0))
                 ticks = axis.tickGenerator(axis);
             else if (oticks) {
-                if ($.isFunction(oticks))
+                if (typeof oticks === 'function')
                     // generate the ticks
                     ticks = oticks(axis);
                 else
@@ -1872,7 +1872,7 @@ Licensed under the MIT license.
             // draw markings
             var markings = options.grid.markings;
             if (markings) {
-                if ($.isFunction(markings)) {
+                if (typeof markings === 'function') {
                     axes = plot.getAxes();
                     // xmin etc. is backwards compatibility, to be
                     // removed in the future
@@ -2652,7 +2652,7 @@ Licensed under the MIT license.
             // Sort the legend using either the default or a custom comparator
 
             if (options.legend.sorted) {
-                if ($.isFunction(options.legend.sorted)) {
+                if (typeof options.legend.sorted === 'function') {
                     entries.sort(options.legend.sorted);
                 } else if (options.legend.sorted == "reverse") {
                 	entries.reverse();


### PR DESCRIPTION
## What does this do?

Upgrade to jQuery v3 

## Why was this needed?

The sprockets manifests required 'jquery' which resolved to jQuery 1.12.4. That version uses setAttribute(eventName, "t") for feature detection, which triggers CSP script-src-attr violations.

jQuery 3.4+ removed this feature detection. Switch to 'jquery3' which resolves to jQuery 3.7.1 shipped by jquery-rails 4.6.1.
