### PR TITLE
Update default spam terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /config/newrelic.yml
 /config/rails_env.rb
 /config/sidekiq.yml
+/config/spam_terms.txt
 /config/storage.yml
 /config/user_spam_scorer.yml
 /config/xapian.yml

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Remove 720p and 1080p from default spam terms, as these are too generic and
+  can easily be used in legitimate requests (Gareth Rees)
 * Improve search indexing of Microsoft Office, Open Office, RTF and CSV
   attachments (Gareth Rees)
 * Fix indexing of multiple filetype values (Gareth Rees)

--- a/lib/alaveteli_spam_term_checker.rb
+++ b/lib/alaveteli_spam_term_checker.rb
@@ -17,8 +17,6 @@ class AlaveteliSpamTermChecker
     /films?-?hd/i,
     /\[DVDscr\]/i,
     /W@tch/i,
-    /720p/i,
-    /1080p/i,
     /MEGA.TV/i,
     /1080.HD/i,
     /\[Online-Free\]/i,


### PR DESCRIPTION
Remove common video formats as these are too general and could be legitimate (e.g. requests around the resolution of CCTV cameras).

