### PR TITLE
Make info request events searchable

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -275,6 +275,20 @@ body.admin {
   .edit-history .row:nth-child(even) {
     background-color: #f9f9f9;
   }
+
+  #info_request_events .row {
+    margin-bottom: 1em;
+  }
+  #info_request_events .row .details {
+    display: flex;
+    margin-left: 7em;
+  }
+  #info_request_events .row:nth-child(even) {
+    background-color: #f9f9f9;
+  }
+  #info_request_events .row .details .event-params {
+    margin-left: 1em;
+  }
 }
 
 /* Debug */

--- a/app/controllers/admin_info_request_event_controller.rb
+++ b/app/controllers/admin_info_request_event_controller.rb
@@ -5,7 +5,7 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AdminInfoRequestEventController < AdminController
-  before_action :set_info_request_event, only: [:update]
+  before_action :set_info_request_event, only: [:edit, :update]
 
   def index
     @page = params[:page] || 1
@@ -22,21 +22,46 @@ class AdminInfoRequestEventController < AdminController
     end
   end
 
+  def edit
+    @params_to_show = JSON.pretty_generate(@info_request_event.params)
+  end
+
   # used so due dates get fixed
   def update
-    if @info_request_event.event_type != 'response'
-      raise "can only mark responses as requires clarification"
+    @was_clarification = params[:commit] == "Was clarification request"
+
+    if @was_clarification
+      if @info_request_event.event_type != 'response'
+        raise "can only mark responses as requires clarification"
+      end
+
+      @info_request_event.described_state = 'waiting_clarification'
+      @info_request_event.calculated_state = 'waiting_clarification'
+      # TODO: deliberately don't update described_at so doesn't reenter search?
+      @info_request_event.save!
+      # Reset the due dates for the request if necessary
+      @info_request_event.recheck_due_dates
+
+      flash[:notice] = "Old response marked as having been a request for clarification"
+      redirect_to admin_request_url(@info_request_event.info_request)
+    else
+      @params_to_show = params.dig(:info_request_event, :params_to_show)
+
+      if @params_to_show.strip.empty?
+        raise "Event params cannot be empty"
+      end
+      begin
+        @info_request_event.params = JSON.parse(@params_to_show)
+
+        @info_request_event.save!
+        flash[:notice] = "InfoRequestEvent params updated"
+        redirect_to admin_info_request_events_path
+      rescue JSON::ParserError => e
+        flash[:error] = "Invalid JSON content: #{e.message}"
+        render :edit, status: :unprocessable_entity
+      end
+
     end
-
-    @info_request_event.described_state = 'waiting_clarification'
-    @info_request_event.calculated_state = 'waiting_clarification'
-    # TODO: deliberately don't update described_at so doesn't reenter search?
-    @info_request_event.save!
-    # Reset the due dates for the request if necessary
-    @info_request_event.recheck_due_dates
-
-    flash[:notice] = "Old response marked as having been a request for clarification"
-    redirect_to admin_request_url(@info_request_event.info_request)
   end
 
   private

--- a/app/controllers/admin_info_request_event_controller.rb
+++ b/app/controllers/admin_info_request_event_controller.rb
@@ -7,6 +7,21 @@
 class AdminInfoRequestEventController < AdminController
   before_action :set_info_request_event, only: [:update]
 
+  def index
+    @page = params[:page] || 1
+    @query = params[:query] || ""
+    @info_request_events = InfoRequestEvent.
+      order(id: :desc).
+        paginate(page: @page, per_page: 100)
+
+    if @query != ""
+      @info_request_events =@info_request_events.
+        search_scope(@query,
+                     backend: :postgresql,
+                     admin_mode: true)
+    end
+  end
+
   # used so due dates get fixed
   def update
     if @info_request_event.event_type != 'response'

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -109,6 +109,16 @@ class InfoRequestEvent < ApplicationRecord
 
   attr_accessor :no_xapian_reindex
 
