### PR TITLE
2FA gate checks for sign-in and disabling

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -169,6 +169,23 @@ class ApplicationController < ActionController::Base
     )
   end
 
+  # Establish the session and send the user on to where they were heading.
+  def complete_sign_in(user, post_redirect:, remember_me:)
+    sign_in(user, remember_me: remember_me)
+
+    if modal_dialog?
+      render template: 'users/sessions/show'
+    elsif post_redirect
+      do_post_redirect(post_redirect, user)
+    else
+      redirect_to frontpage_path
+    end
+  end
+
+  def modal_dialog?
+    params[:modal].to_i != 0
+  end
+
   # Logout form
   def clear_session_credentials
     session[:admin_id] = nil
@@ -181,6 +198,7 @@ class ApplicationController < ActionController::Base
     session[:change_password_post_redirect_id] = nil
     session[:post_redirect_token] = nil
     session[:ttl] = nil
+    PendingTwoFactorSignIn.new(session).clear
   end
 
   def render_exception(exception)

--- a/app/controllers/one_time_passwords_controller.rb
+++ b/app/controllers/one_time_passwords_controller.rb
@@ -47,6 +47,15 @@ class OneTimePasswordsController < ApplicationController
   end
 
   def destroy
+    if @user.totp?
+      return render :destroy_confirmation if params[:otp_code].nil?
+
+      unless @user.authenticate_otp(params[:otp_code])
+        flash.now[:error] = _('Invalid one time password')
+        return render :destroy_confirmation
+      end
+    end
+
     @user.disable_otp
 
     if @user.save

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -486,13 +486,9 @@ class UserController < ApplicationController
     params.require(key).permit(:name, :email, :password, :password_confirmation)
   end
 
-  def is_modal_dialog
-    params[:modal].to_i != 0
-  end
-
   # when logging in through a modal iframe, don't display chrome around the content
   def select_layout
-    is_modal_dialog ? 'no_chrome' : 'default'
+    modal_dialog? ? 'no_chrome' : 'default'
   end
 
   # Decide where we are going to redirect back to after signin/signup,

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -42,13 +42,19 @@ class Users::SessionsController < UserController
         end && return
       end
 
-      sign_in(@user_signin, remember_me: params[:remember_me].present?)
-
-      if is_modal_dialog
-        render template: 'users/sessions/show'
-      else
-        do_post_redirect @post_redirect, @user_signin
+      if @user_signin.totp?
+        PendingTwoFactorSignIn.new(session).start(
+          user: @user_signin,
+          remember_me: params[:remember_me].present?,
+          post_redirect: @post_redirect
+        )
+        redirect_to signin_two_factor_path(modal: params[:modal].presence)
+        return
       end
+
+      complete_sign_in(@user_signin,
+                       post_redirect: @post_redirect,
+                       remember_me: params[:remember_me].present?)
     else
       send_confirmation_mail @user_signin
     end

--- a/app/controllers/users/two_factor_challenges_controller.rb
+++ b/app/controllers/users/two_factor_challenges_controller.rb
@@ -1,0 +1,48 @@
+# 2FA gate for sign-in. The user has passed the password check but is not signed
+# in yet. The pending sign-in lives in the session (see PendingTwoFactorSignIn).
+# A correct authenticator code completes the sign-in and sends the user on to
+# their original destination.
+class Users::TwoFactorChallengesController < UserController
+  before_action :load_pending_sign_in
+
+  rate_limit to: 5, within: 1.minute,
+             by: -> { @pending.user_id },
+             with: -> { handle_rate_limit },
+             only: :create
+
+  def new
+  end
+
+  def create
+    if @pending.user.authenticate_otp(params[:otp_code])
+      complete_two_factor_sign_in
+    else
+      flash.now[:error] = _('Invalid one time password')
+      render :new
+    end
+  end
+
+  private
+
+  def load_pending_sign_in
+    @pending = PendingTwoFactorSignIn.new(session)
+    return if @pending.active?
+
+    @pending.clear
+    redirect_to signin_path
+  end
+
+  def complete_two_factor_sign_in
+    complete_sign_in(
+      @pending.user,
+      post_redirect: @pending.post_redirect,
+      remember_me: @pending.remember_me
+    )
+  end
+
+  def handle_rate_limit
+    flash.now[:error] =
+      _('Too many attempts. Please wait a minute and try again.')
+    render :new
+  end
+end

