### PR TITLE
Update secret key base configuration

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -442,6 +442,11 @@ TRACK_SENDER_NAME: 'Alaveteli'
 # ---
 RAW_EMAILS_LOCATION: 'files/raw_emails'
 
+# DEPRECATED: secret_key_base is now read from the Rails encrypted credentials
+# (config/credentials.yml.enc) when present; this setting is only a fallback for
+# deployments not yet migrated and will be removed in a future release. See the
+# Upgrade Notes in doc/CHANGES.md for setting up credentials.
+#
 # Rails 4.0 introduces ActiveSupport::KeyGenerator and uses this as a base from
 # which to generate and verify signed cookies (among other things). You can
 # generate a key with `rake secret`.

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,2 +1,2 @@
-secret_key_base = AlaveteliConfiguration.secret_key_base
-Rails.application.credentials.secret_key_base = secret_key_base
+Rails.application.credentials.secret_key_base ||=
+  AlaveteliConfiguration.secret_key_base

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -113,6 +113,14 @@
   If you ever move servers or reinstall Alaveteli then you will need them. See:
   https://guides.rubyonrails.org/security.html#custom-credentials
 
+* _Note:_ `SECRET_KEY_BASE` in `config/general.yml` is deprecated and will be
+  removed in a future release. The secret is now read from the encrypted
+  credentials (`config/credentials.yml.enc`).
+
+  When running `bin/rails config_files:set_credentials` (see above) it copies
+  your existing `config/general.yml` value into the credentials, so sessions and
+  signed/encrypted cookies keep working.
+
 * _Required:_ Please update your `config/storage.yml` file to include a
   production configuration for `inbound_emails`. See
   `config/storage.yml-example` as an example.

--- a/lib/tasks/config_files.rake
+++ b/lib/tasks/config_files.rake
@@ -269,15 +269,20 @@ namespace :config_files do
 
     # Add only what is missing, generating any value not supplied through the
     # environment. Existing values are left untouched, so this is safe to run
-    # repeatedly and against credentials set up another way. secret_key_base is
-    # only a placeholder: config/general.yml is authoritative and overrides it
-    # at boot (see config/initializers/secret_token.rb).
+    # repeatedly and against credentials set up another way.
     existing = YAML.safe_load(encrypted_file.read) || {}
 
     blocks = []
 
     unless existing.key?("secret_key_base")
-      secret_key_base = ENV.fetch("SECRET_KEY_BASE") { SecureRandom.hex(64) }
+      secret_key_base = ENV.fetch("SECRET_KEY_BASE") do
+        configured = AlaveteliConfiguration.secret_key_base
+        if configured == AlaveteliConfiguration::DEFAULTS[:SECRET_KEY_BASE]
+          SecureRandom.hex(64)
+        else
+          configured
+        end
+      end
       blocks << "secret_key_base: #{secret_key_base}"
     end
 


### PR DESCRIPTION
Deprecate SECRET_KEY_BASE in config/general.yml in favour of the Rails encrypted credentials.

Updates `config_files:set_credentials` rake task to seeds the missing value from the existing config/general.yml.