+  # we don't want users to find events, they search through requests
+  # and messages directly. This is only intended for admins to find PII
+  # inside the JSON logs.
+  searchable admin_index: {
+    # call a custom SQL function to extract the relevant bits of JSON into the index,
+    # to help keep the index size manageable.
+    # Doing this in SQL is a lot faster than doing the same in ruby.
+    "cleanup_jsonb_for_search(params)": "A"
+  }
+
   def self.count_of_hides_by_week
     where(event_type: "hide").group("date(date_trunc('week', created_at))").count.sort
   end

--- a/app/views/admin_general/_admin_navbar.html.erb
+++ b/app/views/admin_general/_admin_navbar.html.erb
@@ -30,6 +30,7 @@
             <ul class="dropdown-menu" role="menu">
               <li><%= link_to 'Requests', admin_requests_path %></li>
               <li><%= link_to 'Comments', admin_comments_path %></li>
+              <li><%= link_to 'Request events', admin_info_request_events_path %></li>
               <% if feature_enabled?(:projects) && can?(:admin, Project) %>
                 <li><%= link_to 'Projects', admin_projects_path %></li>
               <% end %>

--- a/app/views/admin_info_request_event/_info_request_event.html.erb
+++ b/app/views/admin_info_request_event/_info_request_event.html.erb
@@ -1,0 +1,25 @@
+<div id="info_request_event_<%=info_request_event.id%>" class="row">
+
+  <div class="myheading">
+    <span class="item-title">
+      <%= "Event #{info_request_event.id}" %>:
+      <strong>
+        <%= h info_request_event.event_type.humanize %><% if !info_request_event.calculated_state.nil? %>; state:
+          <%= info_request_event.calculated_state %><% end %>
+      </strong>
+      <em>
+        <%= info_request_event.created_at %>
+      </em>
+    </span>
+  </div>
+  <div id="event_<%=info_request_event.id%>" class="details">
+    <div><b>Params:</b></div>
+    <div class="event-params">
+      <%= render partial: "admin_request/params",
+      locals: {
+        params: info_request_event.params_diff,
+      } %>
+    </div>
+  </div>
+
+</div>

--- a/app/views/admin_info_request_event/_info_request_event.html.erb
+++ b/app/views/admin_info_request_event/_info_request_event.html.erb
@@ -2,7 +2,12 @@
 
   <div class="myheading">
     <span class="item-title">
-      <%= "Event #{info_request_event.id}" %>:
+      <%= link_to(
+        "Event #{info_request_event.id}:",
+        edit_admin_info_request_event_path(info_request_event),
+        title: "Edit event #{info_request_event.id}",
+      ) %>
+
       <strong>
         <%= h info_request_event.event_type.humanize %><% if !info_request_event.calculated_state.nil? %>; state:
           <%= info_request_event.calculated_state %><% end %>

--- a/app/views/admin_info_request_event/edit.html.erb
+++ b/app/views/admin_info_request_event/edit.html.erb
@@ -1,0 +1,39 @@
+<h1>Edit Info request event</h1>
+
+<table class="table table-striped table-condensed">
+  <tbody>
+    <% @info_request_event.for_admin_column do |name, value| %>
+      <% if name != 'params' %>
+        <tr>
+          <td>
+            <b><%= name.humanize %></b>
+          </td>
+          <td>
+            <%= admin_value(value) %>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+
+<%= form_with(
+  model: @info_request_event,
+  url: admin_info_request_event_path(@info_request_event),
+  method: :put,
+  class: "form form-inline"
+) do |f| %>
+
+  <div class="field">
+    <%= f.label :params, "params (JSON):" %>
+
+    <%= f.text_area :params_to_show,
+                value: @params_to_show,
+                class: "form-control span12",
+                rows: 25 %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.submit "Update event", class: "btn btn-success" %>
+  </div>
+<% end %>

