### PR TITLE
feat(api): add read-only rate limit endpoint

### DIFF
--- a/app/controllers/api/v1/sustainability_controller.rb
+++ b/app/controllers/api/v1/sustainability_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  module V1
+    class SustainabilityController < ApplicationController
+      skip_before_action :html_response
+
+      def rate_limit
+        rule = limiter.rule
+        records = limiter.records(request.remote_ip)
+        active_records = rule.records_in_window(records)
+        remaining = [rule.count - active_records.count, 0].max
+        reset = reset_in_seconds(rule, active_records)
+
+        response.headers['Cache-Control'] = 'no-store'
+        response.headers['RateLimit-Limit'] = rule.count.to_s
+        response.headers['RateLimit-Remaining'] = remaining.to_s
+        response.headers['RateLimit-Reset'] = reset.to_s
+
+        render json: {
+          version: 1,
+          policy: rule.name,
+          limit: rule.count,
+          remaining: remaining,
+          reset_in_seconds: reset
+        }
+      rescue StandardError => exception
+        Rails.logger.warn("Sustainability rate-limit endpoint unavailable: #{exception.class}")
+        render json: { error: 'rate_limit_unavailable' }, status: :service_unavailable
+      end
+
+      private
+
+      def limiter
+        @limiter ||= AlaveteliRateLimiter::IPRateLimiter.new(:request)
+      end
+
+      def reset_in_seconds(rule, records)
+        oldest = records.min
+        return 0 unless oldest
+
+        expiry = oldest + rule.window.value.send(rule.window.unit)
+        [expiry - Time.current, 0].max.to_i
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/sustainability_controller.rb
+++ b/app/controllers/api/v1/sustainability_controller.rb
@@ -41,7 +41,15 @@ module Api
       end
 
       def normalized_client_ip
-        IPAddr.new(request.remote_ip.to_s).to_s
+        raw_ip = request.remote_ip.to_s
+        valid_ip = [
+          IPAddr::RE_IPV4ADDRLIKE,
+          IPAddr::RE_IPV6ADDRLIKE_FULL,
+          IPAddr::RE_IPV6ADDRLIKE_COMPRESSED
+        ].any? { |pattern| pattern.match?(raw_ip) }
+        return unless valid_ip
+
+        IPAddr.new(raw_ip).to_s
       rescue IPAddr::InvalidAddressError, ActionDispatch::RemoteIp::IpSpoofAttackError
         nil
       end

--- a/app/controllers/api/v1/sustainability_controller.rb
+++ b/app/controllers/api/v1/sustainability_controller.rb
@@ -4,13 +4,13 @@ module Api
       skip_before_action :html_response
 
       def rate_limit
-        rule = limiter.rule
         client_ip = normalized_client_ip
         unless client_ip
           response.headers['Cache-Control'] = 'no-store'
           return render json: { error: 'invalid_client_address' }, status: :bad_request
         end
 
+        rule = limiter.rule
         records = limiter.records(client_ip)
         active_records = rule.records_in_window(records)
         remaining = [rule.count - active_records.count, 0].max

--- a/app/controllers/api/v1/sustainability_controller.rb
+++ b/app/controllers/api/v1/sustainability_controller.rb
@@ -24,6 +24,7 @@ module Api
         }
       rescue StandardError => exception
         Rails.logger.warn("Sustainability rate-limit endpoint unavailable: #{exception.class}")
+        response.headers['Cache-Control'] = 'no-store'
         render json: { error: 'rate_limit_unavailable' }, status: :service_unavailable
       end
 

--- a/app/controllers/api/v1/sustainability_controller.rb
+++ b/app/controllers/api/v1/sustainability_controller.rb
@@ -5,7 +5,13 @@ module Api
 
       def rate_limit
         rule = limiter.rule
-        records = limiter.records(request.remote_ip)
+        client_ip = normalized_client_ip
+        unless client_ip
+          response.headers['Cache-Control'] = 'no-store'
+          return render json: { error: 'invalid_client_address' }, status: :bad_request
+        end
+
+        records = limiter.records(client_ip)
         active_records = rule.records_in_window(records)
         remaining = [rule.count - active_records.count, 0].max
         reset = reset_in_seconds(rule, active_records)
@@ -32,6 +38,12 @@ module Api
 
       def limiter
         @limiter ||= AlaveteliRateLimiter::IPRateLimiter.new(:request)
+      end
+
+      def normalized_client_ip
+        IPAddr.new(request.remote_ip.to_s).to_s
+      rescue IPAddr::InvalidAddressError, ActionDispatch::RemoteIp::IpSpoofAttackError
+        nil
       end
 
       def reset_in_seconds(rule, records)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -877,6 +877,10 @@ Rails.application.routes.draw do
   ####
 
   #### Api controller
