### PR TITLE
Authenticator 2fa backup codes

### DIFF
--- a/app/assets/javascripts/snippets.js
+++ b/app/assets/javascripts/snippets.js
@@ -53,4 +53,10 @@
     e.clearSelection();
   });
 
+  // Inline onclick handlers are blocked by the CSP, so bind print triggers here.
+  $(document).on('click', '[data-print]', function(e) {
+    e.preventDefault();
+    window.print();
+  });
+
 })(window.jQuery);

--- a/app/assets/stylesheets/responsive/_one_time_passwords_style.scss
+++ b/app/assets/stylesheets/responsive/_one_time_passwords_style.scss
@@ -45,3 +45,29 @@
     color: darken($primary-color, 15%);
   }
 }
+
+// One code per line in DOM order so a manual select-and-copy gives a clean
+// newline-separated list with no bullets.
+.backup-codes__list {
+  columns: 2;
+  list-style: none;
+  margin: 1em 0;
+  max-width: 14em;
+  padding: 0;
+
+  li {
+    margin-bottom: 0.5em;
+  }
+
+  code {
+    font-family: monospace;
+    font-size: 1.5em;
+    letter-spacing: 0.15em;
+  }
+}
+
+.backup-codes__actions {
+  align-items: center;
+  display: flex;
+  gap: 1.5em;
+}

--- a/app/controllers/one_time_passwords/backup_codes_controller.rb
+++ b/app/controllers/one_time_passwords/backup_codes_controller.rb
@@ -1,0 +1,49 @@
+# View and regenerate two factor backup codes
+class OneTimePasswords::BackupCodesController < ApplicationController
+  before_action :check_two_factor_config, :authenticate, :require_totp
+
+  def show
+  end
+
+  def create
+    unless @user.authenticate_otp(params[:otp_code].to_s)
+      flash.now[:error] = _('Invalid one time password')
+      return render :show
+    end
+
+    codes = @user.otp_regenerate_backup_codes
+
+    if @user.save
+      flash[:backup_codes] = codes
+      redirect_to one_time_password_backup_codes_path,
+                  notice: _('New backup codes generated')
+    else
+      flash.now[:error] = _('Backup codes could not be regenerated')
+      render :show
+    end
+  end
+
+  private
+
+  def check_two_factor_config
+    return if AlaveteliConfiguration.enable_two_factor_auth
+
+    raise ActiveRecord::RecordNotFound, 'Page not enabled'
+  end
+
+  def authenticate
+    authenticated? || ask_to_login(
+      web: _('To manage your two factor backup codes'),
+      email: _('To manage your two factor backup codes'),
+      email_subject: _('To manage your two factor backup codes')
+    )
+  end
+
+  # Backup codes only exist for TOTP users. HOTP and no-2FA users manage
+  # their setup from the two factor settings page.
+  def require_totp
+    return if @user&.totp?
+
+    redirect_to one_time_password_path
+  end
+end

--- a/app/controllers/one_time_passwords_controller.rb
+++ b/app/controllers/one_time_passwords_controller.rb
@@ -29,6 +29,7 @@ class OneTimePasswordsController < ApplicationController
       if @user.otp_counter_previously_was.present?
         flash[:just_upgraded_from_hotp] = true
       end
+      flash[:backup_codes] = @enrolment.backup_codes
       redirect_to one_time_password_path,
                   notice: _('Two factor authentication enabled')
     else

--- a/app/controllers/password_changes_controller.rb
+++ b/app/controllers/password_changes_controller.rb
@@ -92,10 +92,10 @@ class PasswordChangesController < ApplicationController
           redirect_to one_time_password_path, notice: msg
         elsif @pretoken_redirect
           redirect_to SafeRedirect.new(@pretoken_redirect.uri).path,
-                      notice: _('Your password has been changed.')
+                      notice: password_changed_notice(@password_change_user)
         else
           redirect_to show_user_profile_path(@password_change_user.url_name),
-                      notice: _('Your password has been changed.')
+                      notice: password_changed_notice(@password_change_user)
         end
       else
         render :edit
@@ -106,6 +106,14 @@ class PasswordChangesController < ApplicationController
   end
 
   protected
+
+  def password_changed_notice(user)
+    changed = _('Your password has been changed.')
+    return changed unless user.used_backup_code?
+
+    { partial: 'one_time_passwords/backup_code_used',
+      locals: { lead: changed, remaining: user.otp_backup_codes.size } }
+  end
 
   def set_pretoken
     @pretoken = params.fetch(:pretoken, '').blank? ? nil : params[:pretoken]

--- a/app/controllers/users/two_factor_challenges_controller.rb
+++ b/app/controllers/users/two_factor_challenges_controller.rb
@@ -15,6 +15,7 @@ class Users::TwoFactorChallengesController < UserController
 
   def create
     if @pending.user.authenticate_otp(params[:otp_code])
+      flash_backup_code_warning(@pending.user)
       complete_two_factor_sign_in
     else
       flash.now[:error] = _('Invalid one time password')
@@ -38,6 +39,15 @@ class Users::TwoFactorChallengesController < UserController
       post_redirect: @pending.post_redirect,
       remember_me: @pending.remember_me
     )
+  end
+
+  def flash_backup_code_warning(user)
+    return unless user.used_backup_code?
+
+    flash[:notice] = {
+      partial: 'one_time_passwords/backup_code_used',
+      locals: { remaining: user.otp_backup_codes.size }
+    }
   end
 
   def handle_rate_limit

--- a/app/models/otp_enrolment.rb
+++ b/app/models/otp_enrolment.rb
@@ -4,6 +4,10 @@ class OtpEnrolment
 
   attr_accessor :user, :secret, :otp_code
 
+  # Plaintext backup codes issued by a successful save, the only point at
+  # which they're exposed outside the encrypted column.
+  attr_reader :backup_codes
+
   validate :code_matches_secret
 
   def save

--- a/app/models/otp_enrolment.rb
+++ b/app/models/otp_enrolment.rb
@@ -13,7 +13,10 @@ class OtpEnrolment
   def save
     return false unless valid?
 
-    user.enable_totp(secret: secret)
+    codes = user.otp_regenerate_backup_codes
+    saved = user.enable_totp(secret: secret)
+    @backup_codes = codes if saved
+    saved
   end
 
   def provisioning_uri

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,9 +39,9 @@
 #  status_update_count               :integer          default(0), not null
 #  last_sign_in_at                   :datetime
 #  otp_last_used_at                  :integer
-#  otp_backup_codes                  :string           default([]), is an Array
 #  otp_enabled_at                    :datetime
 #  otp_backup_codes_generated_at     :datetime
