### PR TITLE
Enforce two factor authentication for admins

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,7 +6,13 @@
 
 class AdminController < ApplicationController
   layout "admin"
+
+  # Set `AdminController.require_two_factor_auth = true` in your theme to
+  # require admins to have authenticator-app (TOTP) two factor enabled.
+  class_attribute :require_two_factor_auth, default: false
+
   before_action :authenticate
+  before_action :enforce_two_factor_auth, if: :require_two_factor_auth?
 
   # action to take if expecting an authenticity token and one isn't received
   def handle_unverified_request
@@ -35,6 +41,20 @@ class AdminController < ApplicationController
     else
       "*unknown*"
     end
+  end
+
+  def enforce_two_factor_auth
+    # Nothing to enforce if two factor auth isn't enabled for the install.
+    return unless AlaveteliConfiguration.enable_two_factor_auth
+    # External auth and the emergency user have no Alaveteli User to check.
+    return if AlaveteliConfiguration.skip_admin_auth
+    return if current_user.nil?
+
+    return if current_user.totp?
+
+    flash[:error] = _('Two factor authentication is required for ' \
+                       'admins. Please enable it to continue.')
+    redirect_to one_time_password_path
   end
 
   def authenticate

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+RSpec.describe AdminController do
+  controller(AdminController) do
+    def index
+      head :ok
+    end
+  end
+
+  describe 'two factor authentication enforcement' do
+    let(:admin_user) { FactoryBot.create(:admin_user) }
+
+    after do
+      AdminController.require_two_factor_auth = false
+    end
+
+    it 'defaults require_two_factor_auth to false' do
+      expect(AdminController.require_two_factor_auth).to eq(false)
+    end
+
+    context 'when require_two_factor_auth is false (default)' do
+      it 'does not redirect a non-2FA admin' do
+        sign_in admin_user
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when require_two_factor_auth is true' do
+      before do
+        AdminController.require_two_factor_auth = true
+        allow(AlaveteliConfiguration).
+          to receive(:enable_two_factor_auth).and_return(true)
+        allow(AlaveteliConfiguration).
+          to receive(:skip_admin_auth).and_return(false)
+      end
+
+      it 'redirects a non-2FA admin to the two factor page' do
+        sign_in admin_user
+        get :index
+        expect(response).to redirect_to(one_time_password_path)
+      end
+
+      it 'sets a flash explaining the requirement' do
+        sign_in admin_user
+        get :index
+        expect(flash[:error]).to match(/Two factor authentication is required/)
+      end
+
+      it 'redirects a HOTP admin to the two factor page' do
+        sign_in FactoryBot.create(:admin_user, :enable_hotp)
+        get :index
+        expect(response).to redirect_to(one_time_password_path)
+      end
+
+      it 'allows a TOTP admin through' do
+        sign_in FactoryBot.create(:admin_user, :enable_totp)
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not enforce when two factor auth is disabled globally' do
+        allow(AlaveteliConfiguration).
+          to receive(:enable_two_factor_auth).and_return(false)
+        sign_in admin_user
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not enforce when admin authentication is skipped (external auth)' do
+        allow(AlaveteliConfiguration).
+          to receive(:skip_admin_auth).and_return(true)
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'does not enforce for the emergency user (no Alaveteli User)' do
+        # Emergency user authenticates via HTTP basic; admin_name is set to a
+        # bare string and there is no signed-in Alaveteli User.
+        session[:using_admin] = 1
+        session[:admin_name] = 'emergency'
+        get :index
+        expect(response).to have_http_status(:ok)
+      end
+    end
+  end
+end

--- a/spec/integration/admin_two_factor_enforcement_spec.rb
+++ b/spec/integration/admin_two_factor_enforcement_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+require 'integration/alaveteli_dsl'
+
+RSpec.describe 'admin two factor authentication enforcement' do
+  let(:admin_user) { FactoryBot.create(:admin_user) }
+
+  before do
+    allow(AlaveteliConfiguration).
+      to receive(:enable_two_factor_auth).and_return(true)
+    allow(AlaveteliConfiguration).
+      to receive(:skip_admin_auth).and_return(false)
+    AdminController.require_two_factor_auth = true
+  end
+
+  after do
+    AdminController.require_two_factor_auth = false
+  end
+
+  context 'as an admin without TOTP enabled' do
+    it 'redirects to the two factor page with a prompt to enable it' do
+      using_session(login(admin_user)) do
+        visit admin_general_index_path
+
+        expect(page).to have_current_path(one_time_password_path)
+        expect(page).to have_content(
+          'Two factor authentication is required for admins'
+        )
+      end
+    end
+  end
+
+  context 'as an admin with TOTP enabled' do
+    let(:admin_user) { FactoryBot.create(:admin_user, :enable_totp) }
+
+    it 'reaches the admin interface without further prompts' do
+      using_session(login(admin_user)) do
+        visit admin_general_index_path
+
+        expect(page).to have_current_path(admin_general_index_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Part of #9241 

Builds on top of #9306 

## What does this do?

Add an opt-in `AdminController.require_two_factor_auth` class attribute (default false).

When enabled, admins without TOTP enabled are redirected to /profile/two_factor to enable it.

It checks totp?, so HOTP and no-2FA admins are pushed to enrol, while external auth, the emergency user, and installs without two factor auth are exempt.

## Why was this needed?

Currently admin HOTP enforcement is only by convention rather than at a technical level. With this change, it can now be enforced at a technical level, forcing admins to do TOTP enrolment.

## Implementation notes

Follows a similar pattern to the `AtiNetworkController.showcase_enabled` class attribute.

## Screenshots

<img width="1057" height="413" alt="image" src="https://github.com/user-attachments/assets/4967333f-a272-4b72-9644-9a054f080c80" />


## Notes to reviewer

I've tried to handle the emergency user and external auth correctly, but I'm not overly familiar with those bits of code, so any feedback on that bit is particularly welcome.

<!-- [skip changelog] -->