--- a/app/models/pending_two_factor_sign_in.rb
+++ b/app/models/pending_two_factor_sign_in.rb
@@ -1,0 +1,52 @@
+# Wraps the session state for a sign-in that has passed the password check but
+# still needs a second factor.
+class PendingTwoFactorSignIn
+  TTL = 5.minutes
+
+  def initialize(session)
+    @session = session
+  end
+
+  def start(user:, remember_me:, post_redirect:)
+    @session[:pending_2fa_user_id] = user.id
+    @session[:pending_2fa_started_at] = Time.zone.now.to_i
+    @session[:pending_2fa_remember_me] = remember_me
+    @session[:pending_2fa_post_redirect_token] = post_redirect.token
+  end
+
+  def user_id
+    @session[:pending_2fa_user_id]
+  end
+
+  def remember_me
+    @session[:pending_2fa_remember_me]
+  end
+
+  def user
+    @user ||= User.find_by(id: user_id) if user_id
+  end
+
+  def post_redirect
+    token = @session[:pending_2fa_post_redirect_token]
+    @post_redirect ||= PostRedirect.find_by(token: token) if token
+  end
+
+  # started_at is stored as an epoch integer so it survives the JSON session
+  # round-trip as a number rather than a string that needs coercing back.
+  def expired?
+    started_at = @session[:pending_2fa_started_at]
+    started_at.nil? || started_at < TTL.ago.to_i
+  end
+
+  # A challenge is only live for a still-TOTP user inside the TTL window.
+  def active?
+    user&.totp? ? !expired? : false
+  end
+
+  def clear
+    %i[pending_2fa_user_id
+       pending_2fa_started_at
+       pending_2fa_remember_me
+       pending_2fa_post_redirect_token].each { |key| @session.delete(key) }
+  end
+end

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -110,7 +110,7 @@
               'width': 950,
               'height': 400,
               'type': 'iframe',