+#  otp_backup_codes                  :text
 #
 
 class User < ApplicationRecord

--- a/app/models/user/one_time_password.rb
+++ b/app/models/user/one_time_password.rb
@@ -85,6 +85,7 @@ module User::OneTimePassword
       remaining = otp_backup_codes - [code]
       self.otp_backup_codes = remaining
       update_column(:otp_backup_codes, remaining) if persisted?
+      @used_backup_code = true
       true
     end
     private :authenticate_backup_code
@@ -111,6 +112,13 @@ module User::OneTimePassword
     self.otp_enabled = true
     self.otp_enabled_at = Time.zone.now
     save
+  end
+
+  # Whether this instance consumed a backup code (rather than an
+  # authenticator code) in a successful `authenticate_otp` call, so
+  # controllers can warn the user that single-use codes are running down.
+  def used_backup_code?
+    @used_backup_code == true
   end
 
   def disable_otp

--- a/app/models/user/one_time_password.rb
+++ b/app/models/user/one_time_password.rb
@@ -5,6 +5,8 @@ module User::OneTimePassword
   included do
     has_one_time_password after_column_name: :otp_last_used_at
 
+    encrypts :otp_secret_key
+
     # otp_backup_codes is a single encrypted text column holding a JSON array of
     # the plaintext codes. active_model_otp expects an array, so serialize back
     # to one and default to an empty array when unset.

--- a/app/models/user/one_time_password.rb
+++ b/app/models/user/one_time_password.rb
@@ -3,8 +3,14 @@ module User::OneTimePassword
   extend ActiveSupport::Concern
 
   included do
-    has_one_time_password after_column_name: :otp_last_used_at,
-                          one_time_backup_codes: true
+    has_one_time_password after_column_name: :otp_last_used_at
+
+    # otp_backup_codes is a single encrypted text column holding a JSON array of
+    # the plaintext codes. active_model_otp expects an array, so serialize back
+    # to one and default to an empty array when unset.
+    serialize :otp_backup_codes, coder: JSON, type: Array
+    attribute :otp_backup_codes, default: []
+    encrypts :otp_backup_codes
 
     attr_accessor :entered_otp_code
 
@@ -15,14 +21,6 @@ module User::OneTimePassword
     validate :verify_otp_code, if: :otp_enabled_and_required?
     validate :otp_backup_codes_paired_with_timestamp
 
-    # The `before_create` hook in active_model_otp auto-generates backup codes
-    # if the `otp_backup_codes` column exists, but it has no awareness of the
-    # `otp_backup_codes_generated_at` column, so codes would be persisted
-    # without a matching issued-at timestamp. Codes are only meaningful
-    # alongside the timestamp, so suppress the auto-generation and let
-    # TOTP enrolment populate both columns together.
-    before_create -> { self.otp_backup_codes = [] }
-
     # active_model_otp reads `otp_counter_based` from self in
     # `authenticate_otp`, `otp_code` and `provisioning_uri`, so deriving it
     # from the persisted counter dispatches each user to the right HOTP/TOTP
@@ -31,22 +29,65 @@ module User::OneTimePassword
       otp_counter.present?
     end
 
-    # active_model_otp's `authenticate_totp` persists the anti-replay
-    # timestamp via `update(otp_last_used_at: ts)`. When `authenticate_otp`
-    # runs inside a save (e.g. PasswordChangesController#update with
-    # require_otp), that nested update re-runs validations and re-enters
-    # `verify_otp_code` with the same code. `otp_last_used_at` is now set, so
-    # ROTP rejects it as replayed and the outer save fails despite a valid
-    # code. Flag the in-progress authentication so the re-entrant validation
-    # skips re-verifying. The override must live here (on the class) rather
-    # than in the module body so `super` reaches the gem's method, which is
-    # included into the class by `has_one_time_password` above.
+    # Override the gem's `authenticate_otp` for two reasons:
+    #
+    # 1. The gem checks backup codes before the primary factor. Try the primary
+    #    factor first so a valid authenticator code never spends one of the
+    #    user's single-use backup codes, only falling back to backup codes when
+    #    it fails.
+    #
+    # 2. active_model_otp's `authenticate_totp` persists the anti-replay
+    #    timestamp via `update(otp_last_used_at: ts)`. When this runs inside a
+    #    save (e.g. PasswordChangesController#update with require_otp), that
+    #    nested update re-runs validations and re-enters `verify_otp_code`
+    #    with the same code. `otp_last_used_at` is now set, so ROTP rejects it
+    #    as replayed and the outer save fails despite a valid code. Flag the
+    #    in-progress authentication so the re-entrant validation skips
+    #    re-verifying.
+    #
+    # The override must live here (on the class) rather than in the module
+    # body so `super` reaches the gem's method, which is included into the
+    # class by `has_one_time_password` above.
     def authenticate_otp(code, options = {})
+      return false if code.blank?
+
       @authenticating_otp = true
-      super
+      super || authenticate_backup_code(code)
     ensure
       @authenticating_otp = false
     end
+
+    # active_model_otp's `before_create` hook would generate backup codes for
+    # every new user. Switch the gem's machinery off and replace it with the
+    # implementation below: `otp_regenerate_backup_codes` issues codes only when
+    # called explicitly, and `authenticate_otp` restores backup codes as a
+    # fallback to the primary factor.
+    def backup_codes_enabled?
+      false
+    end
+
+    # Replaces the gem's generator. Returns the codes, the only point at which
+    # they're shown to the user. They're persisted encrypted at rest via the
+    # `encrypts :otp_backup_codes` declaration. Callers are responsible for
+    # saving.
+    def otp_regenerate_backup_codes
+      codes = Array.new(self.class.otp_backup_codes_count) do
+        format("%0#{otp_digits}d", SecureRandom.random_number(10**otp_digits))
+      end
+      self.otp_backup_codes = codes
+      self.otp_backup_codes_generated_at = Time.current
+      codes
+    end
+
+    def authenticate_backup_code(code) # rubocop:disable Naming/PredicateMethod
+      return false unless otp_backup_codes.include?(code)
+
+      remaining = otp_backup_codes - [code]
+      self.otp_backup_codes = remaining
+      update_column(:otp_backup_codes, remaining) if persisted?
+      true
+    end
+    private :authenticate_backup_code
   end
 
   def otp_enabled?
@@ -93,14 +134,14 @@ module User::OneTimePassword
     otp_enabled? && require_otp?
   end
 
