### PR TITLE
Add Redactable

### DIFF
--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -11,7 +11,7 @@ class Admin::FoiAttachmentsController < AdminController
   private
 
   def set_foi_attachment
-    @foi_attachment = FoiAttachment.find(params[:id])
+    @foi_attachment = FoiAttachment.find(params[:id]).unredacted
   end
 
   def set_incoming_message

--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -15,7 +15,7 @@ class Admin::FoiAttachmentsController < AdminController
   end
 
   def set_incoming_message
-    @incoming_message = @foi_attachment&.incoming_message
+    @incoming_message = @foi_attachment&.incoming_message.unredacted
   end
 
   def set_info_request

--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -11,15 +11,15 @@ class Admin::FoiAttachmentsController < AdminController
   private
 
   def set_foi_attachment
-    @foi_attachment = FoiAttachment.find(params[:id])
+    @foi_attachment = FoiAttachment.find(params[:id]).unredacted
   end
 
   def set_incoming_message
-    @incoming_message = @foi_attachment&.incoming_message
+    @incoming_message = @foi_attachment&.incoming_message.unredacted
   end
 
   def set_info_request
-    @info_request = @incoming_message&.info_request
+    @info_request = @incoming_message&.info_request.unredacted
   end
 
   def check_info_request

--- a/app/controllers/admin/foi_attachments_controller.rb
+++ b/app/controllers/admin/foi_attachments_controller.rb
@@ -19,7 +19,7 @@ class Admin::FoiAttachmentsController < AdminController
   end
 
   def set_info_request
-    @info_request = @incoming_message&.info_request.unredacted
+    @info_request = @incoming_message&.info_request
   end
 
   def check_info_request

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -91,7 +91,7 @@ class AdminIncomingMessageController < AdminController
   end
 
   def set_incoming_message
-    @incoming_message = IncomingMessage.find(params[:id])
+    @incoming_message = IncomingMessage.find(params[:id]).unredacted
   end
 
   def set_info_request

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -91,13 +91,13 @@ class AdminIncomingMessageController < AdminController
   end
 
   def set_incoming_message
-    @incoming_message = IncomingMessage.find(params[:id])
+    @incoming_message = IncomingMessage.find(params[:id]).unredacted
   end
 
   def set_info_request
     @info_request = @incoming_message&.info_request || InfoRequest.find(
       params[:request_id]
-    )
+    ).unredacted
   end
 
   def check_info_request

--- a/app/controllers/admin_incoming_message_controller.rb
+++ b/app/controllers/admin_incoming_message_controller.rb
@@ -97,7 +97,7 @@ class AdminIncomingMessageController < AdminController
   def set_info_request
     @info_request = @incoming_message&.info_request || InfoRequest.find(
       params[:request_id]
-    ).unredacted
+    )
   end
 
   def check_info_request

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -79,7 +79,7 @@ class AdminOutgoingMessageController < AdminController
   end
 
   def set_outgoing_message
-    @outgoing_message = OutgoingMessage.find(params[:id])
+    @outgoing_message = OutgoingMessage.find(params[:id]).unredacted
   end
 
   def set_info_request

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -83,7 +83,7 @@ class AdminOutgoingMessageController < AdminController
   end
 
   def set_info_request
-    @info_request = @outgoing_message.info_request.unredacted
+    @info_request = @outgoing_message.info_request
   end
 
   def check_info_request

--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -79,11 +79,11 @@ class AdminOutgoingMessageController < AdminController
   end
 
   def set_outgoing_message
-    @outgoing_message = OutgoingMessage.find(params[:id])
+    @outgoing_message = OutgoingMessage.find(params[:id]).unredacted
   end
 
   def set_info_request
-    @info_request = @outgoing_message.info_request
+    @info_request = @outgoing_message.info_request.unredacted
   end
 
   def check_info_request

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -126,7 +126,9 @@ class AdminRequestController < AdminController
 
   def generate_upload_url
     if params[:incoming_message_id]
-      incoming_message = IncomingMessage.find(params[:incoming_message_id])
+      incoming_message =
+        IncomingMessage.find(params[:incoming_message_id]).unredacted
+
       email = incoming_message.from_email
       name = incoming_message.safe_from_name || @info_request.public_body.name
     else

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -228,7 +228,7 @@ class AdminRequestController < AdminController
   end
 
   def set_info_request
-    @info_request = InfoRequest.find(params[:id].to_i).unredacted
+    @info_request = InfoRequest.find(params[:id].to_i)
   end
 
   def check_info_request

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -228,7 +228,7 @@ class AdminRequestController < AdminController
   end
 
   def set_info_request
-    @info_request = InfoRequest.find(params[:id].to_i)
+    @info_request = InfoRequest.find(params[:id].to_i).unredacted
   end
 
   def check_info_request

--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -45,7 +45,7 @@ module Admin::LinkHelper
     info_request = foi_attachment.incoming_message.info_request
 
     link_to(icon, foi_attachment_path(foi_attachment), title: title) + ' ' +
