### PR TITLE
Add an attachment download button to admin UI

### DIFF
--- a/app/views/admin/foi_attachments/edit.html.erb
+++ b/app/views/admin/foi_attachments/edit.html.erb
@@ -4,6 +4,19 @@
   foi_attachment: @foi_attachment
 } %>
 
+
+<% if @foi_attachment.erased? %>
+  <p>
+    <%= button_to 'Download', '', class: 'btn', disabled: true %>
+    <span class="muted">Erased attachments cannot be downloaded.</span>
+  </p>
+<% else %>
+  <p>
+    <%= link_to 'Download', attachment_path(@foi_attachment), class: 'btn' %>
+    <span class="muted">Downloads the public version.</span>
+  </p>
+<% end %>
+
 <table class="table table-striped table-condensed">
   <tbody>
     <% @foi_attachment.for_admin_column do |name, value| %>


### PR DESCRIPTION
Makes it easier to view the raw attachment from the admin interface rather than having to open up the public view or extract it from the downloaded raw email.

<img width="992" height="215" alt="Screenshot 2026-07-08 at 12 55 37" src="https://github.com/user-attachments/assets/5660f0f6-0b15-49fc-b4d6-172a12a2d6c1" />


<img width="997" height="212" alt="Screenshot 2026-07-08 at 12 57 18" src="https://github.com/user-attachments/assets/2d7cf58d-9234-4abe-8e0a-77552fdea7e1" />


[skip changelog]
