### PR TITLE
[#8823] Redactable

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,6 +7,7 @@
 class AdminController < ApplicationController
   layout "admin"
   before_action :authenticate
+  before_action { Redactable::Current.unredacted_access = true }
 
   # action to take if expecting an authenticity token and one isn't received
   def handle_unverified_request

--- a/app/models/concerns/redactable.rb
+++ b/app/models/concerns/redactable.rb
@@ -1,0 +1,24 @@
+module Redactable
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :redactable_attrs, default: []
+
+    delegate :apply_masks, to: :info_request
+  end
+
+  class_methods do
+    # Allow classes to set attributes or methods that may contain personal data
+    # and so should be put through the redaction pipeline to check for any
+    # applicable redactions.
+    def redactable(*attrs)
+      self.redactable_attrs = attrs
+    end
+  end
+
+  def redacted
+    @redacted ||= Redacted.new(self)
+  end
+
+  end
+end

--- a/app/models/concerns/redactable.rb
+++ b/app/models/concerns/redactable.rb
@@ -1,10 +1,14 @@
 module Redactable
   extend ActiveSupport::Concern
 
+  UnredactedAccessError = Class.new(StandardError)
+
   included do
     class_attribute :redactable_attrs, default: []
 
     delegate :apply_masks, to: :info_request
+
+    attr_writer :unredacted_access
   end
 
   class_methods do
@@ -13,6 +17,19 @@ module Redactable
     # applicable redactions.
     def redactable(*attrs)
       self.redactable_attrs = attrs
+
+      # Raise an error if a redactable attribute is accessed without first
+      # explicitly allowing access by setting unredacted_access. We need to
+      # prepend a module so that this override sits above any defined methods
+      # in the including class.
+      prepend(Module.new do
+        attrs.each do |attr|
+          define_method(attr) do
+            raise Redactable::UnredactedAccessError unless unredacted_access
+            super()
+          end
+        end
+      end)
     end
   end
 
@@ -20,5 +37,11 @@ module Redactable
     @redacted ||= Redacted.new(self)
   end
 
+  def unredacted
+    @unredacted ||= Unredacted.new(self)
+  end
+
+  def unredacted_access
+    @unredacted_access || false
   end
 end

--- a/app/models/concerns/redactable.rb
+++ b/app/models/concerns/redactable.rb
@@ -42,6 +42,6 @@ module Redactable
   end
 
   def unredacted_access
-    @unredacted_access || false
+    @unredacted_access || Redactable::Current.unredacted_access || false
   end
 end

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -36,6 +36,7 @@ class FoiAttachment < ApplicationRecord
   include LinkToHelper
 
   include MessageProminence
+  include Redactable
 
   include ContentType
   include Erasable
@@ -66,6 +67,8 @@ class FoiAttachment < ApplicationRecord
 
   admin_columns exclude: %i[url_part_number within_rfc822_subject hexdigest],
                 include: %i[redacted_filename display_filename metadata]
+
+  redactable :filename, :body
 
   BODY_MAX_TRIES = 3
   BODY_MAX_DELAY = 5
@@ -128,6 +131,10 @@ class FoiAttachment < ApplicationRecord
   def default_body
     ensure_not_erased!
     text_type? ? body_as_text.string : body
+  end
+
+  def apply_masks_to_body
+    apply_masks(unmasked_body, content_type)
   end
 
   # return the body as it is in the raw email, unmasked without censor rules

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -37,6 +37,7 @@ require 'zip'
 
 class IncomingMessage < ApplicationRecord
   include MessageProminence
+  include Redactable
   include Taggable
 
   include IncomingMessage::Attachments
@@ -77,6 +78,8 @@ class IncomingMessage < ApplicationRecord
   cache_from_raw_email :subject, :sent_at,
                        :from_name, :from_email, :from_email_domain,
                        :valid_to_reply_to
+
+  redactable :from, :from_name, :from_email, :from_email_domain, :subject
 
   delegate :message_id, to: :raw_email
   delegate :multipart?, to: :raw_email

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -48,6 +48,7 @@ class InfoRequest < ApplicationRecord
   include Taggable
   include Notable
   include RateLimited
+  include Redactable
 
   include AlaveteliPro::RequestSummaries
   include AlaveteliFeatures::Helpers
@@ -56,7 +57,6 @@ class InfoRequest < ApplicationRecord
   include InfoRequest::PublicToken
   include InfoRequest::Sluggable
   include InfoRequest::TitleValidation
-
 
   admin_columns exclude: %i[title url_title],
                 include: %i[rejected_incoming_count]
@@ -70,6 +70,8 @@ class InfoRequest < ApplicationRecord
   strip_attributes allow_empty: true
   strip_attributes only: [:title],
                    replace_newlines: true, collapse_spaces: true
+
+  redactable :title
 
   belongs_to :user,
              inverse_of: :info_requests,
@@ -1816,6 +1818,12 @@ class InfoRequest < ApplicationRecord
       user_path(user),
       show_user_wall_path(url_name: user.url_name)
     ]
