### PR TITLE
Add reindex rake tasks for populating SearchDocuments

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -48,6 +48,13 @@ module Searchable
     @@locale_to_language_map[locale]
   end
 
+  # Every model registered as searchable. The app must be eager loaded first
+  # (e.g. via +Rails.application.eager_load!+) so all +searchable+ declarations
+  # have run, otherwise lazily-loaded models will be missing.
+  def self.searchable_models
+    class_variable_get(:@@searchable_models).keys.map(&:constantize)
+  end
+
   # TODO: rename to `search`
   # Search entry point for searching a single instance of a model.
   # Override per model as each one will have custom logic
@@ -250,7 +257,40 @@ module Searchable
       )
     end
 
-    # Reindex all instances of a model.
+    # Records that have no search document yet. Lets a reindex resume after an
+    # interruption and skip records already in the index, without depending on
+    # id ordering. Backed by the unique
+    # (searchable_type, searchable_id, section_ref, language) index via a
+    # NOT EXISTS correlated subquery.
+    def not_indexed
+      where(
+        "NOT EXISTS (" \
+          "SELECT 1 FROM search_documents " \
+          "WHERE search_documents.searchable_type = :type " \
+          "AND search_documents.searchable_id = #{quoted_table_name}.id" \
+        ")",
+        type: name
+      )
+    end
+
+    # Reindex a single record, logging and swallowing any failure so a batch
+    # run is not aborted by one bad record. Returns true when the record was
+    # indexed, false when it raised.
+    def reindex_record(record)
+      record.reindex
+      true
+    rescue StandardError => e
+      Rails.logger.error(
+        "Failed to reindex #{name}##{record.id}: #{e.class}: #{e.message}"
+      )
+      false
+    end
+
+    # Reindex all instances of a model in a single process. Suited to small,
+    # in-process rebuilds (e.g. the test suite or a console); large rebuilds
+    # should use the chunked `reindex:all` rake task, which releases memory
+    # between chunks. Unlike that task this raises on the first failing record,
+    # which is the behaviour the tests rely on to surface problems.
     # This would normally not be run beyond the initial indexing of a
     # pre-existing database.
     def reindex_all(batch_size: 1000)

--- a/lib/tasks/reindex.rake
+++ b/lib/tasks/reindex.rake
@@ -1,5 +1,111 @@
+require "English"
+require "fileutils"
 
 namespace :reindex do
