### PR TITLE
Improve annotate prominence checks

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -63,9 +63,7 @@ class CommentsController < ApplicationController
     raise "Unknown type #{ params[:type] }" unless params[:type] == 'request'
 
     @info_request = InfoRequest.find_by_url_title!(params[:url_title])
-    return unless @info_request.embargo && cannot?(:read, @info_request)
-
-    raise ActiveRecord::RecordNotFound
+    render_hidden if cannot?(:read, @info_request)
   end
 
   def build_track_thing

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Check request prominence when annotating requests (Gareth Rees, Santosh Kumar
+  Puppala)
 * Remove user name from account confirmation email to guard against spam
   reputation issues (Gareth Rees)
 * Remove 720p and 1080p from default spam terms, as these are too generic and

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -9,6 +9,186 @@ RSpec.describe CommentsController, "when commenting on a request" do
     allow(controller).to receive(:current_ability).and_return(ability)
   end
 
+  describe 'when the request is hidden' do
+    let(:request_owner) { FactoryBot.create(:user) }
+    let(:hidden_request) do
+      FactoryBot.create(:info_request, :hidden, user: request_owner)
+    end
+
+    context 'when a user is not logged in' do
+      it 'does not render the annotation form' do
+        get :new, params: {
+          url_title: hidden_request.url_title,
+          type: 'request'
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+
+      it 'does not render the preview' do
+        post :preview, params: {
+          url_title: hidden_request.url_title,
+          comment: { body: 'Some content' },
+          type: 'request',
+          submitted_comment: 1,
+          preview: 1
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+    end
+
+    context 'when logged in as a non-owner' do
+      let(:other_user) { FactoryBot.create(:user) }
+      let(:ability) { Ability.new(other_user) }
+
+      before { sign_in other_user }
+
+      it 'does not render the annotation form' do
+        get :new, params: {
+          url_title: hidden_request.url_title,
+          type: 'request'
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+
+      it 'does not render the preview' do
+        post :preview, params: {
+          url_title: hidden_request.url_title,
+          comment: { body: 'Some content' },
+          type: 'request',
+          submitted_comment: 1,
+          preview: 1
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+    end
+
+    context 'when logged in as the request owner' do
+      let(:ability) { Ability.new(request_owner) }
+
+      before { sign_in request_owner }
+
+      it 'does not render the annotation form' do
+        get :new, params: {
+          url_title: hidden_request.url_title,
+          type: 'request'
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+
+      it 'does not render the preview' do
+        post :preview, params: {
+          url_title: hidden_request.url_title,
+          comment: { body: 'Some content' },
+          type: 'request',
+          submitted_comment: 1,
+          preview: 1
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+    end
+  end
+
+  describe 'when the request is requester_only' do
+    let(:request_owner) { FactoryBot.create(:user) }
+    let(:requester_only_request) do
+      FactoryBot.create(:info_request, :requester_only, user: request_owner)
+    end
+
+    context 'when the user is not logged in' do
+      it 'does not render the annotation form' do
+        get :new, params: {
+          url_title: requester_only_request.url_title,
+          type: 'request'
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+
+      it 'does not render the preview' do
+        post :preview, params: {
+          url_title: requester_only_request.url_title,
+          comment: { body: 'Some content' },
+          type: 'request',
+          submitted_comment: 1,
+          preview: 1
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+    end
+
+    context 'when logged in as a non-owner' do
+      let(:other_user) { FactoryBot.create(:user) }
+      let(:ability) { Ability.new(other_user) }
+
+      before { sign_in other_user }
+
+      it 'does not render the annotation form' do
+        get :new, params: {
+          url_title: requester_only_request.url_title,
+          type: 'request'
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+
+      it 'does not render the preview' do
+        post :preview, params: {
+          url_title: requester_only_request.url_title,
+          comment: { body: 'Some content' },
+          type: 'request',
+          submitted_comment: 1,
+          preview: 1
+        }
+
+        expect(response).to render_template('request/hidden')
+        expect(response.code).to eq('403')
+      end
+    end
+
+    context 'when logged in as the request owner' do
+      let(:ability) { Ability.new(request_owner) }
+
+      before { sign_in request_owner }
+
+      it 'renders the annotation form' do
+        get :new, params: {
+          url_title: requester_only_request.url_title,
+          type: 'request'
+        }
+
+        expect(response).to be_successful
+      end
+
+      it 'renders the preview' do
+        post :preview, params: {
+          url_title: requester_only_request.url_title,
+          comment: { body: 'Some content' },
+          type: 'request',
+          submitted_comment: 1,
+          preview: 1
+        }
+
+        expect(response).to be_successful
+      end
+    end
+  end
+
   describe 'dealing with embargoed requests' do
     let(:user) { FactoryBot.create(:user) }
     let(:pro_user) { FactoryBot.create(:pro_user) }

--- a/spec/factories/info_requests.rb
+++ b/spec/factories/info_requests.rb
@@ -217,6 +217,10 @@ FactoryBot.define do
       prominence { 'hidden' }
     end
 
+    trait :requester_only do
+      prominence { 'requester_only' }
+    end
+
     trait :backpage do
       prominence { 'backpage' }
     end
@@ -302,6 +306,7 @@ FactoryBot.define do
             traits: [:with_old_incoming, :awaiting_description]
     factory :awaiting_description, traits: [:awaiting_description]
     factory :hidden_request, traits: [:hidden]
+    factory :requester_only_request, traits: [:requester_only]
     factory :backpage_request, traits: [:backpage]
     factory :overdue_request, traits: [:overdue]
     factory :very_overdue_request, traits: [:very_overdue]


### PR DESCRIPTION
Check request prominence when annotating requests 

The annotation (comments) controller enforces the prominence read-check
only when a request is embargoed. A request whose prominence is `hidden`
or `requester_only` but which has no embargo loads anyway, and the
annotation form renders the request's TITLE to an unauthenticated
visitor who knows the request's url_title slug. The main request view
(request#show) enforces prominence unconditionally; the comments path
does not.

Thanks to Santosh Kumar Puppala (@Santoshkumarpuppala) for reporting the
bug and providing a suggested fix.

## Screenshots

<img width="1062" height="371" alt="Screenshot 2026-06-18 at 17 28 31" src="https://github.com/user-attachments/assets/4ef2a7e5-70cd-4224-b38b-2b12648223d4" />