+  match '/api/v1/rate_limit' => 'api/v1/sustainability#rate_limit',
+        :as => :api_v1_rate_limit,
+        :via => :get
+
   match '/api/v2/request.json' => 'api#create_request',
         :as => :api_create_request,
         :via => :post

--- a/spec/controllers/api/v1/sustainability_controller_spec.rb
+++ b/spec/controllers/api/v1/sustainability_controller_spec.rb
@@ -39,9 +39,11 @@ RSpec.describe Api::V1::SustainabilityController, type: :controller do
     end
 
     it 'reports active records without exposing them' do
-      recorded_at = 10.minutes.ago
+      now = Time.current
+      allow(Time).to receive(:current).and_return(now)
+      recorded_at = now - 10.minutes
       allow(limiter).to receive(:records).with('127.0.0.1').
-        and_return([recorded_at, 20.minutes.ago])
+        and_return([recorded_at, now - 20.minutes])
 
       get :rate_limit
 
@@ -54,7 +56,7 @@ RSpec.describe Api::V1::SustainabilityController, type: :controller do
       )
       expect(body).not_to have_key('records')
       expect(response.headers['RateLimit-Remaining']).to eq('1')
-      expect(response.headers['RateLimit-Reset'].to_i).to be_between(2390, 2400)
+      expect(response.headers['RateLimit-Reset']).to eq('2400')
     end
 
     it 'fails closed without exposing limiter details' do
@@ -63,6 +65,7 @@ RSpec.describe Api::V1::SustainabilityController, type: :controller do
       get :rate_limit
 
       expect(response).to have_http_status(:service_unavailable)
+      expect(response.headers['Cache-Control']).to eq('no-store')
       expect(response.body).to eq({ error: 'rate_limit_unavailable' }.to_json)
       expect(response.body).not_to include('backend detail')
     end

--- a/spec/controllers/api/v1/sustainability_controller_spec.rb
+++ b/spec/controllers/api/v1/sustainability_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Api::V1::SustainabilityController, type: :controller do
     end
 
     it 'rejects an invalid client address without querying the limiter' do
-      allow(request).to receive(:remote_ip).and_return('not-an-ip')
+      allow(controller.request).to receive(:remote_ip).and_return('not-an-ip')
       expect(AlaveteliRateLimiter::IPRateLimiter).not_to receive(:new)
 
       get :rate_limit

--- a/spec/controllers/api/v1/sustainability_controller_spec.rb
+++ b/spec/controllers/api/v1/sustainability_controller_spec.rb
@@ -74,14 +74,22 @@ RSpec.describe Api::V1::SustainabilityController, type: :controller do
     end
 
     it 'rejects an invalid client address without querying the limiter' do
-      allow(controller.request).to receive(:remote_ip).and_return('not-an-ip')
-      expect(AlaveteliRateLimiter::IPRateLimiter).not_to receive(:new)
+      allow(controller).to receive(:normalized_client_ip).and_return(nil)
+      expect(limiter).not_to receive(:rule)
+      expect(limiter).not_to receive(:records)
 
       get :rate_limit
 
       expect(response).to have_http_status(:bad_request)
       expect(response.headers['Cache-Control']).to eq('no-store')
       expect(response.body).to eq({ error: 'invalid_client_address' }.to_json)
+    end
+
+    it 'rejects non-literal addresses during normalization' do
+      request_double = instance_double(ActionDispatch::Request, remote_ip: 'not-an-ip')
+      allow(controller).to receive(:request).and_return(request_double)
+
+      expect(controller.send(:normalized_client_ip)).to be_nil
     end
 
     it 'fails closed without exposing limiter details' do