+  # exit status used by `reindex:chunk` to tell the `reindex:missing`
+  # coordinator that it indexed a chunk and more work probably remains. 0 means
+  # nothing was left to index; anything else is a genuine failure.
+  CHUNK_PROCESSED = 10
+
+  # Index one chunk of records, then exit so the OS reclaims everything this
+  # process allocated. Spawned repeatedly by `reindex:missing`/`reindex:all`,
+  # which is how memory is released periodically: each chunk runs in a brand new
+  # process rather than accumulating in a long-lived one.
+  #
+  # Progress is tracked with a per-model id cursor file under STATE_DIR so a
+  # record that fails to index can't stall the run. Unless ONLY_MISSING is "0"
+  # (set by `reindex:all`), `not_indexed` also skips records already indexed by
+  # an earlier run, keeping `reindex:missing` resumable and dedup'd.
+  task chunk: :environment do
+    # ensure every `searchable` declaration has run so all models are known
+    Rails.application.eager_load!
+
+    # A full reindex issues an upsert per record; in the default development
+    # environment ActiveRecord logs every statement, and those writes dominate
+    # disk IO. Quietening the logger keeps the run IO-bound on the real work.
+    ActiveRecord::Base.logger&.level = Logger::WARN
+
+    chunk_size = (ENV["CHUNK_SIZE"] || 10_000).to_i
+    batch_size = (ENV["BATCH_SIZE"] || 1_000).to_i
+    only_missing = ENV["ONLY_MISSING"] != "0"
+    state_dir = ENV.fetch("STATE_DIR") { File.join(Dir.pwd, "tmp", "reindex") }
+    FileUtils.mkdir_p(state_dir)
+
+    models =
+      if ENV["MODELS"].present?
+        ENV["MODELS"].split(",").map { |name| name.strip.constantize }
+      else
+        Searchable.searchable_models
+      end
+
+    models.each do |model|
+      cursor_file = File.join(state_dir, "#{model.name.tr(':', '_')}.cursor")
+      last_id = File.exist?(cursor_file) ? File.read(cursor_file).to_i : 0
+      pk = "#{model.quoted_table_name}.#{model.quoted_primary_key}"
+
+      scope = model.indexable
+      scope = scope.not_indexed if only_missing
+      ids = scope.
+        where("#{pk} > ?", last_id).
+        order(model.primary_key).
+        limit(chunk_size).
+        pluck(model.primary_key)
+      next if ids.empty?
+
+      records = model.indexable.where(id: ids)
+      records.find_each(batch_size: batch_size) do |record|
+        model.reindex_record(record)
+      end
+
+      File.write(cursor_file, ids.max.to_s)
+      puts "Indexed #{ids.size} #{model} records (up to id #{ids.max})"
+      exit(CHUNK_PROCESSED)
+    end
+
+    # no model had records left to index
+    exit(0)
+  end
+
+  # Drive a chunked reindex by spawning a fresh `reindex:chunk` process per
+  # chunk until one reports there is nothing left to do. Deliberately avoids
+  # loading the app itself, so this coordinator stays tiny while memory is
+  # released between chunks by the short-lived workers.
+  def coordinate_reindex(model_arg, only_missing:)
+    state_dir = ENV["STATE_DIR"] || File.join(Dir.pwd, "tmp", "reindex")
+
+    # discard cursors from a previous run unless explicitly resuming
+    FileUtils.rm_rf(state_dir) unless ENV["RESUME"]
+
+    env = {
+      "STATE_DIR" => state_dir,
+      "ONLY_MISSING" => only_missing ? "1" : "0"
+    }
+    env["MODELS"] = model_arg if model_arg.present?
+    %w[CHUNK_SIZE BATCH_SIZE].each { |key| env[key] = ENV[key] if ENV[key] }
+
+    loop do
+      system(env, "bundle", "exec", "rake", "reindex:chunk")
+      status = $CHILD_STATUS.exitstatus
+      case status
+      when 0 then break
+      when CHUNK_PROCESSED then next
+      else abort "reindex:chunk failed (exit #{status.inspect})"
+      end
+    end
+
+    puts "Reindex complete"
+  end
+
+  desc "Index searchable records missing a search document (resumable, dedup)"
+  task :missing, [:model] do |_task, args|
+    coordinate_reindex(args[:model], only_missing: true)
+  end
+
+  desc "Reindex every searchable record (full rebuild, resumable)"
+  task :all, [:model] do |_task, args|
+    coordinate_reindex(args[:model], only_missing: false)
+  end
+
   desc "Reindex events in batches"
   task events: :environment do
     reindex_log = Logger.new("#{Rails.root}/log/reindex_events.log")

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -78,3 +78,49 @@ RSpec.describe Searchable, 'index lifecycle' do
     end
   end
 end
+
+RSpec.describe Searchable do
+  describe '.searchable_models' do
+    it 'returns the registered models as classes' do
+      expect(described_class.searchable_models).
+        to include(User)
+    end
+  end
+
+  describe '.not_indexed', :postgresql do
+    let(:user) { users(:bob_smith_user) }
+
+    it 'excludes records that already have a search document' do
+      # the :postgresql hook has already indexed every user
+      expect(User.not_indexed).not_to include(user)
+    end
+
+    it 'includes records without a search document' do
+      SearchDocument.delete_all
+      expect(User.not_indexed).to include(user)
+    end
+
+    it 'excludes a record once it has been reindexed' do
+      SearchDocument.delete_all
+      user.reindex
+      expect(User.not_indexed).not_to include(user)
+    end
+  end
+
+  describe '.reindex_record', :postgresql do
+    let(:user) { users(:bob_smith_user) }
+
+    it 'reindexes the record and returns true' do
+      SearchDocument.delete_all
+      expect(User.reindex_record(user)).to be(true)
+      expect(User.not_indexed).not_to include(user)
+    end
+
+    it 'logs and returns false when the record fails to reindex' do
+      allow(user).to receive(:reindex).and_raise(StandardError, 'boom')
+      expect(Rails.logger).to receive(:error).
+        with(/Failed to reindex User/)
+      expect(User.reindex_record(user)).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## What does this do?

Adds the tooling to populate and rebuild the PostgreSQL search index at production scale:

* `rake reindex:missing[Model]` — indexes records that have no search document yet; resumable and safe to re-run
* `rake reindex:all[Model]` — full rebuild of every searchable record

Both accept an optional model argument (all searchable models when omitted) and are tunable via `CHUNK_SIZE`, `BATCH_SIZE`, `STATE_DIR` and `RESUME` environment variables.

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