-  # Backup codes are only meaningful alongside a generated-at timestamp.
-  # Writing one without the other would mean e.g. the management page showing
-  # "last regenerated never" for a user who has codes.
-  # Enforce that they're set or cleared together.
+  # Backup codes are only meaningful alongside a generated-at timestamp,
+  # codes without one would mean e.g. the management page showing "last
+  # regenerated never" for a user who has codes. The reverse, a timestamp
+  # with no codes, is a legitimate state once every issued code has been
+  # consumed.
   def otp_backup_codes_paired_with_timestamp
-    has_codes = otp_backup_codes.present?
-    has_timestamp = otp_backup_codes_generated_at.present?
-    return if has_codes == has_timestamp
+    return if otp_backup_codes.blank? ||
+              otp_backup_codes_generated_at.present?
 
     errors.add(:otp_backup_codes,
                'must be set together with otp_backup_codes_generated_at')

--- a/app/models/user/one_time_password.rb
+++ b/app/models/user/one_time_password.rb
@@ -116,6 +116,8 @@ module User::OneTimePassword
   def disable_otp
     self.otp_enabled = false
     self.require_otp = false
+    self.otp_backup_codes = []
+    self.otp_backup_codes_generated_at = nil
     true
   end
 

--- a/app/views/one_time_passwords/_backup_code_used.html.erb
+++ b/app/views/one_time_passwords/_backup_code_used.html.erb
@@ -1,0 +1,25 @@
+<%# locals: (remaining:, lead: nil) %>
+<% if lead %>
+  <p><%= lead %></p>
+<% end %>
+
+<% if remaining.zero? %>
+  <p>
+    <%= _('You used your last backup code. Generate new backup codes now ' \
+          'so you are not locked out if you lose access to your ' \
+          'authenticator app.') %>
+  </p>
+<% else %>
+  <p>
+    <%= _('You used a backup code, which cannot be used again.') %>
+    <%= n_('You have {{count}} backup code left.',
+           'You have {{count}} backup codes left.',
+           remaining,
+           count: remaining) %>
+  </p>
+<% end %>
+
+<p>
+  <%= link_to _('Generate new backup codes'),
+              one_time_password_backup_codes_path %>
+</p>

--- a/app/views/one_time_passwords/_backup_codes.html.erb
+++ b/app/views/one_time_passwords/_backup_codes.html.erb
@@ -1,0 +1,27 @@
+<%# locals: (codes:) %>
+<div class="one-time-password__callout one-time-password__callout--warning backup-codes">
+  <h2><%= _('Your backup codes') %></h2>
+
+  <p>
+    <%= _('Each backup code can be used once in place of a code from your ' \
+          'authenticator app, for example if you lose your phone.') %>
+  </p>
+
+  <p>
+    <strong>
+      <%= _('Save these codes somewhere safe, they will not be shown ' \
+            'again. You can add them to a password manager or print them ' \
+            'and store them in a safe place.') %>
+    </strong>
+  </p>
+
+  <ul class="backup-codes__list">
+    <% codes.each do |code| %>
+      <li><code><%= code %></code></li>
+    <% end %>
+  </ul>
+
+  <p class="not-for-print">
+    <%= link_to _('Print codes'), '#', data: { print: true } %>
+  </p>
+</div>

--- a/app/views/one_time_passwords/_backup_codes.html.erb
+++ b/app/views/one_time_passwords/_backup_codes.html.erb
@@ -21,7 +21,15 @@
     <% end %>
   </ul>
 
-  <p class="not-for-print">
+  <div class="backup-codes__actions not-for-print">
+    <%= button_tag _('Copy codes'),
+                   type: 'button',
+                   class: 'button',
+                   data: {
+                     'clipboard-text': codes.join("\n"),
+                     'clipboard-success': _('Copied!')
+                   } %>
+
     <%= link_to _('Print codes'), '#', data: { print: true } %>
-  </p>
+  </div>
 </div>

--- a/app/views/one_time_passwords/backup_codes/show.html.erb
+++ b/app/views/one_time_passwords/backup_codes/show.html.erb
@@ -1,0 +1,47 @@
+<% @title = _('Backup codes') %>
+
+<h1><%= @title %></h1>
+
+<% if flash[:backup_codes] %>
+  <%= render 'one_time_passwords/backup_codes',
+             codes: flash[:backup_codes] %>
+<% else %>
+  <% if @user.otp_backup_codes_generated_at %>
+    <p>
+      <%= _('Your current backup codes were generated on {{date}}.',
+            date: simple_date(@user.otp_backup_codes_generated_at,
+                              format: :text)) %>
+    </p>
+
+    <p>
+      <%= n_('You have {{count}} backup code remaining.',
+             'You have {{count}} backup codes remaining.',
+             @user.otp_backup_codes.size,
+             count: @user.otp_backup_codes.size) %>
+    </p>
+  <% else %>
+    <p>
+      <%= _('You have no backup codes yet. Backup codes let you sign in ' \
+            'if you lose access to your authenticator app.') %>
+    </p>
+  <% end %>
+
+  <p>
+    <%= _('Generating new backup codes replaces all of your existing ' \
+          'codes.') %>
+  </p>
+
+  <p>
+    <%= _('Enter a current code from your authenticator app to confirm.') %>
+  </p>
+
+  <%= render 'one_time_passwords/code_form',
+             model: false,
+             form_url: one_time_password_backup_codes_path,
+             submit_label: _('Generate new backup codes') %>
+<% end %>
+
+<p>
+  <%= link_to _('Back to two factor authentication'),
+              one_time_password_path %>
+</p>

--- a/app/views/one_time_passwords/show.html.erb
+++ b/app/views/one_time_passwords/show.html.erb
@@ -26,6 +26,10 @@
       </div>
     <% end %>
 