+  end
+
+  # Return this request. This is mainly for
+  # duck-typing with other censorable relationships.
+  def info_request
+    self
   end
 
   # Return only this request in a chainable relation. This is mainly for

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -28,6 +28,7 @@ class OutgoingMessage < ApplicationRecord
   include MessageProminence
   include Rails.application.routes.url_helpers
   include LinkToHelper
+  include Redactable
   include Taggable
 
   include OutgoingMessage::DeliveryStatus
@@ -75,6 +76,8 @@ class OutgoingMessage < ApplicationRecord
   after_update :xapian_reindex_after_update
 
   strip_attributes allow_empty: true
+
+  redactable :from, :from_name, :body
 
   admin_columns include: [:to, :from, :subject]
 

--- a/app/models/redactable/current.rb
+++ b/app/models/redactable/current.rb
@@ -1,0 +1,3 @@
+class Redactable::Current < ActiveSupport::CurrentAttributes
+  attribute :unredacted_access
+end

--- a/app/models/redactable/redacted.rb
+++ b/app/models/redactable/redacted.rb
@@ -18,7 +18,7 @@ class Redactable::Redacted < SimpleDelegator
     if record.respond_to?("apply_masks_to_#{attr}")
       record.send("apply_masks_to_#{attr}")
     elsif record.respond_to?(attr)
-      record.apply_masks(record.public_send(attr).to_s, 'text/plain')
+      record.apply_masks(record.unredacted.public_send(attr).to_s, 'text/plain')
     else
       msg = "Unknown method :#{attr} given to #{record.class} redactable"
       raise ArgumentError, msg

--- a/app/models/redactable/redacted.rb
+++ b/app/models/redactable/redacted.rb
@@ -1,0 +1,33 @@
+class Redactable::Redacted < SimpleDelegator
+  def method_missing(method_name, *args, **kwargs, &block)
+    if record.redactable_attrs.include?(method_name)
+      apply_masks_to(method_name)
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    record.redactable_attrs.include?(method_name) || super
+  end
+
+  # Allow classes to define a custom masking method per attribute. If a custom
+  # method is not defined, its assumed the attribute can be redacted by the
+  # plain text pipeline.
+  def apply_masks_to(attr)
+    if record.respond_to?("apply_masks_to_#{attr}")
+      record.send("apply_masks_to_#{attr}")
+    elsif record.respond_to?(attr)
+      record.apply_masks(record.public_send(attr).to_s, 'text/plain')
+    else
+      msg = "Unknown method :#{attr} given to #{record.class} redactable"
+      raise ArgumentError, msg
+    end
+  end
+
+  private
+
+  def record
+    __getobj__
+  end
+end

--- a/app/models/redactable/unredacted.rb
+++ b/app/models/redactable/unredacted.rb
@@ -1,0 +1,27 @@
+class Redactable::Unredacted < SimpleDelegator
+  def method_missing(method_name, *args, **kwargs, &block)
+    if record.redactable_attrs.include?(method_name)
+      with_unredacted_access { record.public_send(method_name) }
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    record.redactable_attrs.include?(method_name) || super
+  end
+
+  def with_unredacted_access
+    was = record.unredacted_access
+    record.unredacted_access = true
+    yield(self)
+  ensure
+    record.unredacted_access = was
+  end
+
+  private
+
+  def record
+    __getobj__
+  end
+end

