### PR TITLE
Fix duplicate attachments from concurrent parsing

### DIFF
--- a/app/jobs/foi_attachment/mask_job.rb
+++ b/app/jobs/foi_attachment/mask_job.rb
@@ -7,7 +7,7 @@
 #
 class FoiAttachment::MaskJob < ApplicationJob
   queue_as :default
-  unique :until_and_while_executing, on_conflict: :log
+  unique :until_executed, on_conflict: :log
 
   attr_reader :attachment
 

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -100,6 +100,11 @@ class IncomingMessage < ApplicationRecord
     raw_email_ensure_not_erased!
 
     ActiveRecord::Base.transaction do
+      # Lock the row to serialize concurrent re-parsing, otherwise two
+      # processes can each insert a full set of attachments. Locking a
+      # fresh copy avoids reloading self mid-parse.
+      self.class.lock.find(id) if persisted?
+
       extract_attachments
       self.sent_at = raw_email.date || created_at
       self.subject = raw_email.subject

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Fix duplicate attachments from concurrent incoming message masking (Laurent
+  Savaete, Graeme Porteous)
 * Move admin attachment erasure into background job (Graeme Porteous)
 * Add Search module providing a backend-agnostic search interface, decoupling
   controllers, models and mailers from Xapian (Graeme Porteous)

--- a/spec/jobs/foi_attachment/mask_job_spec.rb
+++ b/spec/jobs/foi_attachment/mask_job_spec.rb
@@ -11,6 +11,28 @@ RSpec.describe FoiAttachment::MaskJob, type: :job do
 
   before { rebuild_raw_emails(info_request) }
 
+  describe 'uniqueness' do
+    let(:attachment_1) { incoming_message.foi_attachments.first }
+    let(:attachment_2) { incoming_message.foi_attachments.last }
+
+    before { described_class.unlock! }
+    after { described_class.unlock! }
+
+    it 'does not enqueue duplicate jobs for the same attachment' do
+      expect {
+        described_class.perform_later(attachment_1)
+        described_class.perform_later(attachment_1)
+      }.to have_enqueued_job(described_class).exactly(:once)
+    end
+
+    it 'enqueues jobs for sibling attachments of the same message' do
+      expect {
+        described_class.perform_later(attachment_1)
+        described_class.perform_later(attachment_2)
+      }.to have_enqueued_job(described_class).twice
+    end
+  end
+
   context 'after rescuing from FoiAttachment::MissingError' do
     before do
       # first call to #unmasked_body should raise MissingError exception

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -102,6 +102,51 @@ RSpec.describe IncomingMessage do
         expect { subject }.to raise_error(RawEmail::ErasedError)
       end
     end
+
+    context 'when another process parses the message concurrently' do
+      # Threads need their own connections and to see committed data
+      self.use_transactional_tests = false
+
+      let(:message) do
+        FactoryBot.create(:incoming_message, :with_html_attachment)
+      end
+
+      before do
+        # Remove the existing attachments so both parse_raw_email calls insert
+        # them from scratch
+        message.foi_attachments.delete_all
+      end
+
+      after do
+        # Without a wrapping transaction the committed records leak into other
+        # examples unless destroyed
+        [message.info_request, message.info_request.user,
+         message.info_request.public_body].each(&:destroy)
+      end
+
+      it 'does not store duplicate attachments' do
+        concurrent_parse = nil
+
+        # Start a second parse after this one has checked for existing
+        # attachments but before it saves the rebuilt ones
+        allow(message).to receive(:extract_attachments).
+          and_wrap_original do |original_method|
+            result = original_method.call
+            concurrent_parse = Thread.new do
+              ActiveRecord::Base.connection_pool.with_connection do
+                IncomingMessage.find(message.id).parse_raw_email!
+              end
+            end
+            sleep 0.5
+            result
+          end
+
+        message.parse_raw_email!
+        concurrent_parse.join
+
+        expect(message.foi_attachments.reload.count).to eq(2)
+      end
+    end
   end
 
   describe '#extract_attachments!' do


### PR DESCRIPTION
## Relevant issue(s)

Fixes #9354 

## What does this do?

This prevents the insertion of duplicate attachments (with the same hexdigest) for a given message.

## Why was this needed?

Duplicate FoiAttachment records (for a same actual file) cause duplication of notification and other annoyances for users and admins.

## Implementation notes

The row-level lock taken in `IncomingMessage#parse_raw_email!` is the ultimate preventer. Two processes re-parsing the same message serialize on the message row: the second blocks until the first commits, then finds the freshly committed attachments and updates them in place instead of inserting a duplicate set. Unlike a unique index, nothing errors and no job fails - the losing parser just does no-op updates.

A unique index on `(incoming_message_id, hexdigest)` was considered and rejected: the same content can legitimately appear more than once on a message (Outlook permits duplicate attachments; admin file replacement can equalise content), existing production data already contains duplicates that would block the migration, and it would have turned the race into a `RecordNotUnique` error rather than a clean result.

The modified uniqueness strategy on `FoiAttachment::MaskJob` (one job per incoming message, `until_executed`) removes the most common source of concurrent re-parsing - two mask jobs for sibling attachments both rescuing `FoiAttachment::MissingError`. The row lock covers the remaining paths, EG `MaskJob.perform_now` invoked on demand from `FoiAttachment#body`, which bypasses queue-level deduplication entirely.
