### PR TITLE
[#8543] Stop retrying attachment masking after timeout

### DIFF
--- a/app/controllers/attachment_masks_controller.rb
+++ b/app/controllers/attachment_masks_controller.rb
@@ -16,6 +16,9 @@ class AttachmentMasksController < ApplicationController
         referer: verifier.generate(@referer)
       )
 
+    elsif @attachment.masking_failed?
+      redirect_to @referer
+
     else
       @attachment.mask_later
     end

--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -132,15 +132,22 @@ class AttachmentsController < ApplicationController
   def ensure_masked
     if @attachment.masked?
       yield
+    elsif @attachment.masking_failed?
+      render_attachment_masking_failed
     else
       @attachment.mask_later
 
       Timeout.timeout(5) do
-        until @attachment.masked?
+        until @attachment.masked? || @attachment.masking_failed?
           sleep 0.5
           @attachment.reload
         end
-        redirect_to(request.fullpath)
+
+        if @attachment.masking_failed?
+          render_attachment_masking_failed
+        else
+          redirect_to(request.fullpath)
+        end
       end
     end
 
@@ -149,6 +156,11 @@ class AttachmentsController < ApplicationController
       @attachment.to_signed_global_id,
       referer: verifier.generate(request.fullpath)
     )
+  end
+
+  def render_attachment_masking_failed
+    request.format = :html
+    render template: 'attachments/masking_failed', status: 422
   end
 
   def set_cors

--- a/app/jobs/foi_attachment/mask_job.rb
+++ b/app/jobs/foi_attachment/mask_job.rb
@@ -35,11 +35,27 @@ class FoiAttachment::MaskJob < ApplicationJob
   def mask
     attachment.mask
 
+    # Masking hit a Regexp::TimeoutError. Notify once (on the first failure) so
+    # it can be investigated, then stop.
+    if attachment.masking_failed?
+      notify_masking_failure if attachment.masking_failed_at_previously_changed?
+      return
+    end
+
     # ensure the after_commit callback runs which uploads the blob, without this
     # the callback might not execute in time and the job exits resulting in the
     # lost of the masked attachment body.
     return if attachment.file_blob.service.exist?(attachment.file_blob.key)
 
     attachment.run_callbacks(:commit)
+  end
+
+  def notify_masking_failure
+    return unless send_exception_notifications?
+
+    ExceptionNotifier.notify_exception(
+      Regexp::TimeoutError.new("masking timed out (ID=#{attachment.id})"),
+      data: { foi_attachment: attachment.id }
+    )
   end
 end

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -46,6 +46,7 @@ class FoiAttachment < ApplicationRecord
   include Replaceable
 
   MissingError = Class.new(StandardError)
+  MaskingError = Class.new(StandardError)
 
   belongs_to :incoming_message, inverse_of: :foi_attachments, optional: true
   has_one :raw_email, through: :incoming_message, source: :raw_email
@@ -107,6 +108,10 @@ class FoiAttachment < ApplicationRecord
       # file isn't in storage and has gone missing, rescue to allow the masking
       # job to run and rebuild the stored file or even the whole attachment.
       raise ex if locked? || erased?
+    end
+
+    if masking_failed?
+      raise MaskingError, "masking previously failed (ID=#{id})"
     end
 
     if persisted?

--- a/app/models/foi_attachment.rb
+++ b/app/models/foi_attachment.rb
@@ -20,6 +20,7 @@
 #  replaced_at           :datetime
 #  replaced_reason       :string
 #  erased_at             :datetime
+#  masking_failed_at     :datetime
 #
 
 # models/foi_attachment.rb:

--- a/app/models/foi_attachment/maskable.rb
+++ b/app/models/foi_attachment/maskable.rb
@@ -11,7 +11,13 @@ module FoiAttachment::Maskable
     file.attached? && masked_at.present? && masked_at < Time.zone.now
   end
 
+  def masking_failed?
+    masking_failed_at.present?
+  end
+
   def mask
+    return if masking_failed?
+
     body = apply_masks(unmasked_body, content_type)
 
     if content_type == 'text/html'
