### PR TITLE
[#8823] Delegate to `InfoRequest#apply_masks`

### DIFF
--- a/app/models/foi_attachment/maskable.rb
+++ b/app/models/foi_attachment/maskable.rb
@@ -3,6 +3,10 @@
 module FoiAttachment::Maskable
   extend ActiveSupport::Concern
 
+  included do
+    delegate :apply_masks, to: :info_request
+  end
+
   def masked?
     file.attached? && masked_at.present? && masked_at < Time.zone.now
   end
@@ -22,18 +26,5 @@ module FoiAttachment::Maskable
 
   def mask_later
     FoiAttachment::MaskJob.perform_later(self)
-  end
-
-  def apply_masks(text, content_type)
-    AlaveteliTextMasker.apply_masks(text, content_type, masks)
-  end
-
-  private
-
-  def masks
-    {
-      censor_rules: info_request.applicable_censor_rules,
-      masks: info_request.masks
-    }
   end
 end

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -83,6 +83,8 @@ class IncomingMessage < ApplicationRecord
   delegate :parts, to: :raw_email
   delegate :erased?, :ensure_not_erased!, to: :raw_email, prefix: :raw_email
 
+  delegate :apply_masks, to: :info_request
+
   # Given that there are in theory many info request events, a convenience
   # method for getting the response event.
   def response_event
@@ -157,12 +159,6 @@ class IncomingMessage < ApplicationRecord
   # when updating an IncomingMessage associated with the request
   def update_request
     info_request.update_last_public_response_at
-  end
-
-  def apply_masks(text, content_type)
-    mask_options = { censor_rules: info_request.applicable_censor_rules,
-                     masks: info_request.masks }
-    AlaveteliTextMasker.apply_masks(text, content_type, mask_options)
   end
 
   # Removes anything cached about the object in the database, and saves

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -67,7 +67,7 @@ class OutgoingMessage < ApplicationRecord
            inverse_of: :outgoing_message,
            dependent: :destroy
 
-  delegate :expire, :log_event, to: :info_request
+  delegate :apply_masks, :expire, :log_event, to: :info_request
   delegate :public_body, to: :info_request, private: true, allow_nil: true
 
   after_initialize :set_default_letter
@@ -196,10 +196,6 @@ class OutgoingMessage < ApplicationRecord
 
   def raw_body
     read_attribute(:body)
-  end
-
-  def apply_masks(text, content_type)
-    info_request.apply_masks(text, content_type)
   end
 
   # Used to give warnings when writing new messages


### PR DESCRIPTION
The IncomingMessage, OutgoingMessage and FoiAttachment apply_masks methods are all essentially replicating the InfoRequest version, so just delegate to that

Prep for #8823 

[skip changelog]
