### PR TITLE
WIP: Make comments searchable

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -24,6 +24,7 @@ class Comment < ApplicationRecord
   include LinkToHelper
 
   include RateLimited
+  include Searchable
 
   strip_attributes allow_empty: true
 
@@ -64,6 +65,8 @@ class Comment < ApplicationRecord
           where('embargoes.id IS NULL').
             references(:embargoes)
   }
+
+  searchable index: { body: "A" }
 
   after_save :reindex_request_events
 


### PR DESCRIPTION
## Relevant issue(s)

#8814 
#8816 

## What does this do?

This PR makes `Comment`s searchable through the new postgres-based search system for admin users.

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
