### PR TITLE
Update attachment erasing

### DIFF
--- a/app/controllers/admin/foi_attachments/erasures_controller.rb
+++ b/app/controllers/admin/foi_attachments/erasures_controller.rb
@@ -6,12 +6,10 @@ class Admin::FoiAttachments::ErasuresController < AdminController
   before_action :check_info_request
 
   def create
-    if @foi_attachment.erase(editor: admin_current_user, reason: erasure_reason)
-      flash[:notice] = success_message
-    else
-      flash[:error] = failure_message
-    end
-
+    @foi_attachment.erase_later(
+      editor: admin_current_user, reason: erasure_reason
+    )
+    flash[:notice] = 'Attachment erasure has been queued.'
     redirect_to edit_admin_foi_attachment_path(@foi_attachment)
   end
 
@@ -24,14 +22,6 @@ class Admin::FoiAttachments::ErasuresController < AdminController
 
   def erasure_params
     params.require(:foi_attachment).permit(:erasure_reason)
-  end
-
-  def success_message
-    'Attachment successfully erased.'
-  end
-
-  def failure_message
-    'Could not erase this attachment. Request technical assistance.'
   end
 
   def set_foi_attachment

--- a/app/jobs/foi_attachment/erase_job.rb
+++ b/app/jobs/foi_attachment/erase_job.rb
@@ -1,0 +1,16 @@
+##
+# Job to erase a FoiAttachment.
+#
+# Example:
+#   FoiAttachment::EraseJob.perform_later(
+#     FoiAttachment.first, editor: User.first, reason: 'GDPR request'
+#   )
+#
+class FoiAttachment::EraseJob < ApplicationJob
+  queue_as :default
+  unique :until_and_while_executing, on_conflict: :log
+
+  def perform(attachment, editor:, reason:)
+    attachment.erase(editor: editor, reason: reason)
+  end
+end

--- a/app/models/foi_attachment/erasable.rb
+++ b/app/models/foi_attachment/erasable.rb
@@ -18,8 +18,14 @@ module FoiAttachment::Erasable
     raise ErasedError, "attachment has been erased (ID=#{id})" if erased?
   end
 
+  def erase_later(editor:, reason:)
+    FoiAttachment::EraseJob.perform_later(self, editor: editor, reason: reason)
+  end
+
   def erase(editor:, reason:)
     return if erased?
+
+    mask_siblings
 
     transaction do |t|
       t.after_rollback { return false }

--- a/app/models/foi_attachment/maskable.rb
+++ b/app/models/foi_attachment/maskable.rb
@@ -27,4 +27,13 @@ module FoiAttachment::Maskable
   def mask_later
     FoiAttachment::MaskJob.perform_later(self)
   end
+
+  def mask_siblings
+    incoming_message.foi_attachments.each do |sibling|
+      next if sibling == self
+      next if sibling.masked? || sibling.erased?
+
+      sibling.mask
+    end
+  end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Move admin attachment erasure into background job (Graeme Porteous)
 * Add Search module providing a backend-agnostic search interface, decoupling
   controllers, models and mailers from Xapian (Graeme Porteous)
 * Fix blank responses caused by deeply nested emails (Graeme Porteous)

--- a/spec/controllers/admin/foi_attachments/erasures_controller_spec.rb
+++ b/spec/controllers/admin/foi_attachments/erasures_controller_spec.rb
@@ -21,21 +21,10 @@ RSpec.describe Admin::FoiAttachments::ErasuresController do
       }
     end
 
-    def erase_attachment_event
-      info_request.info_request_events.find_by(event_type: 'erase_attachment')
-    end
-
-    it 'erases the attachment' do
-      post :create, params: erase_params
-      expect { foi_attachment.reload }.to change(foi_attachment, :erased?).
-        from(false).to(true)
-    end
-
-    it 'logs event with editor and reason' do
+    it 'queues an erase job for the attachment' do
       expect { post :create, params: erase_params }.
-        to change { erase_attachment_event }.from(nil)
-      expect(erase_attachment_event.params[:editor]).to eq(admin_user)
-      expect(erase_attachment_event.params[:reason]).to eq('GDPR request')
+        to have_enqueued_job(FoiAttachment::EraseJob).
+        with(foi_attachment, editor: admin_user, reason: 'GDPR request')
     end
 
     it 'redirects to edit page with success message' do
@@ -43,18 +32,7 @@ RSpec.describe Admin::FoiAttachments::ErasuresController do
 
       expect(response).
         to redirect_to(edit_admin_foi_attachment_path(foi_attachment))
-      expect(flash[:notice]).to eq('Attachment successfully erased.')
-    end
-
-    it 'shows error message if erasure fails' do
-      allow_any_instance_of(FoiAttachment).to receive(:erase).and_return(false)
-
-      post :create, params: erase_params
-
-      expect(response).
-        to redirect_to(edit_admin_foi_attachment_path(foi_attachment))
-      expect(flash[:error]).
-        to eq('Could not erase this attachment. Request technical assistance.')
+      expect(flash[:notice]).to eq('Attachment erasure has been queued.')
     end
 
     it 'raises ParameterMissing if reason is blank' do