@@ -22,6 +28,9 @@ module FoiAttachment::Maskable
     end
 
     update(body: body, masked_at: Time.zone.now)
+
+  rescue Regexp::TimeoutError
+    update(masking_failed_at: Time.zone.now) if persisted?
   end
 
   def mask_later

--- a/app/models/foi_attachment/replaceable.rb
+++ b/app/models/foi_attachment/replaceable.rb
@@ -86,15 +86,21 @@ module FoiAttachment::Replaceable
   end
 
   def replacement_body
-    super || normalize_string_to_utf8(body)
+    super || normalize_string_to_utf8(current_body)
   end
 
   def replacement_body=(new_replacement_body)
     super unless normalize_line_endings(new_replacement_body) ==
-                 normalize_line_endings(body)
+                 normalize_line_endings(current_body)
   end
 
   private
+
+  def current_body
+    body
+  rescue FoiAttachment::MaskingError
+    unmasked_body
+  end
 
   def handle_replacements
     if replacing? || (replaced? && replaced_filename_changed?)

--- a/app/models/foi_attachment/replaceable.rb
+++ b/app/models/foi_attachment/replaceable.rb
@@ -114,6 +114,7 @@ module FoiAttachment::Replaceable
     if replacing?
       self.replaced_at = Time.zone.now
       self.masked_at = Time.zone.now
+      self.masking_failed_at = nil
       self.locked = true
 
       if replacement_file_changed?

--- a/app/models/incoming_message/attachments.rb
+++ b/app/models/incoming_message/attachments.rb
@@ -168,10 +168,13 @@ module IncomingMessage::Attachments
     # Extract text from each attachment
     get_attachments_for_display.reduce('') do |memo, attachment|
       return memo if Ability.guest.cannot?(:read, attachment)
+      next memo if attachment.masking_failed?
 
       text = attachment.body_to_text
       text = apply_masks(text, 'text/html') unless attachment.locked?
       memo += text
+    rescue FoiAttachment::MaskingError
+      memo
     end
   end
 

--- a/app/models/incoming_message/main_body.rb
+++ b/app/models/incoming_message/main_body.rb
@@ -32,6 +32,10 @@ module IncomingMessage::MainBody
 
   rescue FoiAttachment::ErasedError
     ''
+
+  rescue FoiAttachment::MaskingError
+    _('[ {{site_name}} note: We were not able to process this message. ]',
+      site_name: site_name)
   end
 
   # Returns part which contains main body text, or nil if there isn't one,

--- a/app/views/attachments/masking_failed.html.erb
+++ b/app/views/attachments/masking_failed.html.erb
@@ -1,0 +1,12 @@
+<% @title = _('Attachment could not be processed') %>
+
+<h1><%= @title %></h1>
+
+<p>
+  <%= _('We were not able to process this attachment, so it cannot be ' \
+        'viewed or downloaded.') %>
+</p>
+
+<p>
+  <%= link_to _('Return to request'), request_path(@info_request) %>
+</p>

--- a/app/views/request/_attachments.html.erb
+++ b/app/views/request/_attachments.html.erb
@@ -19,7 +19,21 @@
           <% if concealed_prominence?(a) %>
             <span class="hidden_attachment"><%= render_prominence(a) %></span>
           <% end %>
-          <% if can?(:read, a) %>
+          <% if can?(:read, a) && a.masking_failed? %>
+            <p class="attachment__name">
+              <%= h a.display_filename %>
+            </p>
+
+            <p class="attachment__meta">
+              <%= a.display_size %>
+              <em><%= _('We were not able to process this attachment.') %></em>
+
+              <% if @user.present? && @user.admin_page_links? %>
+                <%= link_to _('Admin'), edit_admin_foi_attachment_path(a) %>
+              <% end %>
+            </p>
+
+          <% elsif can?(:read, a) %>
             <%= attachment_link(incoming_message, a) %>
 
             <p class="attachment__name">