--- a/app/views/admin_info_request_event/index.html.erb
+++ b/app/views/admin_info_request_event/index.html.erb
@@ -1,0 +1,30 @@
+<% @title = "Listing FOI request events" %>
+
+<h1><%= @title %></h1>
+
+<%= form_tag({}, method: 'get', class: 'form form-search') do %>
+  <div class="input-append">
+    <%= text_field_tag "query",
+    params[:query],
+    size: 40,
+    class: "input-large search-query" %>
+    <%= submit_tag "Search", class: "btn" %>
+  </div>
+
+  <span class="help-inline">(search in event metadata)</span>
+<% end %>
+
+<div class="accordion" id="info_request_events">
+  <% if @info_request_events.any? %>
+    <h2>Found
+      <%= @info_request_events.count %>
+      events
+    </h2>
+
+    <%= render partial: "admin_info_request_event/info_request_event",
+    collection: @info_request_events %>
+    <%= will_paginate(@info_request_events) %>
+  <% else %>
+    <p>Nothing found.</p>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -732,7 +732,7 @@ Rails.application.routes.draw do
   scope '/admin', :as => 'admin' do
     resources :info_request_events,
       :controller => 'admin_info_request_event',
-      :only => [:update]
+      :only => [:index, :update]
   end
 
   #### AdminIncomingMessage controller

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -732,7 +732,7 @@ Rails.application.routes.draw do
   scope '/admin', :as => 'admin' do
     resources :info_request_events,
       :controller => 'admin_info_request_event',
-      :only => [:index, :update]
+      :only => [:edit, :index, :update]
   end
 
   #### AdminIncomingMessage controller

--- a/db/migrate/20260728143826_add_info_request_event_indexing_function.rb
+++ b/db/migrate/20260728143826_add_info_request_event_indexing_function.rb
@@ -1,0 +1,35 @@
+class AddInfoRequestEventIndexingFunction < ActiveRecord::Migration[8.0]
+  def up
+    execute(
+      <<-SQL
+      CREATE OR REPLACE FUNCTION cleanup_jsonb_for_search(json_v jsonb)
+      -- simplify jsonb columns to keep only values that are likely to be searched.
+      -- This excludes keys, timestamps and references to other objects.
+      RETURNS text
+      LANGUAGE SQL
+      IMMUTABLE PARALLEL SAFE
+      AS $$
+        SELECT string_agg(v, ' ' ORDER BY k)
+        FROM jsonb_each_text(json_v) AS x(k,v)
+        WHERE k NOT IN (
+          'described_state',
+          'embargo',
+          'event_created_at',
+          'incoming_message',
+          'old_described_state',
+          'outgoing_message',
+          'user'
+        )
+      $$;
+      SQL
+    )
+  end
+
+  def down
+    execute(
+      <<-SQL
+      DROP FUNCTION IF EXISTS cleanup_jsonb_for_search;
+      SQL
+    )
+  end
+end

--- a/spec/controllers/admin_info_request_event_controller_spec.rb
+++ b/spec/controllers/admin_info_request_event_controller_spec.rb
@@ -1,19 +1,25 @@
 require 'spec_helper'
 
 RSpec.describe AdminInfoRequestEventController do
-  describe 'PUT update' do
+  describe 'PUT update to mark event as clarification request' do
     let(:info_request_event) do
       info_request_event = FactoryBot.create(:response_event)
     end
 
     describe 'when handling valid data' do
       it 'gets the info request event' do
-        put :update, params: { id: info_request_event }
+        put :update, params: {
+          id: info_request_event,
+          commit: 'Was clarification request'
+        }
         expect(assigns[:info_request_event]).to eq(info_request_event)
       end
 
       it 'sets the described and calculated states on the event' do
-        put :update, params: { id: info_request_event }
+        put :update, params: {
+          id: info_request_event,
+          commit: 'Was clarification request'
+        }
         event = InfoRequestEvent.find(info_request_event.id)
         expect(event.described_state).to eq('waiting_clarification')
         expect(event.calculated_state).to eq('waiting_clarification')
@@ -35,14 +41,20 @@ RSpec.describe AdminInfoRequestEventController do
             'example.id'
           )
           outgoing_message.save!