+    <% if flash[:backup_codes] %>
+      <%= render 'backup_codes', codes: flash[:backup_codes] %>
+    <% end %>
+
     <p>
       <%= _('Two factor authentication is active on your account. ' \
             "You'll need to enter the code from your authenticator app " \
@@ -33,6 +37,12 @@
     </p>
 
     <ul class="one-time-password-actions not-for-print">
+      <li class="one-time-password-actions__action-item action-item">
+        <%= link_to one_time_password_backup_codes_path,
+                    :class => 'action-item__action' do %>
+          <%= _('Manage backup codes') %>
+        <% end %>
+      </li>
       <li class="one-time-password-actions__action-item action-item">
         <%= link_to one_time_password_path, :method => :delete,
                                             :class => 'action-item__action' do %>

--- a/app/views/users/two_factor_challenges/new.html.erb
+++ b/app/views/users/two_factor_challenges/new.html.erb
@@ -11,4 +11,9 @@
   <%= render 'one_time_passwords/code_form',
              model: false,
              form_url: signin_two_factor_path(modal: params[:modal].presence) %>
+
+  <p>
+    <%= _('If you have lost access to your authenticator app, you can ' \
+          'enter one of your backup codes instead.') %>
+  </p>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,6 +73,11 @@ module Alaveteli
     # Make Active Record use UTC-base instead of local time
     config.active_record.default_timezone = :utc
 
+    # otp_secret_key predates encryption, so an install holds plaintext secrets
+    # until its data migration encrypts them in place. Reading them has to keep
+    # working until that migration has run.
+    config.active_record.encryption.support_unencrypted_data = true
+
     # Disable the IP spoofing warning. This is triggered by a conflict between
     # the CLIENT_IP and X_FORWARDED_FOR headers. If you're using the example
     # nginx config, that should be setting X_FORWARDED_FOR which is used in

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,6 +6,14 @@ Rails.application.configure do
   # Make code changes take effect immediately without server restart.
   config.enable_reloading = true
 
+  # Production reads the Active Record Encryption keys from credentials, but
+  # development runs without them, so set insecure static keys here instead.
+  config.active_record.encryption.update(
+    primary_key: "development insecure primary key",
+    deterministic_key: "development insecure deterministic key",
+    key_derivation_salt: "development insecure key derivation salt"
+  )
+
   # Do not eager load code on boot.
   config.eager_load = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,6 +9,14 @@ Rails.application.configure do
   # While tests run files are not watched, reloading is not necessary.
   config.enable_reloading = false
 
+  # Production reads the Active Record Encryption keys from credentials, but the
+  # test suite runs without them, so set insecure static keys here instead.
+  config.active_record.encryption.update(
+    primary_key: "test insecure primary key",
+    deterministic_key: "test insecure deterministic key",
+    key_derivation_salt: "test insecure key derivation salt"
+  )
+
   # Eager loading loads your entire application. When running a single test locally,
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -281,6 +281,11 @@ Rails.application.routes.draw do
            :only => [:new, :show, :create, :update, :destroy],
            :path => '/profile/two_factor'
 
+  resource :one_time_password_backup_codes,
+           :only => [:show, :create],
+           :path => '/profile/two_factor/backup_codes',
+           :controller => 'one_time_passwords/backup_codes'
+
   match '/profile/sign_in' => 'users/sessions#new',
         :as => :signin,
         :via => :get

--- a/db/migrate/20260616160603_change_users_otp_backup_codes_to_text.rb
+++ b/db/migrate/20260616160603_change_users_otp_backup_codes_to_text.rb
@@ -1,0 +1,14 @@
+class ChangeUsersOtpBackupCodesToText < ActiveRecord::Migration[8.0]
+  # otp_backup_codes was a string column declared with `array: true`. Active
+  # Record Encryption writes a single ciphertext string, which can't go into an
+  # array column, so move the codes to a plain text column.
+  def up
+    remove_column :users, :otp_backup_codes
+    add_column :users, :otp_backup_codes, :text
+  end
+
+  def down
+    remove_column :users, :otp_backup_codes
+    add_column :users, :otp_backup_codes, :string, array: true, default: []
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -68,17 +68,47 @@
 
 ## Upgrade Notes
 
-* _Note:_ This release now allows responses to be received from any source,
-  1. Postfix/Exim `./script/mailin` pipe, 2. POP poller or 3. ActionMailbox
+* _Required:_ This release now allows responses to be received from any source,
+  1. Postfix/Exim `./script/mailin` pipe,
+  2. POP poller or
+  3. ActionMailbox
+
   While you can have multiple sources configured we recommend migrating to
-  ActionMailbox as the others are depreicated and will be removed in a future
+  ActionMailbox as the others are deprecated and will be removed in a future
   release.
+
   See: https://github.com/mysociety/alaveteli/wiki/ActionMailbox-Migration-Guide
 
-* _Required:_ After ActionMailbox migration please backup `config/master.key`.
-  This file gets generated automatically and is the private encryption key for
-  the credentials. Without it the application can't read credentials. If you
-  ever move servers or reinstall Alaveteli then you will need this file. See:
+* _Required:_ This release encrypts sensitive database columns (such as users'
+  two factor authentication secret and backup codes) with Active Record
+  Encryption, which reads its keys from the Rails credentials. Set the
+  credentials up with:
+
+      bin/rails config_files:set_credentials
+
+  This generates `config/master.key` and the credentials if they are missing,
+  adds an ActionMailbox ingress password and a set of Active Record Encryption
+  keys for anything not already set, and prints the ingress password so you can
+  configure it in your MTA (see above).
+
+  Existing values are never changed and it is safe to run more than once and
+  fresh installs already run this during installation.
+
+  Keep the encryption keys stable and secret; losing or changing them makes the
+  encrypted data unrecoverable. Back up the credentials as described below.
+
+* _Required:_ Back up `config/master.key` and `config/credentials.yml.enc`.
+  These are generated automatically and are not kept in version control.
+
+  The credentials file holds secrets such as the ActionMailbox ingress password
+  and the Active Record Encryption keys (see above), and `config/master.key` is
+  the private key needed to read it.
+
+  Without `config/master.key` the credentials, and every database column
+  encrypted with them, cannot be read, so store both somewhere safe and separate
+  from the server.
+
+  If you ever move servers or reinstall Alaveteli then you will need them. See:
   https://guides.rubyonrails.org/security.html#custom-credentials
 
 * _Required:_ Please update your `config/storage.yml` file to include a

--- a/lib/tasks/config_files.rake
+++ b/lib/tasks/config_files.rake
@@ -249,19 +249,16 @@ namespace :config_files do
     end
   end
 
-  desc 'Set the initial Rails credentials'
-  task set_initial_credentials: :environment do
-    next if Rails.root.join("config/credentials.yml.enc").exist?
-
-    check_for_env_vars(%w[SECRET_KEY_BASE INGRESS_PASSWORD], <<~TXT.squish)
-      rake config_files:set_initial_credentials
-        SECRET_KEY_BASE=...
-        INGRESS_PASSWORD=...
-    TXT
-    secret_key_base = ENV.fetch("SECRET_KEY_BASE")
-    ingress_password = ENV.fetch("INGRESS_PASSWORD")
-
+  desc 'Set the Rails credentials, adding any that are missing'
+  task set_credentials: :environment do
     require "active_support/encrypted_configuration"
+
+    # Generate the master key on first run so a single command can bootstrap the
+    # credentials, the same way `rails credentials:edit` would.
+    master_key = Rails.root.join("config/master.key")
+    unless master_key.exist? || ENV["RAILS_MASTER_KEY"]
+      master_key.write(ActiveSupport::EncryptedFile.generate_key)
+    end
 
     encrypted_file = ActiveSupport::EncryptedConfiguration.new(
       config_path: "config/credentials.yml.enc",
@@ -270,12 +267,55 @@ namespace :config_files do
       raise_if_missing_key: true
     )
 
-    encrypted_file.change do |tmp_path|
-      File.write(tmp_path, <<~YAML)
-        secret_key_base: #{secret_key_base}
+    # Add only what is missing, generating any value not supplied through the
+    # environment. Existing values are left untouched, so this is safe to run
+    # repeatedly and against credentials set up another way. secret_key_base is
+    # only a placeholder: config/general.yml is authoritative and overrides it
+    # at boot (see config/initializers/secret_token.rb).
+    existing = YAML.safe_load(encrypted_file.read) || {}
+
+    blocks = []
+
+    unless existing.key?("secret_key_base")
+      secret_key_base = ENV.fetch("SECRET_KEY_BASE") { SecureRandom.hex(64) }
+      blocks << "secret_key_base: #{secret_key_base}"
+    end
+
+    unless existing.dig("action_mailbox", "ingress_password")
+      ingress_password =
+        ENV.fetch("INGRESS_PASSWORD") { SecureRandom.alphanumeric(24) }
+      blocks << <<~YAML.chomp
         action_mailbox:
           ingress_password: #{ingress_password}
       YAML
+
+      puts "\e[1;33m" \
+        "ActionMailbox ingress password: #{ingress_password}\n" \
+        "Set this same value in your MTA (Postfix/Exim) configuration." \
+        "\e[0m"
     end
+
+    unless existing.key?("active_record_encryption")
+      blocks << <<~YAML.chomp
+        active_record_encryption:
+          primary_key: #{SecureRandom.alphanumeric(32)}
+          deterministic_key: #{SecureRandom.alphanumeric(32)}
+          key_derivation_salt: #{SecureRandom.alphanumeric(32)}
+      YAML
+    end
+
+    next if blocks.empty?
+
+    encrypted_file.change do |tmp_path|
+      parts = ([File.read(tmp_path).chomp] + blocks).reject(&:empty?)
+      File.write(tmp_path, parts.join("\n") + "\n")
+    end
+
+    puts "\e[1;33m" \
+      "IMPORTANT: back up config/master.key and config/credentials.yml.enc " \
+      "now, somewhere safe and separate from the server. Without " \
+      "config/master.key the credentials, and every database column " \
+      "encrypted with them, cannot be read." \
+      "\e[0m"
   end
 end

--- a/lib/tasks/temp.rake
+++ b/lib/tasks/temp.rake
@@ -20,6 +20,27 @@ namespace :temp do
     puts "Populating User#status_update_count completed."
   end
 
+  desc "Encrypt users' existing plaintext otp_secret_key"
+  task encrypt_user_otp_secret_keys: :environment do
+    # otp_secret_key predates Active Record Encryption, so existing rows hold
+    # the secret in plaintext. #encrypt re-saves each user's encrypted columns
+    # in place. support_unencrypted_data keeps unencrypted rows readable until
+    # this has run, so it can be run out of band after deploying and re-run
+    # safely.
+    scope = User.where.not(otp_secret_key: nil)
+    count = scope.count
+
+    scope.find_each.with_index do |user, index|
+      user.encrypt
+
+      erase_line
+      print "Encrypting otp_secret_key #{index + 1}/#{count}"
+    end
+
+    erase_line
+    puts "Encrypting otp_secret_key completed."
+  end
+
   def erase_line
     # https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences
     print "\e[1G\e[K"

--- a/script/install-as-user
+++ b/script/install-as-user
@@ -194,7 +194,7 @@ script/rails-post-deploy
 
 echo Setting credentials
 INGRESS_PASSWORD=$(random_alphanumerics 24)
-bundle exec rake config_files:set_initial_credentials SECRET_KEY_BASE=$RANDOM_COOKIE_SECRET INGRESS_PASSWORD=$INGRESS_PASSWORD
+bundle exec rake config_files:set_credentials SECRET_KEY_BASE=$RANDOM_COOKIE_SECRET INGRESS_PASSWORD=$INGRESS_PASSWORD
 
 # We created the test database above and migrated the development / production
 # database through `script/rails-post-deploy`, but in a development install

--- a/spec/controllers/one_time_passwords/backup_codes_controller_spec.rb
+++ b/spec/controllers/one_time_passwords/backup_codes_controller_spec.rb
@@ -1,0 +1,138 @@
+require 'spec_helper'
+
+RSpec.describe OneTimePasswords::BackupCodesController do
+  before :each do
+    allow(AlaveteliConfiguration).
+      to receive(:enable_two_factor_auth).and_return(true)
+  end
+
+  let(:user) { FactoryBot.create(:user, :enable_totp) }
+  let(:valid_code) { user.otp_code }
+  let(:invalid_code) { valid_code == '000000' ? '000001' : '000000' }
+
+  describe 'GET show' do
+    it 'redirects to the sign-in page without a signed in user' do
+      get :show
+      expect(response).
+        to redirect_to(signin_path(token: PostRedirect.last.token))
+    end
+
+    it 'redirects a HOTP user to the two factor settings page' do
+      hotp_user = FactoryBot.create(:user, :enable_hotp)
+      sign_in hotp_user
+      get :show
+      expect(response).to redirect_to(one_time_password_path)
+    end
+
+    it 'redirects a user without 2FA to the two factor settings page' do
+      sign_in FactoryBot.create(:user)
+      get :show
+      expect(response).to redirect_to(one_time_password_path)
+    end
+
+    it 'renders the management page for a TOTP user' do
+      sign_in user
+      get :show
+      expect(response).to render_template(:show)
+    end
+
+    it 'raises ActiveRecord::RecordNotFound when 2factor auth is disabled' do
+      allow(AlaveteliConfiguration).
+        to receive(:enable_two_factor_auth).and_return(false)
+      sign_in user
+
+      expect { get :show }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe 'POST create' do
+    it 'redirects to the sign-in page without a signed in user' do
+      post :create
+      expect(response).
+        to redirect_to(signin_path(token: PostRedirect.last.token))
+    end
+
+    context 'with a valid code from the authenticator app' do
+      before { sign_in user }
+
+      it 'issues a fresh set of backup codes' do
+        expect { post :create, params: { otp_code: valid_code } }.
+          to change { user.reload.otp_backup_codes }
+        expect(user.otp_backup_codes.size).to eq(12)
+        expect(user.otp_backup_codes_generated_at).to be_present
+      end
+
+      it 'replaces any existing codes' do
+        old_codes = user.otp_regenerate_backup_codes
+        user.save!
+
+        post :create, params: { otp_code: valid_code }
+
+        expect(user.reload.authenticate_otp(old_codes.first)).to eq(false)
+      end
+
+      it 'passes the new plaintext codes to the redirect target' do
+        post :create, params: { otp_code: valid_code }
+
+        expect(flash[:backup_codes].size).to eq(12)
+      end
+
+      it 'redirects back to the management page with a notice' do
+        post :create, params: { otp_code: valid_code }
+
+        expect(response).to redirect_to(one_time_password_backup_codes_path)
+        expect(flash[:notice]).to eq('New backup codes generated')
+      end
+    end
+
+    context 'with a valid backup code as the confirmation code' do
+      before { sign_in user }
+
+      it 'issues a fresh set of backup codes' do
+        old_codes = user.otp_regenerate_backup_codes
+        user.save!
+
+        post :create, params: { otp_code: old_codes.first }
+
+        expect(flash[:backup_codes].size).to eq(12)
+        expect(response).to redirect_to(one_time_password_backup_codes_path)
+      end
+    end
+
+    context 'with an invalid code' do
+      before { sign_in user }
+
+      it 'does not change the stored codes' do
+        user.otp_regenerate_backup_codes
+        user.save!
+
+        expect { post :create, params: { otp_code: invalid_code } }.
+          not_to change { user.reload.otp_backup_codes }
+      end
+
+      it 're-renders the management page with an error' do
+        post :create, params: { otp_code: invalid_code }
+
+        expect(response).to render_template(:show)
+        expect(flash[:error]).to be_present
+      end
+    end
+
+    context 'with no code' do
+      before { sign_in user }
+
+      it 're-renders the management page with an error' do
+        post :create
+
+        expect(response).to render_template(:show)
+        expect(flash[:error]).to be_present
+      end
+
+      it 'does not issue codes' do
+        post :create
+
+        expect(user.reload.otp_backup_codes).to be_empty
+      end
+    end
+  end
+end

--- a/spec/controllers/one_time_passwords_controller_spec.rb
+++ b/spec/controllers/one_time_passwords_controller_spec.rb
@@ -230,6 +230,12 @@ RSpec.describe OneTimePasswordsController do
         expect(flash[:notice]).to eq('Two factor authentication enabled')
       end
 
+      it 'passes the new backup codes to the redirect target' do
+        post :create, params: { otp_enrolment: { otp_code: valid_code } }
+
+        expect(flash[:backup_codes].size).to eq(12)
+      end
+
       context 'and the user had no 2FA before' do
         it 'does not set the upgrade-from-HOTP flag' do
           post :create, params: { otp_enrolment: { otp_code: valid_code } }
@@ -457,6 +463,17 @@ RSpec.describe OneTimePasswordsController do
         it 'disables two factor authentication' do
           delete :destroy, params: { otp_code: valid_code }
           expect(user.reload.otp_enabled?).to eq(false)
+        end
+
+        it 'clears any backup codes' do
+          user.otp_regenerate_backup_codes
+          user.save!
+
+          delete :destroy, params: { otp_code: valid_code }
+
+          user.reload
+          expect(user.otp_backup_codes).to be_empty
+          expect(user.otp_backup_codes_generated_at).to be_nil
         end
 
         it 'redirects to the settings page' do

--- a/spec/controllers/password_changes_controller_spec.rb
+++ b/spec/controllers/password_changes_controller_spec.rb
@@ -590,6 +590,24 @@ RSpec.describe PasswordChangesController do
         expect(flash[:notice]).not_to match(/passcode/i)
       end
 
+      it 'changes the password with a backup code and notes its use' do
+        codes = user.otp_regenerate_backup_codes
+        user.save!
+        old_hash = user.hashed_password
+
+        params = @valid_password_params.merge(otp_code: codes.first)
+        put :update, params: {
+          id: post_redirect.token,
+          password_change_user: params
+        }
+
+        expect(user.reload.hashed_password).not_to eq(old_hash)
+        expect(flash[:notice]).
+          to eq(partial: 'one_time_passwords/backup_code_used',
+                locals: { lead: 'Your password has been changed.',
+                          remaining: 11 })
+      end
+
       it 'respects a pretoken redirect on success' do
         pretoken = PostRedirect.create(user: user, uri: '/')
         params = @valid_password_params.merge(otp_code: user.otp_code)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -39,9 +39,9 @@
 #  status_update_count               :integer          default(0), not null
 #  last_sign_in_at                   :datetime
 #  otp_last_used_at                  :integer
-#  otp_backup_codes                  :string           default([]), is an Array
 #  otp_enabled_at                    :datetime
 #  otp_backup_codes_generated_at     :datetime
+#  otp_backup_codes                  :text
 #
 
 FactoryBot.define do

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -39,9 +39,9 @@
 #  status_update_count               :integer          default(0), not null
 #  last_sign_in_at                   :datetime
 #  otp_last_used_at                  :integer
-#  otp_backup_codes                  :string           default([]), is an Array
 #  otp_enabled_at                    :datetime
 #  otp_backup_codes_generated_at     :datetime
+#  otp_backup_codes                  :text
 #
 
 # If sample data has been loaded you can log in as any of these users with their

--- a/spec/integration/two_factor_backup_codes_spec.rb
+++ b/spec/integration/two_factor_backup_codes_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+require 'integration/alaveteli_dsl'
+
+RSpec.describe 'managing two factor backup codes' do
+  before do
+    allow(AlaveteliConfiguration).
+      to receive(:enable_two_factor_auth).and_return(true)
+  end
+
+  let(:user) { FactoryBot.create(:user, :enable_totp) }
+
+  it 'regenerates codes from the management page' do
+    user.otp_regenerate_backup_codes
+    user.save!
+
+    using_session(login(user)) do
+      # The sign-in challenge consumed the current TOTP code; move past its
+      # 30 second window so the confirmation code is fresh.
+      travel(31.seconds) do
+        visit one_time_password_path
+        click_link 'Manage backup codes'
+
+        expect(page).to have_content('Backup codes')
+
+        fill_in 'Code from your authenticator app',
+                with: user.otp_code
+        click_button 'Generate new backup codes'
+
+        expect(page).to have_content('New backup codes generated')
+        expect(page).to have_content('Save these codes somewhere safe')
+
+        new_codes = page.all('.backup-codes__list code').map(&:text)
+        expect(new_codes.size).to eq(12)
+      end
+    end
+  end
+
+  it 'rejects regeneration with a wrong code' do
+    user.otp_regenerate_backup_codes
+    user.save!
+
+    using_session(login(user)) do
+      visit one_time_password_backup_codes_path
+
+      valid_code = user.otp_code
+      wrong_code = valid_code == '000000' ? '000001' : '000000'
+      fill_in 'Code from your authenticator app', with: wrong_code
+      click_button 'Generate new backup codes'
+
+      expect(page).to have_content('Invalid one time password')
+    end
+  end
+end

--- a/spec/integration/two_factor_enrolment_spec.rb
+++ b/spec/integration/two_factor_enrolment_spec.rb
@@ -47,6 +47,23 @@ RSpec.describe 'enrolling in two factor authentication' do
         expect(user.totp?).to eq(true)
       end
     end
+
+    it 'shows the new backup codes exactly once' do
+      using_session(login(user)) do
+        visit new_one_time_password_path
+        complete_enrolment_with_valid_code
+
+        expect(page).to have_content('Save these codes somewhere safe')
+        codes = page.all('.backup-codes__list code').map(&:text)
+        expect(codes.size).to eq(12)
+        expect(codes).to all(match(/\A\d{6}\z/))
+
+        expect(user.reload.authenticate_otp(codes.first)).to eq(true)
+
+        visit one_time_password_path
+        expect(page).not_to have_content('Save these codes somewhere safe')
+      end
+    end
   end
 
   context 'as a user already on HOTP' do

--- a/spec/integration/two_factor_enrolment_spec.rb
+++ b/spec/integration/two_factor_enrolment_spec.rb
@@ -58,6 +58,10 @@ RSpec.describe 'enrolling in two factor authentication' do
         expect(codes.size).to eq(12)
         expect(codes).to all(match(/\A\d{6}\z/))
 
+        copy_button = page.find_button('Copy codes')
+        expect(copy_button['data-clipboard-text']).to eq(codes.join("\n"))
+        expect(copy_button['data-clipboard-success']).to eq('Copied!')
+
         expect(user.reload.authenticate_otp(codes.first)).to eq(true)
 
         visit one_time_password_path

--- a/spec/integration/two_factor_sign_in_spec.rb
+++ b/spec/integration/two_factor_sign_in_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe 'signing in with two factor authentication' do
         click_button 'Verify'
 
         expect(page).to have_content(user.name)
+        expect(page).to have_no_content('You used a backup code')
       end
     end
 
@@ -61,6 +62,29 @@ RSpec.describe 'signing in with two factor authentication' do
         click_button 'Verify'
 
         expect(page).to have_content(user.name)
+        expect(page).
+          to have_content('You used a backup code, which cannot be used ' \
+                          'again. You have 11 backup codes left.')
+        expect(page).to have_link('Generate new backup codes')
+      end
+    end
+
+    it 'warns when the last backup code is used' do
+      codes = user.otp_regenerate_backup_codes
+      user.otp_backup_codes = [user.otp_backup_codes.first]
+      user.save!
+
+      using_session(without_login) do
+        submit_credentials(user)
+
+        fill_in 'Code from your authenticator app', with: codes.first
+        click_button 'Verify'
+
+        expect(page).to have_content(user.name)
+        expect(page).
+          to have_content('You used your last backup code. Generate new ' \
+                          'backup codes now so you are not locked out')
+        expect(page).to have_link('Generate new backup codes')
       end
     end
   end

--- a/spec/integration/two_factor_sign_in_spec.rb
+++ b/spec/integration/two_factor_sign_in_spec.rb
@@ -44,6 +44,25 @@ RSpec.describe 'signing in with two factor authentication' do
         expect(page).to have_content(user.name)
       end
     end
+
+    it 'accepts a backup code in place of an authenticator code' do
+      codes = user.otp_regenerate_backup_codes
+      user.save!
+
+      using_session(without_login) do
+        submit_credentials(user)
+
+        expect(page).
+          to have_content('If you have lost access to your authenticator ' \
+                          'app, you can enter one of your backup codes ' \
+                          'instead')
+
+        fill_in 'Code from your authenticator app', with: codes.first
+        click_button 'Verify'
+
+        expect(page).to have_content(user.name)
+      end
+    end
   end
 
   context 'as a HOTP user' do

--- a/spec/models/otp_enrolment_spec.rb
+++ b/spec/models/otp_enrolment_spec.rb
@@ -98,6 +98,19 @@ RSpec.describe OtpEnrolment do
       it 'returns true' do
         expect(enrolment.save).to eq(true)
       end
+
+      it 'issues backup codes alongside their timestamp' do
+        enrolment.save
+        user.reload
+        expect(user.otp_backup_codes.size).to eq(12)
+        expect(user.otp_backup_codes_generated_at).to be_present
+      end
+
+      it 'exposes the plaintext backup codes after saving' do
+        enrolment.save
+        expect(enrolment.backup_codes.size).to eq(12)
+        expect(enrolment.backup_codes).to all(match(/\A\d{6}\z/))
+      end
     end
 
     context 'with a code that does not match' do
@@ -124,6 +137,14 @@ RSpec.describe OtpEnrolment do
         enrolment.save
         expect(enrolment.errors[:otp_code]).to be_present
       end
+
+      it 'does not issue backup codes' do
+        enrolment.save
+        user.reload
+        expect(user.otp_backup_codes).to be_empty
+        expect(user.otp_backup_codes_generated_at).to be_nil
+        expect(enrolment.backup_codes).to be_nil
+      end
     end
 
     context 'when the underlying user save returns false' do
@@ -132,6 +153,12 @@ RSpec.describe OtpEnrolment do
       it 'returns false rather than reporting success' do
         allow(user).to receive(:save).and_return(false)
         expect(enrolment.save).to eq(false)
+      end
+
+      it 'does not expose backup codes' do
+        allow(user).to receive(:save).and_return(false)
+        enrolment.save
+        expect(enrolment.backup_codes).to be_nil
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1343,6 +1343,16 @@ RSpec.describe User do
       expect(user.authenticate_otp(user.otp_code)).to eq(true)
     end
 
+    it 'records that a backup code was used' do
+      expect { user.authenticate_otp(codes.first) }.
+        to change(user, :used_backup_code?).from(false).to(true)
+    end
+
+    it 'does not set the backup-code flag for an authenticator code' do
+      user.authenticate_otp(user.otp_code)
+      expect(user.used_backup_code?).to eq(false)
+    end
+
     it 'leaves the user valid after the last code is consumed' do
       user.otp_backup_codes.size.times { |i| user.authenticate_otp(codes[i]) }
       user.reload

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1194,6 +1194,17 @@ RSpec.describe User do
       user = User.new
       expect(user.disable_otp).to eq(true)
     end
+
+    it 'clears backup codes and their generated-at timestamp' do
+      user = FactoryBot.create(:user, :enable_totp)
+      user.otp_regenerate_backup_codes
+      user.save!
+
+      user.disable_otp
+
+      expect(user.otp_backup_codes).to be_empty
+      expect(user.otp_backup_codes_generated_at).to be_nil
+    end
   end
 
   describe '#require_otp?' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,9 +39,9 @@
 #  status_update_count               :integer          default(0), not null
 #  last_sign_in_at                   :datetime
 #  otp_last_used_at                  :integer
-#  otp_backup_codes                  :string           default([]), is an Array
 #  otp_enabled_at                    :datetime
 #  otp_backup_codes_generated_at     :datetime
+#  otp_backup_codes                  :text
 #
 
 require 'spec_helper'
@@ -998,6 +998,17 @@ RSpec.describe User do
         expect(user.save).to eq(true)
         expect(user.reload.name).to eq('Renamed User')
       end
+
+      it 'saves a TOTP user with a backup code' do
+        user = FactoryBot.create(:user, :enable_totp)
+        codes = user.otp_regenerate_backup_codes
+        user.save!
+        user.name = 'Renamed User'
+        user.require_otp = true
+        user.entered_otp_code = codes.first
+        expect(user.save).to eq(true)
+        expect(user.reload.name).to eq('Renamed User')
+      end
     end
 
     context 'with otp disabled' do
@@ -1233,6 +1244,7 @@ RSpec.describe User do
     it 'is empty on a newly created user' do
       user = FactoryBot.create(:user)
       expect(user.otp_backup_codes).to eq([])
+      expect(user.otp_backup_codes_generated_at).to be_nil
     end
 
     it 'is valid when both codes and timestamp are blank' do
@@ -1257,12 +1269,74 @@ RSpec.describe User do
       expect(user.errors[:otp_backup_codes]).not_to be_empty
     end
 
-    it 'is invalid when a timestamp is set without codes' do
+    it 'is valid when a timestamp remains after all codes are consumed' do
       user = FactoryBot.build(:user,
                               otp_backup_codes: [],
                               otp_backup_codes_generated_at: Time.current)
-      expect(user).not_to be_valid
-      expect(user.errors[:otp_backup_codes]).not_to be_empty
+      expect(user).to be_valid
+    end
+  end
+
+  describe '#otp_regenerate_backup_codes' do
+    it 'returns the configured number of plaintext codes' do
+      user = FactoryBot.build(:user, :enable_totp)
+      codes = user.otp_regenerate_backup_codes
+      expect(codes.size).to eq(12)
+      expect(codes).to all(match(/\A\d{6}\z/))
+    end
+
+    it 'stores the codes encrypted at rest' do
+      user = FactoryBot.create(:user, :enable_totp)
+      codes = user.otp_regenerate_backup_codes
+      user.save!
+
+      raw = User.connection.select_value(
+        "SELECT otp_backup_codes FROM users WHERE id = #{user.id}"
+      )
+      codes.each { |code| expect(raw).not_to include(code) }
+      expect(user.reload.otp_backup_codes).to eq(codes)
+    end
+
+    it 'sets otp_backup_codes_generated_at' do
+      user = FactoryBot.build(:user, :enable_totp)
+      expect { user.otp_regenerate_backup_codes }.
+        to change(user, :otp_backup_codes_generated_at).from(nil)
+    end
+  end
+
+  describe 'backup code authentication' do
+    let(:user) { FactoryBot.create(:user, :enable_totp) }
+    let!(:codes) { user.otp_regenerate_backup_codes.tap { user.save! } }
+
+    it 'accepts an issued backup code' do
+      expect(user.authenticate_otp(codes.first)).to eq(true)
+    end
+
+    it 'consumes a backup code on use' do
+      user.authenticate_otp(codes.first)
+      expect(user.reload.otp_backup_codes.size).to eq(codes.size - 1)
+      expect(user.authenticate_otp(codes.first)).to eq(false)
+    end
+
+    it 'leaves the remaining codes usable after one is consumed' do
+      user.authenticate_otp(codes.first)
+      expect(user.authenticate_otp(codes.last)).to eq(true)
+    end
+
+    it 'rejects a code that was not issued' do
+      unissued = format('%06d', (codes.first.to_i + 1) % 1_000_000)
+      expect(user.authenticate_otp(unissued)).to eq(false)
+    end
+
+    it 'still accepts a current TOTP code when backup codes exist' do
+      expect(user.authenticate_otp(user.otp_code)).to eq(true)
+    end
+
+    it 'leaves the user valid after the last code is consumed' do
+      user.otp_backup_codes.size.times { |i| user.authenticate_otp(codes[i]) }
+      user.reload
+      expect(user.otp_backup_codes).to be_empty
+      expect(user).to be_valid
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Part of #9241 

Follows on from #9317 

## What does this do?

Adds backup codes for 2FA which are issues when the user first enrols, and can be regenerated manually by the user. Includes a management page where the user can see when they last generated backup codes and how many backup codes they have remaining.

## Implementation notes

I originally implemented this using bcrypt, as that's the approach one of the open PRs on the active_model_otp repo took. But after thinking about it bcrypt has the following weaknesses:

- bcrypt is slow by design, but that means generating 12 codes and bcrypting them all takes ~3 seconds on my laptop, not terrible but not ideal. Same cost when checking backup codes as well.
- Because they're 6 digit codes it's a small keyspace to brute-force if someone gets hold of a DB dump.
- The otp_secret_key was still in plain text, so if someone got hold of a DB dump they wouldn't need to brute-force the backup codes because they could derive valid keys from this.

So given all that I switched the implementation to use Active Record Encryption, which encrypts the database columns using some new configuration variables. This makes it almost instant to generate or check a backup code, and makes a database dump far less useful to an attacker.

As a bonus encrypted attributes also show up as `"[FILTERED]"` in the console when e.g. inspecting a user, so should make it harder to accidentally leak these credentials.

## Screenshots


https://github.com/user-attachments/assets/470729fb-ba63-47f3-9ca0-e31c7ad505b4


[skip changelog]