--- a/db/migrate/20260727120000_add_masking_failed_at_to_foi_attachments.rb
+++ b/db/migrate/20260727120000_add_masking_failed_at_to_foi_attachments.rb
@@ -1,0 +1,5 @@
+class AddMaskingFailedAtToFoiAttachments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :foi_attachments, :masking_failed_at, :datetime
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Safely recover from attachment masking timeouts (Graeme Porteous)
 * Add PostgreSQL full-text search indexing, initially enabled for users only
   (Laurent Savaete, Graeme Porteous)
 * Fix reCAPTCHA blocked by Content Security Policy (Graeme Porteous)

--- a/spec/controllers/attachment_masks_controller_spec.rb
+++ b/spec/controllers/attachment_masks_controller_spec.rb
@@ -59,6 +59,20 @@ RSpec.describe AttachmentMasksController, type: :controller do
       end
     end
 
+    context 'when the attachment has failed masking' do
+      let(:attachment) do
+        FactoryBot.build(
+          :body_text, :unmasked, id: 1, masking_failed_at: Time.zone.now
+        )
+      end
+
+      it 'redirects to the referer without masking again' do
+        expect(attachment).to_not receive(:mask_later)
+        wait
+        expect(response).to redirect_to('/referer')
+      end
+    end
+
     context "when attachment can't be found" do
       it 'redirects to referer' do
         allow(GlobalID::Locator).to receive(:locate_signed).with('ABC').

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -134,6 +134,47 @@ RSpec.describe AttachmentsController, type: :controller do
         end
       end
 
+      context 'when the attachment has already failed masking' do
+        let(:attachment) do
+          FactoryBot.create(
+            :body_text, :unmasked,
+            incoming_message: message,
+            prominence: attachment_prominence,
+            masking_failed_at: Time.zone.now
+          )
+        end
+
+        before do
+          allow(IncomingMessage).to receive(
+            :get_attachment_by_url_part_number_and_filename!
+          ).and_return(attachment)
+        end
+
+        it 'renders the masking failed page without masking again' do
+          expect(attachment).to_not receive(:mask_later)
+          show
+          expect(response).to render_template('attachments/masking_failed')
+          expect(response.code).to eq('422')
+        end
+      end
+
+      context 'when masking fails while waiting' do
+        before do
+          allow(IncomingMessage).to receive(
+            :get_attachment_by_url_part_number_and_filename!
+          ).and_return(attachment)
+          allow(attachment).to receive(:masked?).and_return(false)
+          allow(attachment).to receive(:masking_failed?).
+            and_return(false, true)
+        end
+
+        it 'renders the masking failed page' do
+          show
+          expect(response).to render_template('attachments/masking_failed')
+          expect(response.code).to eq('422')
+        end
+      end
+
       shared_examples 'redirects to attachment mask route' do
         it 'masks the attachment' do
           expect_any_instance_of(FoiAttachment).to receive(:mask_later)

--- a/spec/factories/foi_attachments.rb
+++ b/spec/factories/foi_attachments.rb
@@ -20,6 +20,7 @@
 #  replaced_at           :datetime
 #  replaced_reason       :string
 #  erased_at             :datetime
+#  masking_failed_at     :datetime
 #
 FactoryBot.define do
   factory :foi_attachment do

--- a/spec/jobs/foi_attachment/mask_job_spec.rb
+++ b/spec/jobs/foi_attachment/mask_job_spec.rb
@@ -33,6 +33,31 @@ RSpec.describe FoiAttachment::MaskJob, type: :job do
     end
   end
 
+  context 'when masking times out' do
+    before do
+      allow(attachment).to receive(:apply_masks).and_raise(Regexp::TimeoutError)
+      allow_any_instance_of(described_class).
+        to receive(:send_exception_notifications?).and_return(true)
+      allow(ExceptionNotifier).to receive(:notify_exception)
+    end
+
+    it 'records the failure without raising' do
+      expect { perform }.to_not raise_error
+      expect(attachment.masking_failed_at).to be_present
+    end
+
+    it 'notifies once on the first failure' do
+      expect(ExceptionNotifier).to receive(:notify_exception).once
+      perform
+    end
+
+    it 'does not notify when the attachment already failed' do
+      attachment.update_column(:masking_failed_at, Time.zone.now)
+      expect(ExceptionNotifier).to_not receive(:notify_exception)
+      perform
+    end
+  end
+
   context 'after rescuing from FoiAttachment::MissingError' do
     before do
       # first call to #unmasked_body should raise MissingError exception

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -20,6 +20,7 @@
 #  replaced_at           :datetime
 #  replaced_reason       :string
 #  erased_at             :datetime