-      link_to(foi_attachment.filename,
+      link_to(foi_attachment.unredacted.filename,
               edit_admin_foi_attachment_path(foi_attachment),
               title: admin_title)
   end

--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -13,7 +13,7 @@ module Admin::LinkHelper
 
     link_to(icon, request_path(info_request), title: title) + ' ' +
       classification_icon(info_request) + ' ' +
-        link_to(info_request.title, admin_request_path(info_request),
+        link_to(info_request.unredacted.title, admin_request_path(info_request),
                 title: admin_title)
   end
 
@@ -23,7 +23,7 @@ module Admin::LinkHelper
     info_request = outgoing_message.info_request
 
     link_to(icon, outgoing_message_path(outgoing_message), title: title) + ' ' +
-      link_to("#{info_request.title} ##{dom_id(outgoing_message)}",
+      link_to("#{info_request.unredacted.title} ##{dom_id(outgoing_message)}",
               edit_admin_outgoing_message_path(outgoing_message),
               title: admin_title)
   end
@@ -34,7 +34,7 @@ module Admin::LinkHelper
     info_request = incoming_message.info_request
 
     link_to(icon, incoming_message_path(incoming_message), title: title) + ' ' +
-      link_to("#{info_request.title} ##{dom_id(incoming_message)}",
+      link_to("#{info_request.unredacted.title} ##{dom_id(incoming_message)}",
               edit_admin_incoming_message_path(incoming_message),
               title: admin_title)
   end
@@ -45,7 +45,7 @@ module Admin::LinkHelper
     info_request = foi_attachment.incoming_message.info_request
 
     link_to(icon, foi_attachment_path(foi_attachment), title: title) + ' ' +
-      link_to(foi_attachment.filename,
+      link_to(foi_attachment.unredacted.filename,
               edit_admin_foi_attachment_path(foi_attachment),
               title: admin_title)
   end

--- a/app/helpers/admin/link_helper.rb
+++ b/app/helpers/admin/link_helper.rb
@@ -13,7 +13,7 @@ module Admin::LinkHelper
 
     link_to(icon, request_path(info_request), title: title) + ' ' +
       classification_icon(info_request) + ' ' +
-        link_to(info_request.unredacted.title, admin_request_path(info_request),
+        link_to(info_request.title, admin_request_path(info_request),
                 title: admin_title)
   end
 
@@ -23,7 +23,7 @@ module Admin::LinkHelper
     info_request = outgoing_message.info_request
 
     link_to(icon, outgoing_message_path(outgoing_message), title: title) + ' ' +
-      link_to("#{info_request.unredacted.title} ##{dom_id(outgoing_message)}",
+      link_to("#{info_request.title} ##{dom_id(outgoing_message)}",
               edit_admin_outgoing_message_path(outgoing_message),
               title: admin_title)
   end
@@ -34,7 +34,7 @@ module Admin::LinkHelper
     info_request = incoming_message.info_request
 
     link_to(icon, incoming_message_path(incoming_message), title: title) + ' ' +
-      link_to("#{info_request.unredacted.title} ##{dom_id(incoming_message)}",
+      link_to("#{info_request.title} ##{dom_id(incoming_message)}",
               edit_admin_incoming_message_path(incoming_message),
               title: admin_title)
   end

--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -33,9 +33,16 @@ class OutgoingMailer < ApplicationMailer
     @contact_email = AlaveteliConfiguration.contact_email
     headers["message-id"] = OutgoingMailer.id_for_message(@outgoing_message)
 
+    subject = OutgoingMailer.subject_for_followup(
+      @info_request,
+      @outgoing_message,
+      html: false,
+      incoming_message: @incoming_message_followup&.unredacted
+    )
+
     mail(from: @outgoing_message.unredacted.from,
          to: @outgoing_message.to,
-         subject: @outgoing_message.subject)
+         subject: subject)
   end
 
   # TODO: the condition checking valid_to_reply_to? also appears in views/request/_followup.html.erb,
@@ -79,8 +86,12 @@ class OutgoingMailer < ApplicationMailer
     if outgoing_message.what_doing == 'internal_review'
       _("Internal review of {{email_subject}}", email_subject: info_request.email_subject_request(html: options[:html]))
     else
-      info_request.email_subject_followup(incoming_message: outgoing_message.incoming_message_followup,
-                                                 html: options[:html])
+      incoming_message = options.fetch(:incoming_message) do
+        outgoing_message.incoming_message_followup
+      end
+
+      info_request.email_subject_followup(incoming_message: incoming_message,
+                                          html: options[:html])
     end
   end
 

--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -48,8 +48,10 @@ class OutgoingMailer < ApplicationMailer
       info_request.recipient_name_and_email
     else
       # calling safe_from_name from so censor rules are run
-      MailHandler.address_from_name_and_email(incoming_message_followup.safe_from_name,
-                                                     incoming_message_followup.from_email)
+      MailHandler.address_from_name_and_email(
+        incoming_message_followup.safe_from_name,
+        incoming_message_followup.unredacted.from_email
+      )
     end
   end
 
@@ -68,7 +70,7 @@ class OutgoingMailer < ApplicationMailer
     if incoming_message_followup.nil? || !incoming_message_followup.valid_to_reply_to?
       info_request.recipient_email
     else
-      incoming_message_followup.from_email
+      incoming_message_followup.unredacted.from_email
     end
   end
 

--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -20,7 +20,7 @@ class OutgoingMailer < ApplicationMailer
     @contact_email = AlaveteliConfiguration.contact_email
     headers["message-id"] = OutgoingMailer.id_for_message(@outgoing_message)
 
-    mail(from: @outgoing_message.from,
+    mail(from: @outgoing_message.unredacted.from,
          to: @outgoing_message.to,
          subject: @outgoing_message.subject)
   end
@@ -33,7 +33,7 @@ class OutgoingMailer < ApplicationMailer
     @contact_email = AlaveteliConfiguration.contact_email
     headers["message-id"] = OutgoingMailer.id_for_message(@outgoing_message)
 
-    mail(from: @outgoing_message.from,
+    mail(from: @outgoing_message.unredacted.from,
          to: @outgoing_message.to,
          subject: @outgoing_message.subject)
   end

--- a/app/models/concerns/redactable.rb
+++ b/app/models/concerns/redactable.rb
@@ -1,0 +1,78 @@
+# Applies applicable TextMasks and CensorRules from the parent InfoRequest to
+# attributes defined as being redactable.
+module Redactable
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :redactable_attrs, default: []
+
+    delegate :apply_masks, to: :info_request
+
+    attr_writer :unredacted_access
+  end
+
+  class_methods do
+    # Declare attributes/methods whose values may contain personal data.
+    # Direct access returns redacted content; use #unredacted to access raw
+    # values.
+    def redactable(*attrs)
+      self.redactable_attrs = attrs
+
+      prepend(Module.new do
+        attrs.each do |attr|
+          define_method(attr) do |*args, **kwargs, &block|
+            return_super = unredacted_access || !info_request
+            return super(*args, **kwargs, &block) if return_super
+
+            apply_masks_to(attr, *args, **kwargs, &block)
+          end
+        end
+      end)
+    end
+  end
+
+  # Returns the redacted value for attr. Dispatches to apply_masks_to_<attr>
+  # if defined on the model, otherwise runs the plain text masking pipeline.
+  # Any extra args/kwargs are forwarded to a custom apply_masks_to_<attr>,
+  # but are not meaningful for the default masking pipeline.
+  #
+  # Masking needs a persisted info_request (the default pipeline calls
+  # info_request.apply_masks, which masks out the request's own incoming
+  # email address, and that needs an id) - so with no persisted info_request
+  # to pull rules from, nothing gets masked, custom or otherwise.
+  def apply_masks_to(attr, *args, **kwargs, &block)
+    unless respond_to?(attr)
+      msg = "Unknown method :#{attr} given to #{self.class} redactable"
+      raise ArgumentError, msg
+    end
+
+    unless info_request.persisted?
+      return unredacted.send(attr, *args, **kwargs, &block)
+    end
+
+    if respond_to?("apply_masks_to_#{attr}", true)
+      send("apply_masks_to_#{attr}", *args, **kwargs, &block)
+    else
+      apply_masks(unredacted.send(attr), 'text/plain')
+    end
+  end
+
+  def unredacted
+    @unredacted ||= Redactable::Unredacted.new(self)
+  end
+
+  def unredacted_access
+    @unredacted_access || false
+  end
+
+  # Validations (e.g. validates_presence_of) read the attribute via this
+  # method, which by default just calls the public getter. For a redactable
+  # attr that would run it through the masking pipeline - validating the
+  # masked value instead of what's actually stored, and re-entering masking
+  # (with its own side effects/failure modes) as a side effect of validating.
+  def read_attribute_for_validation(attr)
+    return unredacted.send(attr) if self.class.redactable_attrs.include?(attr)
+
+    super
+  end
+end

--- a/app/models/concerns/redactable.rb
+++ b/app/models/concerns/redactable.rb
@@ -18,7 +18,7 @@ module Redactable
       prepend(Module.new do
         attrs.each do |attr|
           define_method(attr) do
-            return super() if unredacted_access
+            return super() if unredacted_access || new_record? || !info_request
             apply_masks_to(attr)
           end
         end

--- a/app/models/concerns/redactable.rb
+++ b/app/models/concerns/redactable.rb
@@ -1,0 +1,48 @@
+module Redactable
+  extend ActiveSupport::Concern
+
+  included do
+    class_attribute :redactable_attrs, default: []
+
+    delegate :apply_masks, to: :info_request
+
+    attr_writer :unredacted_access
+  end
+
+  class_methods do
+    # Declare attributes/methods whose values may contain personal data.
+    # Direct access returns redacted content; use #unredacted to access raw values.
+    def redactable(*attrs)
+      self.redactable_attrs = attrs
+
+      prepend(Module.new do
+        attrs.each do |attr|
+          define_method(attr) do
+            return super() if unredacted_access
+            apply_masks_to(attr)
+          end
+        end
+      end)
+    end
+  end
+
+  # Returns the redacted value for attr. Dispatches to apply_masks_to_<attr>
+  # if defined on the model, otherwise runs the plain text masking pipeline.
+  def apply_masks_to(attr)
+    unless respond_to?(attr)
+      msg = "Unknown method :#{attr} given to #{self.class} redactable"
+      raise ArgumentError, msg
+    end
+
+    try("apply_masks_to_#{attr}") ||
+      apply_masks(unredacted.send(attr).to_s, 'text/plain')
+  end
+
+  def unredacted
+    @unredacted ||= Redactable::Unredacted.new(self)
+  end
+
+  def unredacted_access
+    @unredacted_access || false
+  end
+end

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -182,10 +182,9 @@ class FoiAttachment < ApplicationRecord
 
   def redacted_filename
     return replaced_filename if replaced_filename.present?
-    return filename unless info_request
-    return filename if locked? && !locking?
+    return unredacted.filename if locked? && !locking?
 
-    info_request.apply_censor_rules_to_text(filename)
+    filename
   end
 
   # TODO: changing this will break existing URLs, so have a care - maybe

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -36,6 +36,7 @@ class FoiAttachment < ApplicationRecord
   include LinkToHelper
 
   include MessageProminence
+  include Redactable
 
   include ContentType
   include Erasable
@@ -66,6 +67,8 @@ class FoiAttachment < ApplicationRecord
 
   admin_columns exclude: %i[url_part_number within_rfc822_subject hexdigest],
                 include: %i[redacted_filename display_filename metadata]
+
+  redactable :filename, :body
 
   BODY_MAX_TRIES = 3
   BODY_MAX_DELAY = 5
@@ -128,6 +131,10 @@ class FoiAttachment < ApplicationRecord
   def default_body
     ensure_not_erased!
     text_type? ? body_as_text.string : body
+  end
+
+  def apply_masks_to_body
+    apply_masks(unmasked_body, content_type)
   end
 
   # return the body as it is in the raw email, unmasked without censor rules

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -37,6 +37,7 @@ class FoiAttachment < ApplicationRecord
   include LinkToHelper
 
   include MessageProminence
+  include Redactable
 
   include ContentType
   include Erasable
@@ -68,6 +69,8 @@ class FoiAttachment < ApplicationRecord
 
   admin_columns exclude: %i[url_part_number within_rfc822_subject hexdigest],
                 include: %i[redacted_filename display_filename metadata]
+
+  redactable :filename, :body
 
   BODY_MAX_TRIES = 3
   BODY_MAX_DELAY = 5
@@ -136,6 +139,16 @@ class FoiAttachment < ApplicationRecord
     text_type? ? body_as_text.string : body
   end
 
+  # unredacted.body already goes through the real #body method, which
+  # masks (and caches) the content itself via FoiAttachment::MaskJob.
+  # Applying masks again here would be redundant, and isn't safe to do
+  # twice for every content type (e.g. PDF mask application isn't
+  # perfectly idempotent, so a second pass can needlessly re-derive a
+  # byte-different, but equally unmasked, PDF).
+  def apply_masks_to_body
+    unredacted.body
+  end
+
   # return the body as it is in the raw email, unmasked without censor rules
   # applied
   def unmasked_body
@@ -194,7 +207,7 @@ class FoiAttachment < ApplicationRecord
   end
 
   def ensure_filename!
-    if filename.blank?
+    if read_attribute(:filename).blank?
       calc_ext = AlaveteliFileTypes.mimetype_to_extension(content_type)
       calc_ext = "bin" unless calc_ext
       if !within_rfc822_subject.nil?
@@ -220,7 +233,7 @@ class FoiAttachment < ApplicationRecord
 
   # Size to show next to the download link for the attachment
   def update_display_size!
-    s = body.size
+    s = unredacted.body.size
 
     if s > 1024 * 1024
       self.display_size = format("%.1f", s.to_f / 1024 / 1024) + 'M'

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -37,6 +37,7 @@ require 'zip'
 
 class IncomingMessage < ApplicationRecord
   include MessageProminence
+  include Redactable
   include Taggable
 
   include IncomingMessage::Attachments
@@ -77,6 +78,8 @@ class IncomingMessage < ApplicationRecord
   cache_from_raw_email :subject, :sent_at,
                        :from_name, :from_email, :from_email_domain,
                        :valid_to_reply_to
+
+  redactable :from, :from_name, :from_email, :from_email_domain, :subject
 
   delegate :message_id, to: :raw_email
   delegate :multipart?, to: :raw_email

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -151,7 +151,8 @@ class IncomingMessage < ApplicationRecord
   #
   # Returns a String
   def safe_from_name
-    info_request.apply_censor_rules_to_text(from_name) if from_name
+    name = unredacted.from_name
+    info_request.apply_censor_rules_to_text(name) if name
   end
 
   def specific_from_name?

--- a/app/models/incoming_message/attachments.rb
+++ b/app/models/incoming_message/attachments.rb
@@ -208,7 +208,7 @@ module IncomingMessage::Attachments
     # e.g. for https://secure.mysociety.org/admin/foi/request/show_raw_email/24550
     if main_part
       c = _mail.count_first_uudecode_count
-      attachments += _uudecode_attachments(main_part.body, c)
+      attachments += _uudecode_attachments(main_part.unredacted.body, c)
     end
 
     # Purge old public attachments that will be rebuilt with a new hexdigest

--- a/app/models/incoming_message/main_body.rb
+++ b/app/models/incoming_message/main_body.rb
@@ -190,8 +190,13 @@ module IncomingMessage::MainBody
     if part.nil?
       text = "[ Email has no body, please see attachments ]"
     else
-      # whatever kind of attachment it is, get the UTF-8 encoded text
-      text = part.body_as_text.string
+      # whatever kind of attachment it is, get the UTF-8 encoded text.
+      # Convert from the unredacted body: masks are applied to the
+      # assembled main body text below, and applying them here first would
+      # feed already-masked HTML into the text conversion, which can shift
+      # its layout (e.g. table cells re-wrapping around a placeholder of a
+      # different length than the original text).
+      text = part.unredacted.body_as_text.string
 
       if part.content_type == 'text/html'
         # e.g. http://www.whatdotheyknow.com/request/35/response/177
@@ -203,7 +208,7 @@ module IncomingMessage::MainBody
     end
 
     # Add an annotation if the text had to be scrubbed
-    if part && part.body_as_text.scrubbed?
+    if part && part.unredacted.body_as_text.scrubbed?
       text += _("\n\n[ {{site_name}} note: The above text was badly " \
                 "encoded, and has had strange characters removed. ]",
                 site_name: site_name)

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1240,11 +1240,10 @@ class InfoRequest < ApplicationRecord
 
   # Text from the the initial request, for use in summary display
   def initial_request_text
-    return '' if outgoing_messages.empty?
-
-    body_opts = { censor_rules: applicable_censor_rules }
     first_message = outgoing_messages.first
-    first_message.is_public? ? first_message.get_text_for_indexing(true, body_opts) : ''
+    return '' unless first_message&.is_public?
+
+    first_message.get_text_for_indexing(true).strip
   end
 
   def last_event_id_needing_description

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -719,7 +719,8 @@ class InfoRequest < ApplicationRecord
   def safe_from_name
     return external_user_name if is_external?
 
-    apply_censor_rules_to_text(from_name)
+    name = outgoing_messages.first&.unredacted&.from_name || user_name
+    apply_censor_rules_to_text(name)
   end
 
   def user_name_slug

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -58,7 +58,6 @@ class InfoRequest < ApplicationRecord
   include InfoRequest::Sluggable
   include InfoRequest::TitleValidation
 
-
   admin_columns exclude: %i[title url_title],
                 include: %i[rejected_incoming_count]
 
@@ -1468,11 +1467,14 @@ class InfoRequest < ApplicationRecord
              { to_replace: AlaveteliConfiguration.contact_email,
                replacement: _("[{{site_name}} contact email]",
                               site_name: site_name) }]
+
     if public_body.is_followupable?
       masks << { to_replace: public_body.request_email,
                  replacement: _("[{{public_body}} request email]",
                                    public_body: public_body.short_or_long_name) }
     end
+
+    masks
   end
 
   def is_owning_user?(user)
@@ -1708,6 +1710,12 @@ class InfoRequest < ApplicationRecord
       user_path(user),
       show_user_wall_path(url_name: user.url_name)
     ]
+  end
+
+  # Return this request. This is mainly for
+  # duck-typing with other censorable relationships.
+  def info_request
+    self
   end
 
   # Return only this request in a chainable relation. This is mainly for

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -48,6 +48,7 @@ class InfoRequest < ApplicationRecord
   include Taggable
   include Notable
   include RateLimited
+  include Redactable
 
   include AlaveteliPro::RequestSummaries
   include AlaveteliFeatures::Helpers
@@ -57,7 +58,6 @@ class InfoRequest < ApplicationRecord
   include InfoRequest::PublicToken
   include InfoRequest::Sluggable
   include InfoRequest::TitleValidation
-
 
   admin_columns exclude: %i[title url_title],
                 include: %i[rejected_incoming_count]
@@ -71,6 +71,8 @@ class InfoRequest < ApplicationRecord
   strip_attributes allow_empty: true
   strip_attributes only: [:title],
                    replace_newlines: true, collapse_spaces: true
+
+  redactable :title
 
   belongs_to :user,
              inverse_of: :info_requests,
@@ -1708,6 +1710,12 @@ class InfoRequest < ApplicationRecord
       user_path(user),
       show_user_wall_path(url_name: user.url_name)
     ]
+  end
+
+  # Return this request. This is mainly for
+  # duck-typing with other censorable relationships.
+  def info_request
+    self
   end
 
   # Return only this request in a chainable relation. This is mainly for

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1243,11 +1243,10 @@ class InfoRequest < ApplicationRecord
 
   # Text from the the initial request, for use in summary display
   def initial_request_text
-    return '' if outgoing_messages.empty?
-
-    body_opts = { censor_rules: applicable_censor_rules }
     first_message = outgoing_messages.first
-    first_message.is_public? ? first_message.get_text_for_indexing(true, body_opts) : ''
+    return '' unless first_message&.is_public?
+
+    first_message.get_text_for_indexing(true).strip
   end
 
   def last_event_id_needing_description

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -48,7 +48,6 @@ class InfoRequest < ApplicationRecord
   include Taggable
   include Notable
   include RateLimited
-  include Redactable
 
   include AlaveteliPro::RequestSummaries
   include AlaveteliFeatures::Helpers
@@ -71,8 +70,6 @@ class InfoRequest < ApplicationRecord
   strip_attributes allow_empty: true
   strip_attributes only: [:title],
                    replace_newlines: true, collapse_spaces: true
-
-  redactable :title
 
   belongs_to :user,
              inverse_of: :info_requests,

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -28,6 +28,7 @@ class OutgoingMessage < ApplicationRecord
   include MessageProminence
   include Rails.application.routes.url_helpers
   include LinkToHelper
+  include Redactable
   include Taggable
 
   include OutgoingMessage::DeliveryStatus
@@ -75,6 +76,8 @@ class OutgoingMessage < ApplicationRecord
   after_update :xapian_reindex_after_update
 
   strip_attributes allow_empty: true
+
+  redactable :from, :from_name, :body
 
   admin_columns include: [:to, :from, :subject]
 
@@ -144,8 +147,10 @@ class OutgoingMessage < ApplicationRecord
   def to
     if replying_to_incoming_message?
       # calling safe_from_name from so censor rules are run
-      MailHandler.address_from_name_and_email(incoming_message_followup.safe_from_name,
-                                              incoming_message_followup.from_email)
+      MailHandler.address_from_name_and_email(
+        incoming_message_followup.safe_from_name,
+        incoming_message_followup.unredacted.from_email
+      )
     else
       info_request.recipient_name_and_email
     end
@@ -179,16 +184,23 @@ class OutgoingMessage < ApplicationRecord
   #                           InfoRequest. (optional)
   #
   # Returns a String
-  def body(options = {})
+  def body(_options = {})
     text = raw_body.dup
     return text if text.nil?
 
-    text = clean_text(text)
+    clean_text(text)
+  end
+
+  # Dispatches redactable's #body accessor to apply the given (or the
+  # associated info_request's) censor rules to the text.
+  def apply_masks_to_body(options = {})
+    text = unredacted.body
+    return text if text.nil?
 
     # Use the given censor_rules; otherwise fetch them from the associated
     # info_request
     censor_rules = options.fetch(:censor_rules) do
-      info_request.try(:applicable_censor_rules) or []
+      info_request.try(:applicable_censor_rules) || []
     end
 
     censor_rules.reduce(text) { |t, rule| rule.apply_to_text(t) }

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -130,7 +130,7 @@ class OutgoingMessage < ApplicationRecord
   def safe_from_name
     return info_request.external_user_name if info_request.is_external?
 
-    info_request.apply_censor_rules_to_text(from_name)
+    info_request.apply_censor_rules_to_text(unredacted.from_name)
   end
 
   # Public: The value to be used in the From: header of an OutgoingMailer

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -28,6 +28,7 @@ class OutgoingMessage < ApplicationRecord
   include MessageProminence
   include Rails.application.routes.url_helpers
   include LinkToHelper
+  include Redactable
   include Taggable
 
   include OutgoingMessage::DeliveryStatus
@@ -75,6 +76,8 @@ class OutgoingMessage < ApplicationRecord
   after_update :xapian_reindex_after_update
 
   strip_attributes allow_empty: true
+
+  redactable :from, :from_name, :body
 
   admin_columns include: [:to, :from, :subject]
 
@@ -187,11 +190,11 @@ class OutgoingMessage < ApplicationRecord
 
     # Use the given censor_rules; otherwise fetch them from the associated
     # info_request
-    censor_rules = options.fetch(:censor_rules) do
-      info_request.try(:applicable_censor_rules) or []
-    end
+    #censor_rules = options.fetch(:censor_rules) do
+      #info_request.try(:applicable_censor_rules) or []
+    #end
 
-    censor_rules.reduce(text) { |t, rule| rule.apply_to_text(t) }
+    #censor_rules.reduce(text) { |t, rule| rule.apply_to_text(t) }
   end
 
   def raw_body

--- a/app/models/redactable/unredacted.rb
+++ b/app/models/redactable/unredacted.rb
@@ -1,0 +1,26 @@
+# Provides unredacted access to a Redactable's attributes
+class Redactable::Unredacted < SimpleDelegator
+  def method_missing(method_name, *args, **kwargs, &block)
+    with_unredacted_access do
+      record.public_send(method_name, *args, **kwargs, &block)
+    end
+  end
+
+  def with_unredacted_access
+    was = record.unredacted_access
+    record.unredacted_access = true
+    yield
+  ensure
+    record.unredacted_access = was
+  end
+
+  def class
+    record.class
+  end
+
+  private
+
+  def record
+    __getobj__
+  end
+end

--- a/app/models/redactable/unredacted.rb
+++ b/app/models/redactable/unredacted.rb
@@ -1,20 +1,12 @@
 class Redactable::Unredacted < SimpleDelegator
   def method_missing(method_name, *args, **kwargs, &block)
-    if record.redactable_attrs.include?(method_name)
-      with_unredacted_access { record.public_send(method_name) }
-    else
-      super
-    end
-  end
-
-  def respond_to_missing?(method_name, include_private = false)
-    record.redactable_attrs.include?(method_name) || super
+    with_unredacted_access { record.public_send(method_name, *args, **kwargs, &block) }
   end
 
   def with_unredacted_access
     was = record.unredacted_access
     record.unredacted_access = true
-    yield(self)
+    yield
   ensure
     record.unredacted_access = was
   end

--- a/app/models/redactable/unredacted.rb
+++ b/app/models/redactable/unredacted.rb
@@ -1,0 +1,31 @@
+class Redactable::Unredacted < SimpleDelegator
+  def method_missing(method_name, *args, **kwargs, &block)
+    if record.redactable_attrs.include?(method_name)
+      with_unredacted_access { record.public_send(method_name) }
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    record.redactable_attrs.include?(method_name) || super
+  end
+
+  def with_unredacted_access
+    was = record.unredacted_access
+    record.unredacted_access = true
+    yield(self)
+  ensure
+    record.unredacted_access = was
+  end
+
+  def class
+    record.class
+  end
+
+  private
+
+  def record
+    __getobj__
+  end
+end

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -295,7 +295,7 @@
         </span>
 
         <blockquote>
-          <%= truncate(outgoing_message.body, length: 400) %>
+          <%= truncate(outgoing_message.unredacted.body, length: 400) %>
         </blockquote>
       </div>
 

--- a/lib/alaveteli_text_masker.rb
+++ b/lib/alaveteli_text_masker.rb
@@ -50,6 +50,8 @@ module AlaveteliTextMasker
     # images may get broken if we try to. We err on the side of masking too
     # much, as many unknown types will really be text.
 
+    return text if text.nil?
+
     # Special cases for some content types
     case content_type
     when 'application/pdf'

--- a/spec/mailers/outgoing_mailer_spec.rb
+++ b/spec/mailers/outgoing_mailer_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe OutgoingMailer, " when working out follow up names and addresses"
     @incoming_message = mock_model(IncomingMessage,
                                    from_email: 'specific@example.com',
                                    safe_from_name: 'Specific Person')
+
+    allow(@incoming_message).
+      to receive(:unredacted).
+      and_return(@incoming_message)
   end
 
   describe 'if there is no incoming message being replied to' do

--- a/spec/mailers/outgoing_mailer_spec.rb
+++ b/spec/mailers/outgoing_mailer_spec.rb
@@ -78,6 +78,23 @@ RSpec.describe OutgoingMailer, "when working out follow up subjects" do
     expect(OutgoingMailer.subject_for_followup(ir, om, html: false)).to eq("Re: Geraldine FOI Code AZXB421")
   end
 
+  it "uses the unredacted incoming subject when delivering a followup" do
+    ir = info_requests(:fancy_dog_request)
+    im = ir.incoming_messages[0]
+    om = outgoing_messages(:useless_outgoing_message)
+    om.incoming_message_followup = im
+
+    im.raw_email.data = im.raw_email.data.sub(
+      'Subject: Geraldine FOI Code AZXB421',
+      'Subject: Re: case foo@example.com'
+    )
+    im.parse_raw_email!
+
+    expect(im.subject).to eq('Re: case [email address]')
+    expect(OutgoingMailer.followup(ir, om, im).subject).
+      to eq('Re: case foo@example.com')
+  end
+
   it "should not add Re: prefix if there already is such a prefix" do
     ir = info_requests(:fancy_dog_request)
     im = ir.incoming_messages[0]

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -2310,7 +2310,7 @@ RSpec.describe FoiAttachment do
         FactoryBot.create(
           :censor_rule,
           censorable: info_request,
-          text: foi_attachment.filename,
+          text: foi_attachment.unredacted.filename,
           replacement: 'redacted.txt'
         )
       end

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -375,6 +375,24 @@ RSpec.describe FoiAttachment do
     end
   end
 
+  describe '#redacted_filename' do
+    let(:info_request) { FactoryBot.create(:info_request, :with_incoming) }
+    let(:foi_attachment) { info_request.foi_attachments.first }
+
+    it 'applies censor rules once' do
+      filename = foi_attachment.unredacted.filename
+      replacement = "#{filename} [hidden]"
+      FactoryBot.create(
+        :censor_rule,
+        censorable: info_request,
+        text: filename,
+        replacement: replacement
+      )
+
+      expect(foi_attachment.redacted_filename).to eq(replacement)
+    end
+  end
+
   describe '#body_as_text' do
     context 'when erased' do
       let(:foi_attachment) { FactoryBot.create(:body_text, :erased) }

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -490,7 +490,7 @@ RSpec.describe IncomingMessage do
       message = FactoryBot.create(:incoming_message)
       message.raw_email.data = inbound_email
       message.parse_raw_email!
-      expect(message.from_email).to eq('authority@mail.example.com')
+      expect(message.unredacted.from_email).to eq('authority@mail.example.com')
     end
 
     it 'returns an empty string if there is no From header' do

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -472,9 +472,10 @@ RSpec.describe IncomingMessage do
       message.reload
       FactoryBot.create(:censor_rule,
                         text: 'Person',
+                        replacement: 'Person [hidden]',
                         censorable: message.info_request)
 
-      expect(message.safe_from_name).to eq('FOI [REDACTED]')
+      expect(message.safe_from_name).to eq('FOI Person [hidden]')
     end
   end
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -1808,7 +1808,9 @@ RSpec.describe InfoRequest do
     subject { info_request.safe_from_name }
 
     before do
-      FactoryBot.create(:global_censor_rule, text: 'Bob', replacement: 'Robert')
+      FactoryBot.create(:global_censor_rule,
+                        text: 'Bob',
+                        replacement: 'Bob [hidden]')
     end
 
     context 'when external' do
@@ -1828,13 +1830,13 @@ RSpec.describe InfoRequest do
       let(:info_request) { FactoryBot.build(:info_request, user: user) }
 
       it 'returns users name with censor rule applied' do
-        is_expected.to eq('Robert Smith 1')
+        is_expected.to eq('Bob [hidden] Smith 1')
       end
     end
 
     context 'when sent internal message' do
       let(:outgoing_message) do
-        FactoryBot.build(:initial_request, from_name: 'Robert Smith 2')
+        FactoryBot.build(:initial_request, from_name: 'Bob Smith 2')
       end
 
       let(:info_request) do
@@ -1842,7 +1844,7 @@ RSpec.describe InfoRequest do
       end
 
       it 'returns initial request from name with censor rule applied' do
-        is_expected.to eq('Robert Smith 2')
+        is_expected.to eq('Bob [hidden] Smith 2')
       end
     end
   end

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -680,8 +680,10 @@ RSpec.describe OutgoingMessage do
     end
 
     it 'applies censor rules to from_name' do
-      FactoryBot.create(:global_censor_rule, text: 'Bob', replacement: 'Robert')
-      is_expected.to eq('Robert')
+      FactoryBot.create(:global_censor_rule,
+                        text: 'Bob',
+                        replacement: 'Bob [hidden]')
+      is_expected.to eq('Bob [hidden]')
     end
 
     context 'when request is external' do

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -111,8 +111,21 @@ RSpec.describe OutgoingMessage do
 
       message = FactoryBot.create(:outgoing_message, attrs)
 
-      expect_any_instance_of(OutgoingMessage).not_to receive(:body).and_call_original
+      # :body is defined on a module prepended by Redactable, which
+      # `expect_any_instance_of` can't stub, so spy on it with our own
+      # prepended module instead.
+      call_count = 0
+      spy = Module.new do
+        define_method(:body) do |*args, **kwargs|
+          call_count += 1
+          super(*args, **kwargs)
+        end
+      end
+
+      OutgoingMessage.prepend(spy)
       OutgoingMessage.find(message.id)
+
+      expect(call_count).to eq(0)
     end
   end
 
@@ -202,7 +215,7 @@ RSpec.describe OutgoingMessage do
       request = FactoryBot.create(:info_request, user: user)
       message = FactoryBot.build(:initial_request, info_request: request)
       expected = "Spec User 862 <request-#{ request.id }-#{ request.idhash }@localhost>"
-      expect(message.from).to eq(expected)
+      expect(message.unredacted.from).to eq(expected)
     end
   end
 
@@ -226,6 +239,7 @@ RSpec.describe OutgoingMessage do
           mock_model(IncomingMessage, from_email: 'specific@example.com',
                                       safe_from_name: 'Specific Person',
                                       valid_to_reply_to?: true)
+        allow(followup).to receive(:unredacted).and_return(followup)
         allow(message).to receive(:incoming_message_followup).and_return(followup)
 
         expected = 'Specific Person <specific@example.com>'
@@ -375,7 +389,8 @@ RSpec.describe OutgoingMessage do
       attrs = { status: 'ready',
                 message_type: 'initial_request',
                 body: 'This sensitive text contains secret info!',
-                what_doing: 'normal_sort' }
+                what_doing: 'normal_sort',
+                info_request: FactoryBot.create(:info_request) }
       message = FactoryBot.build(:outgoing_message, attrs)
 
       rules = [FactoryBot.build(:censor_rule, text: 'secret'),
@@ -390,7 +405,8 @@ RSpec.describe OutgoingMessage do
       attrs = { status: 'ready',
                 message_type: 'initial_request',
                 body: 'This sensitive text contains secret info!',
-                what_doing: 'normal_sort' }
+                what_doing: 'normal_sort',
+                info_request: FactoryBot.create(:info_request) }
       message = FactoryBot.build(:outgoing_message, attrs)
 
       request_rules = [FactoryBot.build(:censor_rule, text: 'secret'),

--- a/spec/models/redactable/unredacted_spec.rb
+++ b/spec/models/redactable/unredacted_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe Redactable::Unredacted do
+  let(:record) do
+    klass = Class.new do
+      include Redactable
+      redactable :title
+
+      def title = 'Some title'
+      def safe = 'Some generic content'
+    end
+
+    klass.new
+  end
+
+  subject { described_class.new(record) }
+
+  it 'responds to all methods on the given record' do
+    is_expected.to respond_to(:title)
+    is_expected.to respond_to(:safe)
+  end
+
+  it 'does not define methods for undeclared attributes' do
+    is_expected.not_to respond_to(:name)
+  end
+
+  it 'grants unredacted access when reading redactable attributes' do
+    expect(subject).to receive(:with_unredacted_access).and_call_original
+    expect(subject.title).to eq('Some title')
+  end
+
+  it 'returns the correct value for non-redactable attributes' do
+    expect(subject.safe).to eq('Some generic content')
+  end
+end

--- a/spec/models/redactable/unredacted_spec.rb
+++ b/spec/models/redactable/unredacted_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe Redactable::Unredacted do
+  let(:record) do
+    klass = Class.new do
+      include Redactable
+      redactable :title
+
+      def title = 'Some title'
+      def safe = 'Some generic content'
+    end
+
+    klass.new
+  end
+
+  subject { described_class.new(record) }
+
+  it 'responds to all methods on the given record' do
+    is_expected.to respond_to(:title)
+    is_expected.to respond_to(:safe)
+  end
+
+  it 'does not define methods for undeclared attributes' do
+    is_expected.not_to respond_to(:name)
+  end
+
+  it 'grants unredacted access when reading redactable attributes' do
+    expect(subject).to receive(:with_unredacted_access).and_call_original
+    expect(subject.title).to eq('Some title')
+  end
+
+  it 'does not grant unredacted access for non-redactable attributes' do
+    expect(subject).not_to receive(:with_unredacted_access)
+    expect(subject.safe).to eq('Some generic content')
+  end
+end

--- a/spec/models/redactable/unredacted_spec.rb
+++ b/spec/models/redactable/unredacted_spec.rb
@@ -29,8 +29,7 @@ RSpec.describe Redactable::Unredacted do
     expect(subject.title).to eq('Some title')
   end
 
-  it 'does not grant unredacted access for non-redactable attributes' do
-    expect(subject).not_to receive(:with_unredacted_access)
+  it 'returns the correct value for non-redactable attributes' do
     expect(subject.safe).to eq('Some generic content')
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

* Supersedes https://github.com/mysociety/alaveteli/pull/9319
* Prep for https://github.com/mysociety/alaveteli/issues/8824
* Requires https://github.com/mysociety/alaveteli/pull/9302

## What does this do?

Adds explicit interfaces for getting redacted/unredacted versions of content

## Why was this needed?

* Make it easier to get different versions of content
* Reduce number of methods / method overrides that currently do the above
* Protects against information leaks by forcing developers to explicitly permit unredacted access to data

## Implementation notes

Here's how this will work:

```rb
class User < ApplicationRecord
  include Redactable
  redactable :from_name
end

user.censor_rules.create!(
  text: 'Bob Smith',
  replacement: '[name removed]',
  last_edit_editor: 'x',
  last_edit_comment: 'x'
)

msg = user.info_requests.first.outgoing_messages.first

msg.from_name
# => "[name removed]"

msg.unredacted.from_name
# => "Bob Smith"
```

Linking to old commit 2aafd5133001c7117d86ce6981f563b8c66e1a90 which includes some now squashed documentation on a specific problem – might fold this back in.

## Notes to reviewer

While this does force explicit unredacted permission, it still requires us to remember to add attributes to `redactable`. There's an alternative version of this where we by default assume attributes will hold PII unless explicitly told they won't, but that feels like it would get a bit _too_ annoying?

At the moment this applies both censor rules and text masks. We may want to split these up so that we can do e.g. (`record.censored.unmasked.foo`).

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]