-          put :update, params: { id: info_request_event }
+          put :update, params: {
+            id: info_request_event,
+            commit: 'Was clarification request'
+          }
           expect(info_request.reload.date_initial_request_last_sent_at).
             to eq(Time.zone.now.to_date)
         end
       end
 
       it 'shows a success notice' do
-        put :update, params: { id: info_request_event }
+        put :update, params: {
+          id: info_request_event,
+          commit: 'Was clarification request'
+        }
         expect(flash[:notice]).
           to eq(
             'Old response marked as having been a request for clarification'
@@ -50,19 +62,58 @@ RSpec.describe AdminInfoRequestEventController do
       end
 
       it 'redirects to the request admin page' do
-        put :update, params: { id: info_request_event }
+        put :update, params: {
+          id: info_request_event,
+          commit: 'Was clarification request'
+        }
         expect(response).
           to redirect_to(admin_request_url(info_request_event.info_request))
       end
     end
 
     it 'raises an exception if the event is not a response' do
-      put :update, params: { id: info_request_event }
+      put :update, params: {
+        id: info_request_event,
+        commit: 'Was clarification request'
+      }
       info_request_event = FactoryBot.create(:sent_event)
       expect {
-        put :update, params: { id: info_request_event }
+        put :update, params: {
+          id: info_request_event,
+          commit: 'Was clarification request'
+        }
       }.to raise_error(RuntimeError,
                        "can only mark responses as requires clarification")
+    end
+  end
+
+  describe 'update InfoRequestEvent to remove PII' do
+    let(:info_request_event) do
+      info_request_event = FactoryBot.create(:edit_event)
+    end
+
+    it 'redirects to the info request list page' do
+      put :update, params: {
+        id: info_request_event,
+        commit: 'Update event',
+        info_request_event: {
+          params_to_show: '{"key": "value"}'
+        }
+      }
+      expect(response).
+        to redirect_to(admin_info_request_events_url)
+    end
+
+    it 'shows an error message if invalid JSON is submitted' do
+      put :update, params: {
+        id: info_request_event,
+        commit: 'Update event',
+        info_request_event: {
+          params_to_show: '{"key": broken}'
+        }
+      }
+      expect(flash[:error]).
+        to match(/^Invalid JSON conten/)
     end
   end
 end


### PR DESCRIPTION
## Relevant issue(s)

#8814 
#8816 

## What does this do?

This makes `InfoRequestEvent`s searchable via the new postgres based search system.
It also adds a search page for events, along with a simple edit form to remove PII.

## Why was this needed?

## Implementation notes

The JSON blobs can contain a lot of information that isn't useful to keep in the search index (eg. refs to user IDs, timestamps...). This uses a SQL stored function to preprocess the data inside postgres. The benefit compared to doing this in ruby-land is that the `SearchDocument` can be upserted in a single SQL query, instead of at least 2 if doing it in ruby. When batching updates, it's even possible to do the entire batch in a single SQL query (see https://github.com/mysociety/alaveteli/issues/9334#issuecomment-4864895335 about DB roundtrip overhead).
Given the number of events in the db, the time saving should be very substantial (see below).

## Screenshots
The search page:
<img width="854" height="635" alt="image" src="https://github.com/user-attachments/assets/a2bcf649-16db-468c-94bc-058303fd7a8b" />

The edit page:
<img width="839" height="1164" alt="image" src="https://github.com/user-attachments/assets/6846fc67-f85c-4aca-9ec4-b123476e735a" />

which is limited to the JSON params attribute, to limit risk of breaking data consistency. I didn't see an obvious existing way to validate the json content. I believe maybe `def params=` should do that?

## Notes to reviewer

~~Ideally merge this after #9439 to benefit from the faster `reindex_all` implementation in that PR, which is likely to reduce the initial indexing time by a lot.~~
Edit: on 328k events, the faster `reindex_all` ran in 10s on my laptop, vs several minutes with the default version.

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
