### PR TITLE
Require 2FA at the email confirmation link for TOTP users

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -170,8 +170,12 @@ class ApplicationController < ActionController::Base
   end
 
   # Establish the session and send the user on to where they were heading.
-  def complete_sign_in(user, post_redirect:, remember_me:)
+  # `circumstance` is re-set after sign_in because sign_in clears it (see
+  # clear_session_credentials). A sign-in resumed after a 2FA challenge, e.g.
+  # change_email confirmation, still needs it downstream.
+  def complete_sign_in(user, post_redirect:, remember_me:, circumstance: nil)
     sign_in(user, remember_me: remember_me)
+    session[:user_circumstance] = circumstance if circumstance
 
     if modal_dialog?
       render template: 'users/sessions/show'

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -18,6 +18,26 @@ class Users::ConfirmationsController < UserController
         return
       else
         user.confirm!
+
+        # A TOTP user must pass the 2FA challenge before the link grants a
+        # session, or the confirmation link bypasses two factor. HOTP is not a
+        # sign-in factor anywhere (see SessionsController), so gate on totp?.
+        # Consume the link, stash the pending sign-in (with the circumstance the
+        # challenge needs to resume), and hand off to the challenge.
+        if user.totp?
+          post_redirect.update!(
+            email_token: PostRedirect.generate_random_token
+          )
+          PendingTwoFactorSignIn.new(session).start(
+            user: user,
+            remember_me: false,
+            post_redirect: post_redirect,
+            circumstance: post_redirect.circumstance
+          )
+          redirect_to signin_two_factor_path
+          return
+        end
+
         sign_in(user)
       end
     end

--- a/app/controllers/users/two_factor_challenges_controller.rb
+++ b/app/controllers/users/two_factor_challenges_controller.rb
@@ -37,7 +37,8 @@ class Users::TwoFactorChallengesController < UserController
     complete_sign_in(
       @pending.user,
       post_redirect: @pending.post_redirect,
-      remember_me: @pending.remember_me
+      remember_me: @pending.remember_me,
+      circumstance: @pending.circumstance
     )
   end
 

--- a/app/models/pending_two_factor_sign_in.rb
+++ b/app/models/pending_two_factor_sign_in.rb
@@ -7,11 +7,12 @@ class PendingTwoFactorSignIn
     @session = session
   end
 
-  def start(user:, remember_me:, post_redirect:)
+  def start(user:, remember_me:, post_redirect:, circumstance: nil)
     @session[:pending_2fa_user_id] = user.id
     @session[:pending_2fa_started_at] = Time.zone.now.to_i
     @session[:pending_2fa_remember_me] = remember_me
     @session[:pending_2fa_post_redirect_token] = post_redirect.token
+    @session[:pending_2fa_circumstance] = circumstance
   end
 
   def user_id
@@ -20,6 +21,10 @@ class PendingTwoFactorSignIn
 
   def remember_me
     @session[:pending_2fa_remember_me]
+  end
+
+  def circumstance
+    @session[:pending_2fa_circumstance]
   end
 
   def user
@@ -47,6 +52,7 @@ class PendingTwoFactorSignIn
     %i[pending_2fa_user_id
        pending_2fa_started_at
        pending_2fa_remember_me
-       pending_2fa_post_redirect_token].each { |key| @session.delete(key) }
+       pending_2fa_post_redirect_token
+       pending_2fa_circumstance].each { |key| @session.delete(key) }
   end
 end

--- a/spec/controllers/users/confirmations_controller_spec.rb
+++ b/spec/controllers/users/confirmations_controller_spec.rb
@@ -189,6 +189,59 @@ RSpec.describe Users::ConfirmationsController do
       end
     end
 
+    context 'if the post redirect user has TOTP two factor enabled' do
+      let(:user) do
+        FactoryBot.create(:user, :enable_totp, email_confirmed: false)
+      end
+      let(:post_redirect) { PostRedirect.create(uri: '/', user: user) }
+
+      before :each do
+        @original_token = post_redirect.email_token
+        get :confirm, params: { email_token: @original_token }
+      end
+
+      it 'does not sign the user in' do
+        expect(session[:user_id]).to be_nil
+      end
+
+      it 'redirects to the two factor challenge' do
+        expect(response).to redirect_to(signin_two_factor_path)
+      end
+
+      it 'confirms the post redirect user' do
+        expect(user.reload.email_confirmed).to eq(true)
+      end
+
+      it 'consumes the confirmation link before the challenge' do
+        expect(PostRedirect.find_by(email_token: @original_token)).to be_nil
+      end
+
+      it 'stashes the pending sign-in for the challenge to resume' do
+        expect(session[:pending_2fa_user_id]).to eq(user.id)
+        expect(session[:pending_2fa_post_redirect_token]).
+          to eq(post_redirect.token)
+        expect(session[:pending_2fa_circumstance]).to eq('normal')
+      end
+    end
+
+    context 'if the post redirect user has HOTP two factor enabled' do
+      let(:user) do
+        FactoryBot.create(:user, :enable_hotp, email_confirmed: false)
+      end
+      let(:post_redirect) { PostRedirect.create(uri: '/', user: user) }
+
+      before :each do
+        get :confirm, params: { email_token: post_redirect.email_token }
+      end
+
+      # HOTP is not a sign-in factor, so the confirmation link signs them in
+      # directly rather than detouring to the challenge.
+      it 'signs the user in without a two factor challenge' do
+        expect(session[:user_id]).to eq(user.id)
+        expect(response).not_to redirect_to(signin_two_factor_path)
+      end
+    end
+
     context 'token consumption' do
       it 'rotates the email token after successful confirmation' do
         user = FactoryBot.create(:user, email_confirmed: false)