+#  masking_failed_at     :datetime
 #
 
 require 'spec_helper'

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -1590,6 +1590,32 @@ RSpec.describe FoiAttachment do
       it { is_expected.to eq(true) }
     end
 
+    context 'when masking has previously failed' do
+      subject do
+        foi_attachment.replace!(
+          editor: editor,
+          reason: reason,
+          replacement_file: fixture_file_upload('parrot.png', 'image/png')
+        )
+      end
+
+      let(:foi_attachment) do
+        FactoryBot.create(
+          :body_text, :unmasked, masking_failed_at: Time.zone.now
+        )
+      end
+
+      it 'clears the masking failure' do
+        subject
+        expect(foi_attachment.reload.masking_failed_at).to be_nil
+      end
+
+      it 'no longer reports the attachment as failed' do
+        subject
+        expect(foi_attachment.reload).to_not be_masking_failed
+      end
+    end
+
     context 'when logging the event' do
       subject do
         foi_attachment.replace!(

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -2194,6 +2194,23 @@ RSpec.describe FoiAttachment do
         expect(foi_attachment.replacement_body.is_utf8?).to eq(true)
       end
     end
+
+    context 'when masking has previously failed' do
+      let(:foi_attachment) do
+        FactoryBot.create(
+          :body_text, :unmasked, masking_failed_at: Time.zone.now
+        )
+      end
+
+      before do
+        allow(foi_attachment).to receive(:body).and_call_original
+        allow(foi_attachment).to receive(:unmasked_body).and_return('raw'.b)
+      end
+
+      it 'returns the unmasked body' do
+        expect(foi_attachment.replacement_body).to eq('raw')
+      end
+    end
   end
 
   describe '#replacement_body=' do

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -252,6 +252,20 @@ RSpec.describe FoiAttachment do
       end
     end
 
+    context 'when masking has previously failed' do
+      let(:foi_attachment) do
+        FactoryBot.create(
+          :body_text, :unmasked, masking_failed_at: Time.zone.now
+        )
+      end
+
+      it 'raises MaskingError without re-running the mask job' do
+        expect(FoiAttachment::MaskJob).to_not receive(:perform_now)
+        expect { foi_attachment.body }.
+          to raise_error(FoiAttachment::MaskingError)
+      end
+    end
+
     context 'when masked' do
       let(:foi_attachment) { FactoryBot.create(:body_text) }
 
@@ -937,6 +951,28 @@ RSpec.describe FoiAttachment do
       subject
       expect(attachment.body).to_not include 'dull'
       expect(attachment.body).to include 'Horse'
+    end
+
+    context 'when masking times out' do
+      let(:attachment) { FactoryBot.create(:body_text, :unmasked) }
+
+      before do
+        allow(attachment).to receive(:unmasked_body).and_return('body')
+        allow(attachment).to receive(:apply_masks).
+          and_raise(Regexp::TimeoutError)
+      end
+
+      it 'records the failure without masking' do
+        expect { subject }.
+          to change { attachment.masking_failed_at }.from(nil).to(be_present)
+        expect(attachment.masked_at).to be_nil
+      end
+
+      it 'does not attempt masking again once failed' do
+        subject
+        expect(attachment).to_not receive(:apply_masks)
+        attachment.mask
+      end
     end
   end
 

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -1677,4 +1677,22 @@ RSpec.describe IncomingMessage, 'when getting the main body text' do
       expect(incoming_message.get_main_body_text_internal).to eq ''
     end
   end
+
+  context 'when main body attachment cannot be masked' do
+    let(:incoming_message) { FactoryBot.create(:incoming_message) }
+
+    before do
+      allow(incoming_message.get_main_body_text_part).to receive(:body_as_text).
+        and_raise(FoiAttachment::MaskingError)
+    end
+
+    it 'returns a note in place of the body text' do
+      expect(incoming_message.get_main_body_text_internal).
+        to include('We were not able to process this message')
+    end
+
+    it 'does not raise when detecting refusals' do
+      expect { incoming_message.refusals? }.to_not raise_error
+    end
+  end
 end

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -828,6 +828,25 @@ RSpec.describe IncomingMessage do
         expect(message.get_attachment_text_full).to include('hide_me')
       end
     end
+
+    context 'when an attachment cannot be masked' do
+      let(:message) do
+        FactoryBot.create(:incoming_message, :with_text_attachment)
+      end
+
+      it 'skips flagged attachments without reading their body' do
+        allow(message.foi_attachments.last).to receive(:masking_failed?).
+          and_return(true)
+        expect(message.foi_attachments.last).to_not receive(:body_to_text)
+        expect { message.get_attachment_text_full }.to_not raise_error
+      end
+
+      it 'rescues MaskingError raised while masking' do
+        allow(message.foi_attachments.last).to receive(:body_to_text).
+          and_raise(FoiAttachment::MaskingError)
+        expect { message.get_attachment_text_full }.to_not raise_error
+      end
+    end
   end
 
   describe '#get_attachment_text_clipped' do

--- a/spec/views/request/_attachments.html.erb_spec.rb
+++ b/spec/views/request/_attachments.html.erb_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+RSpec.describe 'request/_attachments' do
+  let(:info_request) { FactoryBot.create(:info_request) }
+  let(:incoming_message) do
+    FactoryBot.create(:incoming_message, info_request: info_request)
+  end
+  let(:attachment) do
+    FactoryBot.create(
+      :body_text, :unmasked,
+      incoming_message: incoming_message,
+      masking_failed_at: Time.zone.now
+    )
+  end
+
+  def render_view
+    render partial: 'request/attachments',
+           locals: { incoming_message: incoming_message }
+  end
+
+  before do
+    main_body_part = FactoryBot.create(
+      :body_text, incoming_message: incoming_message
+    )
+    allow(incoming_message).to receive(:get_attachments_for_display).
+      and_return([attachment])
+    allow(incoming_message).to receive(:get_main_body_text_part).
+      and_return(main_body_part)
+    allow(view).to receive(:concealed_prominence?).and_return(false)
+    allow(view).to receive(:can?).and_return(false)
+    allow(view).to receive(:can?).with(:read, attachment).and_return(true)
+    allow(view).to receive(:cannot?).and_return(false)
+    assign(:user, nil)
+  end
+
+  context 'when an attachment could not be masked' do
+    it 'shows a message that it could not be processed' do
+      render_view
+      expect(rendered).
+        to have_content('We were not able to process this attachment')
+    end
+
+    it 'does not offer a download link' do
+      render_view
+      expect(rendered).to_not have_link('Download')
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8543

## What does this do?

Stop retrying attachment masking after timeout

## Why was this needed?

Masking large binary attachments can raise Regexp::TimeoutError. The failure is deterministic, so background retries and every inline fetch re-ran the same expensive regexps, burning CPU/memory and spamming exception notifications.

FoiAttachment#mask now records masking_failed_at and stops instead of raising, acting as a circuit breaker: a failed attachment is not re-masked, and FoiAttachment#body raises a fast MaskingError rather than re-running the masking.

The mask job notifies once, on the first failure, then exits cleanly so it is not retried. Clear masking_failed_at to allow another attempt.

## Screenshots

<img width="722" height="377" alt="Screenshot 2026-07-28 at 10 39 48" src="https://github.com/user-attachments/assets/2e477c82-97fb-4db3-93c4-7eac11f15b3b" />
<img width="449" height="241" alt="Screenshot 2026-07-28 at 10 40 35" src="https://github.com/user-attachments/assets/eb6602a1-4ee3-4713-9cd1-08310724d40f" />

