### PR TITLE
Remove user name from confirm_login email

### DIFF
--- a/app/views/user_mailer/confirm_login.text.erb
+++ b/app/views/user_mailer/confirm_login.text.erb
@@ -1,5 +1,3 @@
-<%= raw @name %>,
-
 <%= _('Please click on the link below to confirm your email ' \
       'address.') %> <%= raw @reasons[:email] %>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Remove user name from account confirmation email to guard against spam
+  reputation issues (Gareth Rees)
 * Remove 720p and 1080p from default spam terms, as these are too generic and
   can easily be used in legitimate requests (Gareth Rees)
 * Improve search indexing of Microsoft Office, Open Office, RTF and CSV


### PR DESCRIPTION
If spam users register for the service with…

* A spam `User#name` (e.g. "buy my warez")
* A geniune `User#email` of a major email provider

…the "confirm your account" email is sent to the email address. Major email providers see that we're sending emails that include spam terms and may downrank the domain.

We're not losing much by removing the user's name in this case.

We also use this template for password change confirmation, but again the name is not that critical there.

It is a nice sense check for the user as they'd notice if the name was not their own, but I think the domain reputation issue is more critical.

Mentioned by @laurentS as a thing that actually happened on their site.
