### PR TITLE
Add CSP nonce to reCAPTCHA script tags

### DIFF
--- a/app/views/public_body_change_requests/new.html.erb
+++ b/app/views/public_body_change_requests/new.html.erb
@@ -63,7 +63,7 @@
   </p>
 
   <% if @render_recaptcha %>
-    <%= recaptcha_tags %>
+    <%= recaptcha_tags(nonce: content_security_policy_nonce) %>
   <% end %>
 
   <p style="display:none;">

--- a/app/views/request/preview.html.erb
+++ b/app/views/request/preview.html.erb
@@ -57,7 +57,7 @@
 
       <% if @render_recaptcha %>
       <p>
-        <%= recaptcha_tags %>
+        <%= recaptcha_tags(nonce: content_security_policy_nonce) %>
       </p>
       <% end %>
 

--- a/app/views/user/_signup.html.erb
+++ b/app/views/user/_signup.html.erb
@@ -42,7 +42,7 @@
     </p>
 
     <% if @request_from_foreign_country %>
-      <%= recaptcha_tags %>
+      <%= recaptcha_tags(nonce: content_security_policy_nonce) %>
     <% end %>
 
     <div class="form_button">

--- a/app/views/user/contact.html.erb
+++ b/app/views/user/contact.html.erb
@@ -37,7 +37,7 @@
   </p>
 
   <% if @recaptcha_required %>
-    <%= recaptcha_tags %><br />
+    <%= recaptcha_tags(nonce: content_security_policy_nonce) %><br />
   <% end %>
 
   <div class="form_button">

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix reCAPTCHA blocked by Content Security Policy (Graeme Porteous)
 * Fix duplicate attachments from concurrent incoming message masking (Laurent
   Savaete, Graeme Porteous)
 * Move admin attachment erasure into background job (Graeme Porteous)


### PR DESCRIPTION
## What does this do?

Add CSP nonce to reCAPTCHA script tags

## Why was this needed?

Pass the request CSP nonce to recaptcha_tags at every call site so the gem adds it to the script tag and the browser allows it to load.

Under strict-dynamic only nonced scripts execute. The reCAPTCHA script tag rendered by recaptcha_tags carried no nonce and was blocked, so the widget never loaded, and no token was produced.

This was most visible on the public body change request form, which always shows reCAPTCHA to signed-out users.
