### PR TITLE
Add a unique index to foi_attachments

### DIFF
--- a/app/jobs/foi_attachment/mask_job.rb
+++ b/app/jobs/foi_attachment/mask_job.rb
@@ -7,12 +7,17 @@
 #
 class FoiAttachment::MaskJob < ApplicationJob
   queue_as :default
-  unique :until_and_while_executing, on_conflict: :log
+  unique :until_executed, on_conflict: :log
 
   attr_reader :attachment
 
   delegate :incoming_message, to: :attachment
   delegate :info_request, to: :incoming_message
+
+  # use the IncomingMessage.id as uniqueness key when queuing up jobs
+  def lock_key_arguments
+    arguments.first.incoming_message.id
+  end
 
   def perform(attachment)
     @attachment = attachment

--- a/db/migrate/20260709171753_add_unique_index_to_foi_attachments.rb
+++ b/db/migrate/20260709171753_add_unique_index_to_foi_attachments.rb
@@ -1,0 +1,7 @@
+class AddUniqueIndexToFoiAttachments < ActiveRecord::Migration[8.0]
+  def change
+    add_index :foi_attachments, [:incoming_message_id, :hexdigest], name: 'index_foi_attachments_uniqueness', unique: true
+    # remove the old index as it is now redundant with the above
+    remove_index :foi_attachments, :incoming_message_id, name: :index_foi_attachments_on_incoming_message_id
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Prevent duplicate attachments from being saved to db (Laurent Savaete)
 * Move admin attachment erasure into background job (Graeme Porteous)
 * Add Search module providing a backend-agnostic search interface, decoupling
   controllers, models and mailers from Xapian (Graeme Porteous)


### PR DESCRIPTION
## Relevant issue(s)

#9354 

## What does this do?

This prevents the insertion of duplicate attachments (with the same hexdigest) for a given message.

## Why was this needed?

Duplicate FoiAttachment records (for a same actual file) cause duplication of notification and other annoyances for users and admins.

## Implementation notes

The unique index in the database is the ultimate preventer, but it will not prevent the situation from arising (in such a case, we would get an error from postgres, instead of silently duplicating records).

The modified strategy on the job uniqueness *should* prevent 2 concurrent jobs from being queued up for a single incoming message, which we believe is the cause for this problem.

As detailed in the ticket, I do not believe that taking a lock is sufficient to prevent this bug from arising.

## Screenshots

## Notes to reviewer

I have not been able to write a test that actually validates this PR, because it seems to be caused by concurrency and a fair bit of randomness. If you have any idea how to do this, please let me know.