--- a/spec/models/redactable/redacted_spec.rb
+++ b/spec/models/redactable/redacted_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+RSpec.describe Redactable::Redacted do
+  let(:record) do
+    klass = Class.new do
+      include Redactable
+      redactable :title
+
+      def title = 'Some title'
+      def safe = 'Some generic content'
+    end
+
+    klass.new
+  end
+
+  before do
+    allow(record).
+      to receive(:info_request).
+      and_return(double(apply_masks: '[REDACTED] title'))
+  end
+
+  subject { described_class.new(record) }
+
+  it 'responds to all methods on the given record' do
+    is_expected.to respond_to(:title)
+    is_expected.to respond_to(:safe)
+  end
+
+  it 'does not define methods for undeclared attributes' do
+    is_expected.not_to respond_to(:name)
+  end
+
+  it 'applies redactions to redactable attributes' do
+    expect(subject.title).to eq('[REDACTED] title')
+  end
+
+  it 'does not apply redactions to non-redactable attributes' do
+    expect(record).not_to receive(:apply_masks)
+    expect(subject.safe).to eq('Some generic content')
+  end
+end

--- a/spec/models/redactable/unredacted_spec.rb
+++ b/spec/models/redactable/unredacted_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe Redactable::Unredacted do
+  let(:record) do
+    klass = Class.new do
+      include Redactable
+      redactable :title
+
+      def title = 'Some title'
+      def safe = 'Some generic content'
+    end
+
+    klass.new
+  end
+
+  subject { described_class.new(record) }
+
+  it 'responds to all methods on the given record' do
+    is_expected.to respond_to(:title)
+    is_expected.to respond_to(:safe)
+  end
+
+  it 'does not define methods for undeclared attributes' do
+    is_expected.not_to respond_to(:name)
+  end
+
+  it 'grants unredacted access when reading redactable attributes' do
+    expect(subject).to receive(:with_unredacted_access).and_call_original
+    expect(subject.title).to eq('Some title')
+  end
+
+  it 'does not grant unredacted access for non-redactable attributes' do
+    expect(subject).not_to receive(:with_unredacted_access)
+    expect(subject.safe).to eq('Some generic content')
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

* Prep for https://github.com/mysociety/alaveteli/issues/8823
* Prep for https://github.com/mysociety/alaveteli/issues/8824
* Requires https://github.com/mysociety/alaveteli/pull/9302

## What does this do?

Adds explicit interfaces for getting redacted/unredacted versions of content

## Why was this needed?

* Make it easier to get different versions of content
* Reduce number of methods / method overrides that currently do the above
* Protects against information leaks by forcing developers to explicitly permit unredacted access to data

## Implementation notes

Here's how this will work:

```rb
class User < ApplicationRecord
  include Redactable
  redactable :from_name
end

user.censor_rules.create!(
  text: 'Bob Smith',
  replacement: '[name removed]',
  last_edit_editor: 'x',
  last_edit_comment: 'x'
)

msg = user.info_requests.first.outgoing_messages.first

msg.unredacted.from_name
# => "Bob Smith"

msg.redacted.from_name
# => "[name removed]"

msg.unredacted_access = false # the default
msg.from_name
# => Redactable::UnredactedAccessError (Redactable::UnredactedAccessError)

msg.unredacted_access = true
msg.from_name
# => "Bob Smith"
```

## Notes to reviewer

While this does force explicit unredacted permission, it still requires us to remember to add attributes to `redactable`. There's an alternative version of this where we by default assume attributes will hold PII unless explicitly told they won't, but that feels like it would get a bit _too_ annoying?

At the moment this applies both censor rules and text masks. We may want to split these up so that we can do e.g. (`record.censored.unmasked.foo`).

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
