### PR TITLE
Add 2FA fixture data

### DIFF
--- a/spec/controllers/admin/two_factor_controller_spec.rb
+++ b/spec/controllers/admin/two_factor_controller_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe Admin::TwoFactorController do
     let!(:hotp_admin) { FactoryBot.create(:admin_user, :enable_hotp) }
     let!(:totp_admin) { FactoryBot.create(:admin_user, :enable_totp) }
 
+    # HACK: Exclude fixture data for clarity
+    before do
+      annie = users(:annie_all_roles_user)
+      annie.disable_otp
+      annie.save!
+    end
+
     it 'returns a successful response' do
       get :show
       expect(response).to be_successful

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -169,6 +169,11 @@ annie_all_roles_user:
   about_me: 'All the roles'
   receive_email_alerts: true
   last_daily_track_email: <%= Time.zone.now %>
+  otp_enabled: true
+  otp_secret_key: W5LLD4AHA7JAINQIQV7NGSEBU3CQGO3D # See https://github.com/mysociety/alaveteli/pull/9343 for setup help
+  otp_enabled_at: 2007-10-31 10:39:15.491593
+  otp_backup_codes: '["133107","591088","687254","426010","773637","735999","489138","769201","198169","600907","821923","805386"]'
+  otp_backup_codes_generated_at: 2007-10-31 10:39:15.491593
 peter_pro_admin_user:
   id: 9
   name: Peter Pro Admin


### PR DESCRIPTION
## Relevant issue(s)

Part of https://github.com/mysociety/alaveteli/issues/9241.

Created as a new PR since it requires https://github.com/mysociety/alaveteli/pull/9317.

## What does this do?

Adds known 2FA fixture data for Annie all roles.

## Why was this needed?

Addresses review comment in https://github.com/mysociety/alaveteli/pull/9317#pullrequestreview-4499079210.

We frequently use Annie for development, so it would be annoying to have
to enrol the user to 2FA all the time. This adds a known secret key and
other 2FA data so we can keep the same authenticator configuration
across database resets.

## Implementation notes

You can generate the QR code to add it to your authenticator app by running this in a rails console:

```rb
puts RQRCode::QRCode.new(
  ROTP::TOTP.new('W5LLD4AHA7JAINQIQV7NGSEBU3CQGO3D').provisioning_uri
).as_ansi
```

You can also copy/paste the key in the "Enter a setup key" workflow of your app.

## Notes to reviewer

Haven't checked this with encrypted attributes enabled, so LMK if there's something different to do there.

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