-              'href': '/<%= AlaveteliLocalization.locale %>/profile/sign_in?modal=1',
+              'href': '<%= signin_path(modal: 1) %>',
               'onClosed': function() {
                 // modal_signin_successful variable set by modal dialog box
                 if (typeof modal_signin_successful != 'undefined' ) {

--- a/app/views/one_time_passwords/_code_form.html.erb
+++ b/app/views/one_time_passwords/_code_form.html.erb
@@ -1,4 +1,8 @@
-<%= form_with model: @enrolment, url: form_url, local: true do |f| %>
+<%# locals: (model:, form_url:, form_method: :post, submit_label: _('Verify')) %>
+<%= form_with model: model,
+              url: form_url,
+              method: form_method,
+              local: true do |f| %>
   <p>
     <%= f.label :otp_code,
                 _('Code from your authenticator app'),
@@ -12,6 +16,6 @@
   </p>
 
   <div class="form_button">
-    <%= f.submit local_assigns.fetch(:submit_label, _('Verify')) %>
+    <%= f.submit submit_label %>
   </div>
 <% end %>

--- a/app/views/one_time_passwords/destroy_confirmation.html.erb
+++ b/app/views/one_time_passwords/destroy_confirmation.html.erb
@@ -1,0 +1,25 @@
+<% @title = _('Disable two factor authentication') %>
+
+<h1><%= @title %></h1>
+
+<div>
+  <p>
+    <%= _('Disabling two factor authentication will remove the extra ' \
+          'protection from your account. Anyone who knows your password ' \
+          'will be able to use your account without further checks.') %>
+  </p>
+
+  <p>
+    <%= _('Enter a current code from your authenticator app to confirm.') %>
+  </p>
+
+  <%= render 'code_form',
+             model: false,
+             form_url: one_time_password_path,
+             form_method: :delete,
+             submit_label: _('Disable two factor authentication') %>
+
+  <p>
+    <%= link_to _('Cancel'), one_time_password_path %>
+  </p>
+</div>

--- a/app/views/one_time_passwords/new.html.erb
+++ b/app/views/one_time_passwords/new.html.erb
@@ -29,6 +29,7 @@
     </p>
 
     <%= render 'code_form',
+                model: @enrolment,
                 form_url: one_time_password_path,
                 submit_label: _('Enable two factor authentication') %>
   </li>

--- a/app/views/one_time_passwords/show.html.erb
+++ b/app/views/one_time_passwords/show.html.erb
@@ -34,11 +34,7 @@
 
     <ul class="one-time-password-actions not-for-print">
       <li class="one-time-password-actions__action-item action-item">
-        <% confirmation_msg = _('Are you sure you want to disable two ' \
-                                'factor authentication? Your account will ' \
-                                'be less secure.') %>
         <%= link_to one_time_password_path, :method => :delete,
-                                            :data => { :confirm => confirmation_msg },
                                             :class => 'action-item__action' do %>
           <%= _('Disable two factor authentication') %>
         <% end %>

--- a/app/views/users/two_factor_challenges/new.html.erb
+++ b/app/views/users/two_factor_challenges/new.html.erb
@@ -1,0 +1,14 @@
+<% @title = _('Two factor authentication') %>
+
+<h1><%= @title %></h1>
+
+<div>
+  <p>
+    <%= _('Enter a current code from your authenticator app to finish ' \
+          'signing in.') %>
+  </p>
+
+  <%= render 'one_time_passwords/code_form',
+             model: false,
+             form_url: signin_two_factor_path(modal: params[:modal].presence) %>
+</div>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,6 +22,13 @@ Rails.application.configure do
   config.consider_all_requests_local = true
   config.cache_store = :null_store
 
+  # Rate limiting reads and writes through the controller cache store, so give
+  # it a real in-memory store rather than the :null_store used for Rails.cache.
+  # Keep fragment/view caching switched off so rendered output is never reused
+  # between examples.
+  config.action_controller.cache_store = :memory_store
+  config.action_controller.perform_caching = false
+
   # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,6 +290,11 @@ Rails.application.routes.draw do
   match '/profile/sign_out' => 'users/sessions#destroy',
         :as => :signout,
         :via => :get
+  match '/profile/sign_in/two_factor' => 'users/two_factor_challenges#new',
+        :as => :signin_two_factor,
+        :via => :get
+  match '/profile/sign_in/two_factor' => 'users/two_factor_challenges#create',
+        :via => :post
   match '/profile/sign_up' => 'user#signup',
         :as => :signup, :via => :post
 

--- a/spec/controllers/one_time_passwords_controller_spec.rb
+++ b/spec/controllers/one_time_passwords_controller_spec.rb
@@ -382,7 +382,6 @@ RSpec.describe OneTimePasswordsController do
 
   describe 'DELETE #destroy' do
     it 'redirects to the sign-in page without a signed in user' do
-      user = FactoryBot.create(:user)
       delete :destroy
       expect(response).
         to redirect_to(signin_path(token: PostRedirect.last.token))
@@ -395,42 +394,124 @@ RSpec.describe OneTimePasswordsController do
       expect(assigns[:user]).to eq(user)
     end
 
-    it 'disables OTP for the user' do
-      user = FactoryBot.create(:user, :enable_hotp)
-      sign_in user
-      delete :destroy
-      expect(user.reload.otp_enabled?).to eq(false)
+    context 'for a TOTP-enabled user' do
+      let(:user) { FactoryBot.create(:user, :enable_totp) }
+      let(:valid_code) { user.otp_code }
+
+      before { sign_in user }
+
+      context 'with no code parameter (link click from show)' do
+        it 'renders the destroy_confirmation template' do
+          delete :destroy
+          expect(response).to render_template(:destroy_confirmation)
+        end
+
+        it 'does not disable two factor authentication' do
+          delete :destroy
+          expect(user.reload.otp_enabled?).to eq(true)
+        end
+
+        it 'does not show an error' do
+          delete :destroy
+          expect(flash[:error]).to be_blank
+        end
+      end
+
+      context 'with an empty code submitted' do
+        it 'renders the destroy_confirmation template' do
+          delete :destroy, params: { otp_code: '' }
+          expect(response).to render_template(:destroy_confirmation)
+        end
+
+        it 'does not disable two factor authentication' do
+          delete :destroy, params: { otp_code: '' }
+          expect(user.reload.otp_enabled?).to eq(true)
+        end
+
+        it 'shows an error in the response' do
+          delete :destroy, params: { otp_code: '' }
+          expect(flash[:error]).to be_present
+        end
+      end
+
+      context 'with an invalid code' do
+        let(:invalid_code) { valid_code == '000000' ? '000001' : '000000' }
+
+        it 'renders the destroy_confirmation template' do
+          delete :destroy, params: { otp_code: invalid_code }
+          expect(response).to render_template(:destroy_confirmation)
+        end
+
+        it 'does not disable two factor authentication' do
+          delete :destroy, params: { otp_code: invalid_code }
+          expect(user.reload.otp_enabled?).to eq(true)
+        end
+
+        it 'shows an error in the response' do
+          delete :destroy, params: { otp_code: invalid_code }
+          expect(flash[:error]).to be_present
+        end
+      end
+
+      context 'with a valid code' do
+        it 'disables two factor authentication' do
+          delete :destroy, params: { otp_code: valid_code }
+          expect(user.reload.otp_enabled?).to eq(false)
+        end
+
+        it 'redirects to the settings page' do
+          delete :destroy, params: { otp_code: valid_code }
+          expect(response).to redirect_to(one_time_password_path)
+        end
+
+        it 'sets a success notice' do
+          delete :destroy, params: { otp_code: valid_code }
+
+          expect(flash[:notice]).
+            to eq('Two factor authentication disabled')
+        end
+      end
     end
 
-    it 'sets a successful notification message' do
-      user = FactoryBot.create(:user)
-      sign_in user
-      delete :destroy
-      expect(flash[:notice]).to eq('Two factor authentication disabled')
+    context 'for a HOTP-enabled user' do
+      let(:user) { FactoryBot.create(:user, :enable_hotp) }
+
+      before { sign_in user }
+
+      it 'disables two factor authentication without requiring a code' do
+        delete :destroy
+        expect(user.reload.otp_enabled?).to eq(false)
+      end
+
+      it 'redirects to the settings page' do
+        delete :destroy
+        expect(response).to redirect_to(one_time_password_path)
+      end
+
+      it 'sets a success notice' do
+        delete :destroy
+        expect(flash[:notice]).to eq('Two factor authentication disabled')
+      end
     end
 
-    it 'redirects back to #show on success' do
-      user = FactoryBot.create(:user)
-      sign_in user
-      delete :destroy
-      expect(response).to redirect_to(one_time_password_path)
-    end
+    context 'on save failure for a non-TOTP user' do
+      let(:user) { FactoryBot.create(:user) }
 
-    it 'sets a failure notification message' do
-      allow_any_instance_of(User).to receive(:save).and_return(false)
-      user = FactoryBot.create(:user)
-      sign_in user
-      delete :destroy
-      expect(flash[:error]).
-        to eq('Two factor authentication could not be disabled')
-    end
+      before do
+        sign_in user
+        allow_any_instance_of(User).to receive(:save).and_return(false)
+      end
 
-    it 'renders #show on failure' do
-      allow_any_instance_of(User).to receive(:save).and_return(false)
-      user = FactoryBot.create(:user)
-      sign_in user
-      delete :destroy
-      expect(response).to render_template(:show)
+      it 'sets a failure notification message' do
+        delete :destroy
+        expect(flash[:error]).
+          to eq('Two factor authentication could not be disabled')
+      end
+
+      it 'renders #show on failure' do
+        delete :destroy
+        expect(response).to render_template(:show)
+      end
     end
 
     context 'when two factor auth is not enabled' do

--- a/spec/controllers/users/sessions_controller_spec.rb
+++ b/spec/controllers/users/sessions_controller_spec.rb
@@ -91,6 +91,69 @@ RSpec.describe Users::SessionsController do
       expect(ActionMailer::Base.deliveries).to be_empty
     end
 
+    context 'with a TOTP-enabled user' do
+      let(:totp_user) do
+        FactoryBot.create(:user, :enable_totp,
+                          email: 'totp@localhost', password: 'jonespassword')
+      end
+      let(:post_redirect) { FactoryBot.create(:post_redirect, uri: '/list') }
+
+      def post_signin
+        post :create, params: {
+          user_signin: { email: totp_user.email, password: 'jonespassword' },
+          token: post_redirect.token
+        }
+      end
+
+      it 'does not sign the user in yet' do
+        post_signin
+        expect(session[:user_id]).to be_nil
+      end
+
+      it 'redirects to the two factor challenge' do
+        post_signin
+        expect(response).to redirect_to(signin_two_factor_path)
+      end
+
+      it 'stashes the pending sign-in in the session' do
+        post_signin
+        expect(session[:pending_2fa_user_id]).to eq(totp_user.id)
+        expect(session[:pending_2fa_post_redirect_token]).
+          to eq(post_redirect.token)
+      end
+
+      context 'when the user is an admin' do
+        let(:totp_user) do
+          FactoryBot.create(:user, :enable_totp, :admin,
+                            email: 'totpadmin@localhost',
+                            password: 'jonespassword')
+        end
+
+        it 'is challenged through the same controller' do
+          post_signin
+          expect(session[:user_id]).to be_nil
+          expect(response).to redirect_to(signin_two_factor_path)
+        end
+      end
+    end
+
+    context 'with a HOTP-enabled user' do
+      let(:hotp_user) do
+        FactoryBot.create(:user, :enable_hotp,
+                          email: 'hotp@localhost', password: 'jonespassword')
+      end
+      let(:post_redirect) { FactoryBot.create(:post_redirect, uri: '/list') }
+
+      it 'signs the user in without a challenge' do
+        post :create, params: {
+          user_signin: { email: hotp_user.email, password: 'jonespassword' },
+          token: post_redirect.token
+        }
+        expect(session[:user_id]).to eq(hotp_user.id)
+        expect(session[:pending_2fa_user_id]).to be_nil
+      end
+    end
+
     it "should not log you in if you use an invalid PostRedirect token, and shouldn't give 500 error either" do
       post_redirect = "something invalid"
       expect {

--- a/spec/controllers/users/two_factor_challenges_controller_spec.rb
+++ b/spec/controllers/users/two_factor_challenges_controller_spec.rb
@@ -1,0 +1,141 @@
+require 'spec_helper'
+
+RSpec.describe Users::TwoFactorChallengesController do
+  before do
+    # Don't call out to external url during tests
+    allow(controller).to receive(:country_from_ip).and_return('gb')
+  end
+
+  let(:user) { FactoryBot.create(:user, :enable_totp) }
+  let(:valid_code) { user.otp_code }
+  let(:invalid_code) { valid_code == '000000' ? '000001' : '000000' }
+  let(:post_redirect) do
+    FactoryBot.create(:post_redirect, uri: request_list_path)
+  end
+
+  def start_pending_sign_in
+    PendingTwoFactorSignIn.new(session).start(
+      user: user, remember_me: false, post_redirect: post_redirect
+    )
+  end
+
+  describe 'GET new' do
+    it 'renders the challenge form for a pending sign-in' do
+      start_pending_sign_in
+      get :new
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'POST create' do
+    context 'with a valid code' do
+      before do
+        start_pending_sign_in
+        post :create, params: { otp_code: valid_code }
+      end
+
+      it 'signs the user in' do
+        expect(session[:user_id]).to eq(user.id)
+      end
+
+      it 'clears the pending sign-in state' do
+        expect(session[:pending_2fa_user_id]).to be_nil
+      end
+
+      it 'redirects to the stashed destination' do
+        expect(response).to redirect_to(request_list_path(post_redirect: 1))
+      end
+    end
+
+    context 'with an invalid code' do
+      before do
+        start_pending_sign_in
+        post :create, params: { otp_code: invalid_code }
+      end
+
+      it 'does not sign the user in' do
+        expect(session[:user_id]).to be_nil
+      end
+
+      it 're-renders the challenge' do
+        expect(response).to render_template(:new)
+      end
+
+      it 'shows an error' do
+        expect(flash[:error]).to be_present
+      end
+
+      it 'keeps the pending sign-in state' do
+        expect(session[:pending_2fa_user_id]).to eq(user.id)
+      end
+    end
+
+    context 'with a blank code' do
+      before { start_pending_sign_in }
+
+      it 'does not sign the user in and re-renders' do
+        post :create, params: { otp_code: '' }
+        expect(session[:user_id]).to be_nil
+        expect(response).to render_template(:new)
+      end
+    end
+
+    context 'when the attempt limit is exceeded' do
+      before do
+        start_pending_sign_in
+        described_class.cache_store.clear
+        # One more than the limit allows, so the final attempt is throttled.
+        6.times { post :create, params: { otp_code: invalid_code } }
+      end
+
+      it 're-renders the challenge with a rate-limit error' do
+        expect(response).to render_template(:new)
+        expect(flash[:error]).to match(/Too many attempts/)
+      end
+
+      it 'keeps the pending sign-in so the password check is not repeated' do
+        expect(session[:pending_2fa_user_id]).to eq(user.id)
+      end
+    end
+  end
+
+  describe 'guarding the pending sign-in' do
+    context 'without a pending sign-in' do
+      it 'redirects GET new to sign in' do
+        get :new
+        expect(response).to redirect_to(signin_path)
+      end
+
+      it 'does not sign anyone in on create, even with a valid code' do
+        post :create, params: { otp_code: valid_code }
+        expect(session[:user_id]).to be_nil
+        expect(response).to redirect_to(signin_path)
+      end
+    end
+
+    context 'when the pending sign-in has expired' do
+      before { start_pending_sign_in }
+
+      it 'redirects to sign in' do
+        travel(PendingTwoFactorSignIn::TTL + 1.minute) do
+          get :new
+          expect(response).to redirect_to(signin_path)
+        end
+      end
+    end
+
+    context 'when the user disabled two factor mid-flow' do
+      before do
+        start_pending_sign_in
+        user.disable_otp
+        user.save!
+      end
+
+      it 'redirects to sign in' do
+        get :new
+        expect(response).to redirect_to(signin_path)
+      end
+    end
+  end
+end

--- a/spec/integration/alaveteli_dsl.rb
+++ b/spec/integration/alaveteli_dsl.rb
@@ -114,6 +114,13 @@ def login(user, **params)
       fill_in "user_signin_password", with: "jonespassword"
       find("input[name='commit']", visible: true).click
     end
+
+    # TOTP users are gated by the sign-in two factor challenge
+    if u.totp?
+      fill_in 'Code from your authenticator app',
+              with: u.otp_code
+      click_button 'Verify'
+    end
   end
   u.id
 end

--- a/spec/integration/two_factor_disable_spec.rb
+++ b/spec/integration/two_factor_disable_spec.rb
@@ -11,29 +11,35 @@ RSpec.describe 'disabling two factor authentication' do
     let(:user) { FactoryBot.create(:user, :enable_totp) }
 
     it 'requires a current authenticator code to disable' do
-      using_session(login(user)) do
-        page.driver.submit :delete, one_time_password_path, {}
+      session_id = login(user)
 
-        expect(page).
-          to have_content('Disabling two factor authentication will remove')
-        expect(page).
-          to have_field('Code from your authenticator app')
+      # The sign-in challenge consumed the current TOTP code; move past its
+      # window so the disable code isn't rejected as a replay.
+      travel(31.seconds) do
+        using_session(session_id) do
+          page.driver.submit :delete, one_time_password_path, {}
 
-        valid_code = user.otp_code
-        invalid_code = valid_code == '000000' ? '000001' : '000000'
+          expect(page).
+            to have_content('Disabling two factor authentication will remove')
+          expect(page).
+            to have_field('Code from your authenticator app')
 
-        fill_in 'Code from your authenticator app', with: invalid_code
-        click_button 'Disable two factor authentication'
+          valid_code = user.otp_code
+          invalid_code = valid_code == '000000' ? '000001' : '000000'
 
-        expect(page).to have_content('Invalid one time password')
-        expect(user.reload.otp_enabled).to eq(true)
+          fill_in 'Code from your authenticator app', with: invalid_code
+          click_button 'Disable two factor authentication'
 
-        fill_in 'Code from your authenticator app', with: valid_code
-        click_button 'Disable two factor authentication'
+          expect(page).to have_content('Invalid one time password')
+          expect(user.reload.otp_enabled).to eq(true)
 
-        expect(page).
-          to have_content('Two factor authentication disabled')
-        expect(user.reload.otp_enabled).to eq(false)
+          fill_in 'Code from your authenticator app', with: valid_code
+          click_button 'Disable two factor authentication'
+
+          expect(page).
+            to have_content('Two factor authentication disabled')
+          expect(user.reload.otp_enabled).to eq(false)
+        end
       end
     end
   end

--- a/spec/integration/two_factor_disable_spec.rb
+++ b/spec/integration/two_factor_disable_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'integration/alaveteli_dsl'
+
+RSpec.describe 'disabling two factor authentication' do
+  before do
+    allow(AlaveteliConfiguration).
+      to receive(:enable_two_factor_auth).and_return(true)
+  end
+
+  context 'as a TOTP user' do
+    let(:user) { FactoryBot.create(:user, :enable_totp) }
+
+    it 'requires a current authenticator code to disable' do
+      using_session(login(user)) do
+        page.driver.submit :delete, one_time_password_path, {}
+
+        expect(page).
+          to have_content('Disabling two factor authentication will remove')
+        expect(page).
+          to have_field('Code from your authenticator app')
+
+        valid_code = user.otp_code
+        invalid_code = valid_code == '000000' ? '000001' : '000000'
+
+        fill_in 'Code from your authenticator app', with: invalid_code
+        click_button 'Disable two factor authentication'
+
+        expect(page).to have_content('Invalid one time password')
+        expect(user.reload.otp_enabled).to eq(true)
+
+        fill_in 'Code from your authenticator app', with: valid_code
+        click_button 'Disable two factor authentication'
+
+        expect(page).
+          to have_content('Two factor authentication disabled')
+        expect(user.reload.otp_enabled).to eq(false)
+      end
+    end
+  end
+
+  context 'as a HOTP user' do
+    let(:user) { FactoryBot.create(:user, :enable_hotp) }
+
+    it 'disables without prompting for a code' do
+      using_session(login(user)) do
+        page.driver.submit :delete, one_time_password_path, {}
+
+        expect(user.reload.otp_enabled).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/integration/two_factor_sign_in_spec.rb
+++ b/spec/integration/two_factor_sign_in_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'integration/alaveteli_dsl'
+
+RSpec.describe 'signing in with two factor authentication' do
+  before do
+    allow(AlaveteliConfiguration).
+      to receive(:enable_two_factor_auth).and_return(true)
+  end
+
+  def submit_credentials(user)
+    visit signin_path
+    within '#signin_form' do
+      fill_in 'Your e-mail:', with: user.email
+      fill_in 'Password:', with: 'jonespassword'
+      click_button 'Sign in'
+    end
+  end
+
+  context 'as a TOTP user' do
+    let(:user) { FactoryBot.create(:user, :enable_totp) }
+
+    it 'challenges for a code and signs in once it is correct' do
+      using_session(without_login) do
+        submit_credentials(user)
+
+        expect(page).to have_current_path(signin_two_factor_path)
+        expect(page).
+          to have_content('Enter a current code from your authenticator app')
+        expect(page).to have_field('Code from your authenticator app')
+        expect(page).to have_no_content(user.name)
+
+        valid_code = user.otp_code
+        invalid_code = valid_code == '000000' ? '000001' : '000000'
+
+        fill_in 'Code from your authenticator app', with: invalid_code
+        click_button 'Verify'
+
+        expect(page).to have_content('Invalid one time password')
+        expect(page).to have_no_content(user.name)
+
+        fill_in 'Code from your authenticator app', with: valid_code
+        click_button 'Verify'
+
+        expect(page).to have_content(user.name)
+      end
+    end
+  end
+
+  context 'as a HOTP user' do
+    let(:user) { FactoryBot.create(:user, :enable_hotp) }
+
+    it 'signs in without a two factor challenge' do
+      using_session(without_login) do
+        submit_credentials(user)
+
+        expect(page).
+          to have_no_field('Code from your authenticator app')
+        expect(page).to have_content(user.name)
+      end
+    end
+  end
+end

--- a/spec/models/pending_two_factor_sign_in_spec.rb
+++ b/spec/models/pending_two_factor_sign_in_spec.rb
@@ -1,0 +1,114 @@
+require 'spec_helper'
+
+RSpec.describe PendingTwoFactorSignIn do
+  subject(:pending) { described_class.new(session) }
+
+  let(:session) { {} }
+  let(:user) { FactoryBot.create(:user, :enable_totp) }
+  let(:post_redirect) { FactoryBot.create(:post_redirect) }
+
+  describe '#start' do
+    before do
+      pending.start(user: user, remember_me: true, post_redirect: post_redirect)
+    end
+
+    it 'stores the user id' do
+      expect(session[:pending_2fa_user_id]).to eq(user.id)
+    end
+
+    it 'stores a started-at timestamp as an epoch integer' do
+      expect(session[:pending_2fa_started_at]).
+        to be_within(1).of(Time.zone.now.to_i)
+    end
+
+    it 'stores the remember-me flag' do
+      expect(session[:pending_2fa_remember_me]).to eq(true)
+    end
+
+    it 'stores the post redirect token' do
+      expect(session[:pending_2fa_post_redirect_token]).
+        to eq(post_redirect.token)
+    end
+  end
+
+  describe '#user' do
+    it 'loads the user from the stored id' do
+      session[:pending_2fa_user_id] = user.id
+      expect(pending.user).to eq(user)
+    end
+
+    it 'is nil without a stored id' do
+      expect(pending.user).to be_nil
+    end
+  end
+
+  describe '#post_redirect' do
+    it 'loads the post redirect from the stored token' do
+      session[:pending_2fa_post_redirect_token] = post_redirect.token
+      expect(pending.post_redirect).to eq(post_redirect)
+    end
+
+    it 'is nil without a stored token' do
+      expect(pending.post_redirect).to be_nil
+    end
+  end
+
+  describe '#remember_me' do
+    it 'reads it back from the session' do
+      session[:pending_2fa_remember_me] = false
+      expect(pending.remember_me).to eq(false)
+    end
+  end
+
+  describe '#expired?' do
+    it 'is true when no timestamp is stored' do
+      expect(pending.expired?).to eq(true)
+    end
+
+    it 'is false within the TTL' do
+      session[:pending_2fa_started_at] = Time.zone.now.to_i
+      expect(pending.expired?).to eq(false)
+    end
+
+    it 'is true past the TTL' do
+      session[:pending_2fa_started_at] =
+        (described_class::TTL + 1.minute).ago.to_i
+      expect(pending.expired?).to eq(true)
+    end
+  end
+
+  describe '#active?' do
+    it 'is true for a TOTP user within the TTL' do
+      pending.start(user: user, remember_me: false,
+                    post_redirect: post_redirect)
+      expect(pending.active?).to eq(true)
+    end
+
+    it 'is false for a HOTP user' do
+      hotp_user = FactoryBot.create(:user, :enable_hotp)
+      pending.start(user: hotp_user, remember_me: false,
+                    post_redirect: post_redirect)
+      expect(pending.active?).to eq(false)
+    end
+
+    it 'is false past the TTL' do
+      pending.start(user: user, remember_me: false,
+                    post_redirect: post_redirect)
+      session[:pending_2fa_started_at] =
+        (described_class::TTL + 1.minute).ago.to_i
+      expect(pending.active?).to eq(false)
+    end
+
+    it 'is false without a pending user' do
+      expect(pending.active?).to eq(false)
+    end
+  end
+
+  describe '#clear' do
+    it 'removes every pending key' do
+      pending.start(user: user, remember_me: true, post_redirect: post_redirect)
+      pending.clear
+      expect(session).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Part of the work to enable two-factor authentication #9241 

Builds on top of the enrolment work in #9276 

## What does this do?

Asks TOTP users for their current OTP code when they're signing in or trying to disable 2FA.

## Why was this needed?

This completes the OTP flow end-to-end. So a user can enrol for TOTP and then when they sign in or try to disable TOTP they will be prompted to enter their current OTP code.

## Implementation notes

Introduces a `PendingTwoFactorSignIn` class which is responsible for managing the session keys for a pending sign-in from a TOTP user. Encapsulates the user and the post redirect for the current sign-in, and makes it easy to clear all the relevant sessions keys at once.

## Screenshots


https://github.com/user-attachments/assets/aa593614-111f-41d7-a597-fa1504da3fb3



## Notes to reviewer

The last commit fixes the modal sign-in link. As the commit message says there was a redirect happening, which meant that the modal wasn't using the modal layout. Using the proper path helper seems to fix it so that the modal appears correctly when clicking the nav link when `FORCE_REGISTRATION_ON_NEW_REQUEST` is `true`.

<!-- [skip changelog] -->