--- a/spec/controllers/api/v1/sustainability_controller_spec.rb
+++ b/spec/controllers/api/v1/sustainability_controller_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+RSpec.describe Api::V1::SustainabilityController, type: :controller do
+  describe 'GET #rate_limit' do
+    let(:rule) do
+      AlaveteliRateLimiter::Rule.new(
+        :request,
+        3,
+        AlaveteliRateLimiter::Window.new(1, :hour)
+      )
+    end
+    let(:limiter) { instance_double(AlaveteliRateLimiter::IPRateLimiter, rule: rule) }
+
+    before do
+      allow(AlaveteliRateLimiter::IPRateLimiter).
+        to receive(:new).with(:request).and_return(limiter)
+      allow(limiter).to receive(:records).with('127.0.0.1').and_return([])
+      request.env['REMOTE_ADDR'] = '127.0.0.1'
+    end
+
+    it 'returns a versioned advisory contract without recording a request' do
+      expect(limiter).not_to receive(:record)
+
+      get :rate_limit
+
+      expect(response).to have_http_status(:ok)
+      expect(response.media_type).to eq('application/json')
+      expect(response.headers['Cache-Control']).to eq('no-store')
+      expect(response.headers['RateLimit-Limit']).to eq('3')
+      expect(response.headers['RateLimit-Remaining']).to eq('3')
+      expect(response.headers['RateLimit-Reset']).to eq('0')
+      expect(JSON.parse(response.body)).to eq(
+        'version' => 1,
+        'policy' => 'request',
+        'limit' => 3,
+        'remaining' => 3,
+        'reset_in_seconds' => 0
+      )
+    end
+
+    it 'reports active records without exposing them' do
+      recorded_at = 10.minutes.ago
+      allow(limiter).to receive(:records).with('127.0.0.1').
+        and_return([recorded_at, 20.minutes.ago])
+
+      get :rate_limit
+
+      body = JSON.parse(response.body)
+      expect(body).to include(
+        'version' => 1,
+        'policy' => 'request',
+        'limit' => 3,
+        'remaining' => 1
+      )
+      expect(body).not_to have_key('records')
+      expect(response.headers['RateLimit-Remaining']).to eq('1')
+      expect(response.headers['RateLimit-Reset'].to_i).to be_between(2390, 2400)
+    end
+
+    it 'fails closed without exposing limiter details' do
+      allow(limiter).to receive(:records).and_raise(StandardError, 'backend detail')
+
+      get :rate_limit
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.body).to eq({ error: 'rate_limit_unavailable' }.to_json)
+      expect(response.body).not_to include('backend detail')
+    end
+  end
+end

--- a/spec/controllers/api/v1/sustainability_controller_spec.rb
+++ b/spec/controllers/api/v1/sustainability_controller_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe Api::V1::SustainabilityController, type: :controller do
 
     it 'rejects an invalid client address without querying the limiter' do
       allow(request).to receive(:remote_ip).and_return('not-an-ip')
-      expect(limiter).not_to receive(:records)
+      expect(AlaveteliRateLimiter::IPRateLimiter).not_to receive(:new)
 
       get :rate_limit
 

--- a/spec/controllers/api/v1/sustainability_controller_spec.rb
+++ b/spec/controllers/api/v1/sustainability_controller_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe Api::V1::SustainabilityController, type: :controller do
       expect(response.headers['RateLimit-Reset']).to eq('2400')
     end
 
+    it 'reports zero remaining while preserving the oldest active reset' do
+      now = Time.current
+      allow(Time).to receive(:current).and_return(now)
+      allow(limiter).to receive(:records).with('127.0.0.1').
+        and_return([now - 20.minutes, now - 10.minutes, now - 5.minutes, now - 1.minute])
+
+      get :rate_limit
+
+      body = JSON.parse(response.body)
+      expect(body).to include('limit' => 3, 'remaining' => 0, 'reset_in_seconds' => 2400)
+      expect(response.headers['RateLimit-Remaining']).to eq('0')
+      expect(response.headers['RateLimit-Reset']).to eq('2400')
+    end
+
+    it 'rejects an invalid client address without querying the limiter' do
+      allow(request).to receive(:remote_ip).and_return('not-an-ip')
+      expect(limiter).not_to receive(:records)
+
+      get :rate_limit
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.headers['Cache-Control']).to eq('no-store')
+      expect(response.body).to eq({ error: 'invalid_client_address' }.to_json)
+    end
+
     it 'fails closed without exposing limiter details' do
       allow(limiter).to receive(:records).and_raise(StandardError, 'backend detail')
 


### PR DESCRIPTION
## Summary

Add the first small server-side foundation for the sustainability contract tracked by #9377 and the parent contract issue #9363.

Fork implementation and cross-reference: edithatogo/alaveteli#40 and edithatogo/alaveteli#39.

[skip changelog]

## Scope

- add `GET /api/v1/rate_limit`
- expose a versioned advisory JSON response and standard `RateLimit-*` headers
- derive values from the existing request IP limiter without recording or exposing request data
- return a generic `503` response if limiter configuration or storage is unavailable
- add focused controller coverage for nominal, active-window, and fail-closed behavior

## Explicitly out of scope

Bulk export, client/MCP integration, Rack/Sprockets migration, dependency updates, scanner changes, and production deployment configuration remain separate follow-up work.

## Verification

- Ruby 3.4.9 syntax checks: passed
- `git diff --check`: passed
- focused RSpec: attempted locally, blocked by the user-local build of `xapian-full-alaveteli` exceeding the local execution window
- upstream GitHub Actions: pending

This draft is intentionally one focused commit based directly on upstream `develop`. It should be promoted only after the upstream checks and maintainer review establish that this narrow contract is acceptable.