--- a/spec/controllers/users/two_factor_challenges_controller_spec.rb
+++ b/spec/controllers/users/two_factor_challenges_controller_spec.rb
@@ -48,6 +48,24 @@ RSpec.describe Users::TwoFactorChallengesController do
       end
     end
 
+    context 'with a circumstance carried from the confirmation link' do
+      before do
+        PendingTwoFactorSignIn.new(session).start(
+          user: user, remember_me: false, post_redirect: post_redirect,
+          circumstance: 'change_email'
+        )
+        post :create, params: { otp_code: valid_code }
+      end
+
+      it 'restores the user_circumstance after signing in' do
+        expect(session[:user_circumstance]).to eq('change_email')
+      end
+
+      it 'redirects to the stashed destination' do
+        expect(response).to redirect_to(request_list_path(post_redirect: 1))
+      end
+    end
+
     context 'with an invalid code' do
       before do
         start_pending_sign_in

--- a/spec/integration/change_email_address_spec.rb
+++ b/spec/integration/change_email_address_spec.rb
@@ -27,4 +27,43 @@ RSpec.describe 'changing your email address' do
       expect(user.email_confirmed).to eq(true)
     end
   end
+
+  context "when the user has TOTP two factor authentication enabled" do
+    let(:user) do
+      FactoryBot.create(:user, :enable_totp, email: 'oldbob@localhost')
+    end
+
+    it "challenges for a code before completing the change" do
+      using_session(login(user)) do
+        visit signchangeemail_path
+        fill_in "signchangeemail_old_email", with: user.email
+        fill_in "signchangeemail_password", with: 'jonespassword'
+        fill_in "signchangeemail_new_email", with: 'newbob@localhost'
+        click_button "Change email on Alaveteli"
+
+        expect(page).to have_content('Now check your email!')
+
+        confirmation_url = confirmation_url_from_email
+
+        # Travel forward for a fresh authenticator code: the login above
+        # already consumed the current one, and TOTP rejects replays.
+        travel(1.minute) do
+          # The confirmation link must not sign the user in directly; it hands
+          # off to the two factor challenge first.
+          visit confirmation_url
+          expect(page).to have_content('Two factor authentication')
+
+          fill_in 'Code from your authenticator app', with: user.otp_code
+          click_button 'Verify'
+        end
+
+        # Only after passing the challenge does the change complete.
+        expect(page).to have_current_path("/user/#{user.url_name}")
+        expect(page).to have_content('You have now changed your email address')
+        user.reload
+        expect(user.email).to eq('newbob@localhost')
+        expect(user.email_confirmed).to eq(true)
+      end
+    end
+  end
 end

--- a/spec/models/pending_two_factor_sign_in_spec.rb
+++ b/spec/models/pending_two_factor_sign_in_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe PendingTwoFactorSignIn do
 
   describe '#start' do
     before do
-      pending.start(user: user, remember_me: true, post_redirect: post_redirect)
+      pending.start(user: user, remember_me: true, post_redirect: post_redirect,
+                    circumstance: 'change_email')
     end
 
     it 'stores the user id' do
@@ -28,6 +29,21 @@ RSpec.describe PendingTwoFactorSignIn do
     it 'stores the post redirect token' do
       expect(session[:pending_2fa_post_redirect_token]).
         to eq(post_redirect.token)
+    end
+
+    it 'stores the circumstance' do
+      expect(session[:pending_2fa_circumstance]).to eq('change_email')
+    end
+  end
+
+  describe '#circumstance' do
+    it 'reads it back from the session' do
+      session[:pending_2fa_circumstance] = 'change_email'
+      expect(pending.circumstance).to eq('change_email')
+    end
+
+    it 'is nil when none was stashed' do
+      expect(pending.circumstance).to be_nil
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Part of https://github.com/mysociety/alaveteli/issues/9241

Follows on from https://github.com/mysociety/alaveteli/pull/9325

## What does this do?

Ensures the user is prompted for a TOTP code when signing in via the signup form's already registered flow.

## Why was this needed?

The /c/:email_token confirmation link (Users::ConfirmationsController#confirm) signed the user in directly, with no second-factor check. For a TOTP user this bypassed two factor entirely, clicking the link sent by the signup / already-registered flow granted a full session without the authenticator code.

Instead we route the confirmation sign-in for TOTP users through the existing 2FA challenges controller.

## Implementation notes

I did consider making a bigger change to ensure `sign_in` always checked two-factor, to prevent anything else like this from being introduced in the future, but that started to turn into quite a complex change, so backed out and just went for this simpler version that addresses the immediate issue.

[skip changelog]