--- a/spec/jobs/foi_attachment/erase_job_spec.rb
+++ b/spec/jobs/foi_attachment/erase_job_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+RSpec.describe FoiAttachment::EraseJob, type: :job do
+  let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
+  let(:incoming_message) { info_request.incoming_messages.first }
+  let(:attachment) do
+    FactoryBot.create(:body_text, incoming_message: incoming_message)
+  end
+  let(:editor) { FactoryBot.create(:admin_user) }
+  let(:reason) { 'GDPR request' }
+
+  def perform
+    described_class.new.perform(attachment, editor: editor, reason: reason)
+  end
+
+  it 'erases the attachment' do
+    expect(attachment).to receive(:erase).with(editor: editor, reason: reason)
+    perform
+  end
+
+  context 'with an unmasked sibling attachment' do
+    let!(:sibling) do
+      FactoryBot.create(
+        :body_text, :unmasked, incoming_message: incoming_message
+      )
+    end
+
+    it 'masks the sibling and erases the attachment' do
+      perform
+      expect(sibling.reload).to be_masked
+      expect(attachment.reload).to be_erased
+    end
+  end
+end

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -950,6 +950,64 @@ RSpec.describe FoiAttachment do
     end
   end
 
+  describe '#mask_siblings' do
+    subject { foi_attachment.mask_siblings }
+
+    let(:info_request) { FactoryBot.create(:info_request_with_incoming) }
+    let(:incoming_message) { info_request.incoming_messages.first }
+    let(:foi_attachment) do
+      FactoryBot.create(:body_text, incoming_message: incoming_message)
+    end
+
+    context 'with an unmasked sibling' do
+      let!(:sibling) do
+        FactoryBot.create(
+          :body_text, :unmasked, incoming_message: incoming_message
+        )
+      end
+
+      it 'masks the sibling' do
+        expect { subject }.to change { sibling.reload.masked? }.
+          from(false).to(true)
+      end
+    end
+
+    context 'with a masked sibling' do
+      let!(:sibling) do
+        FactoryBot.create(:body_text, incoming_message: incoming_message)
+      end
+
+      it 'does not re-mask the sibling' do
+        expect { subject }.to_not change { sibling.reload.masked_at }
+      end
+    end
+
+    context 'with an erased sibling' do
+      let!(:sibling) do
+        FactoryBot.create(
+          :body_text, :erased, :unmasked, incoming_message: incoming_message
+        )
+      end
+
+      it 'does not mask the sibling' do
+        expect { subject }.to_not change { sibling.reload.masked_at }.from(nil)
+      end
+    end
+
+    context 'when itself is unmasked' do
+      let(:foi_attachment) do
+        FactoryBot.create(
+          :body_text, :unmasked, incoming_message: incoming_message
+        )
+      end
+
+      it 'does not mask itself' do
+        expect { subject }.to_not change { foi_attachment.reload.masked? }.
+          from(false)
+      end
+    end
+  end
+
   describe '#lock' do
     subject do
       foi_attachment.lock(editor: editor, reason: reason, extra: 'context')
@@ -2036,6 +2094,43 @@ RSpec.describe FoiAttachment do
       end
 
       it { is_expected.to eq(false) }
+    end
+
+    context 'when a sibling attachment is unmasked' do
+      let!(:sibling) do
+        FactoryBot.create(
+          :body_text, :unmasked, incoming_message: incoming_message
+        )
+      end
+
+      it 'masks the sibling' do
+        expect { subject }.to change { sibling.reload.masked? }.
+          from(false).to(true)
+      end
+
+      it 'erases the attachment' do
+        expect { subject }.to change { foi_attachment.reload.erased? }.
+          from(false).to(true)
+      end
+
+      it 'erases the raw email' do
+        subject
+        expect(foi_attachment.raw_email.reload).to be_erased
+      end
+    end
+  end
+
+  describe '#erase_later' do
+    subject { foi_attachment.erase_later(editor: editor, reason: reason) }
+
+    let(:foi_attachment) { FactoryBot.create(:body_text) }
+    let(:editor) { FactoryBot.create(:admin_user) }
+    let(:reason) { 'Removing PII' }
+
+    it 'enqueues the job' do
+      expect { subject }.
+        to have_enqueued_job(FoiAttachment::EraseJob).
+        with(foi_attachment, editor: editor, reason: reason)
     end
   end
 


### PR DESCRIPTION
## What does this do?

Update attachment erasing

## Why was this needed?

Erasing a FoiAttachment cascades into erasing the shared RawEmail,
which can only be purged once every sibling attachment is masked or
erased. Previously an unmasked sibling made the erase fail.

Adds `FoiAttachment::EraseJob` and `FoiAttachment#earse_later` so the
work can be enqueue and run in the background.

Updates `FoiAttachment#erase` to masks its siblings, so the RawEmail
becomes erasable.

As masking can be slow, running it in the job keeps it out of the
request cycle.

[skip changelog]