### PR TITLE
Change `Note#default_style` to "blue"

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -8,7 +8,7 @@
 #  notable_tag  :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  style        :string           default("original"), not null
+#  style        :string           default("blue"), not null
 #  body         :text
 #
 
@@ -23,7 +23,7 @@ class Note < ApplicationRecord
 
   cattr_accessor :default_style,
                  instance_accessor: false,
-                 default: 'original'
+                 default: 'blue'
   cattr_accessor :style_labels,
                  instance_accessor: false,
                  default: {

--- a/db/migrate/20260713141538_change_default_note_style.rb
+++ b/db/migrate/20260713141538_change_default_note_style.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultNoteStyle < ActiveRecord::Migration[8.0]
+  def change
+    change_column_default :notes, :style, from: 'original', to: 'blue'
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Update the default Note style to "blue". The "original" style is deprecated
+  (Gareth Rees)
 * Add PostgreSQL full-text search indexing, initially enabled for users only
   (Laurent Savaete, Graeme Porteous)
 * Fix reCAPTCHA blocked by Content Security Policy (Graeme Porteous)

--- a/spec/factories/notes.rb
+++ b/spec/factories/notes.rb
@@ -8,7 +8,7 @@
 #  notable_tag  :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  style        :string           default("original"), not null
+#  style        :string           default("blue"), not null
 #  body         :text
 #
 

--- a/spec/fixtures/notes.yml
+++ b/spec/fixtures/notes.yml
@@ -8,7 +8,7 @@
 #  notable_tag  :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  style        :string           default("original"), not null
+#  style        :string           default("blue"), not null
 #  body         :text
 #
 

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -8,7 +8,7 @@
 #  notable_tag  :string
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
-#  style        :string           default("original"), not null
+#  style        :string           default("blue"), not null
 #  body         :text
 #
 


### PR DESCRIPTION
Change `Note#default_style` to "blue"

"original" is deprecated in favour of ActionText-based notes.

[skip changelog]
