### PR TITLE
WIP: Make mail server logs searchable

### DIFF
--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -18,6 +18,7 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class MailServerLog < ApplicationRecord
+  include Searchable
   # `serialize` needs to be called before all other ActiveRecord code.
   # See http://stackoverflow.com/a/15610692/387558
   serialize :delivery_status, coder: DeliveryStatusSerializer
@@ -30,6 +31,14 @@ class MailServerLog < ApplicationRecord
              optional: true
 
   before_create :calculate_delivery_status
+
+  # regular users should never be able to search email logs
+  searchable index: {},
+             admin_index: {
+               line: 'A'
+             },
+             filterable: [],
+             sortable: []
 
   # Load in exim or postfix log file from disk, or update if we already have it
   # Assumes files are named with date, rather than cyclically.

--- a/app/models/mail_server_log.rb
+++ b/app/models/mail_server_log.rb
@@ -40,6 +40,45 @@ class MailServerLog < ApplicationRecord
              filterable: [],
              sortable: []
 
+  # Reindexing all logs in a single SQL query is more than 10x faster than
+  # the base model's reindex_all method (even more if database and app are
+  # on separate machines).
+  def self.reindex_all
+    start = Time.now
+
+    query = <<-SQL
+      INSERT INTO "search_documents" (
+        "searchable_type",
+        "searchable_id",
+        "language",
+        "section_ref",
+        "raw_content",
+        "raw_admin_content",
+        "content_tsv",
+        "admin_content_tsv",
+        "created_at",
+        "updated_at"
+      )
+      SELECT
+        'MailServerLog',
+        mail_server_logs.id,
+        'english',
+        '1',
+        NULL,
+        concat(mail_server_logs.line, ' '),
+        NULL,
+        setweight(to_tsvector('english'::regconfig, unaccent(coalesce(concat(line, ' '), ''))), 'A'),
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      FROM mail_server_logs
+    SQL
+
+    ActiveRecord::Base.connection.exec_query("TRUNCATE search_documents_mailserverlog")
+    ActiveRecord::Base.connection.exec_query(query)
+    t = Time.now - start
+    Rails.logger.info("Reindexed #{indexable.count} #{name} in #{t} seconds")
+  end
+
   # Load in exim or postfix log file from disk, or update if we already have it
   # Assumes files are named with date, rather than cyclically.
   # Doesn't do anything if file hasn't been modified since it was last loaded.


### PR DESCRIPTION
## Relevant issue(s)

#8814

## What does this do?
This makes `MailServerLog`s searchable via the new postgres based search system.

## Why was this needed?

## Implementation notes

See https://github.com/mysociety/alaveteli/issues/9334#issuecomment-4864895335 about speeding up this specific model's indexing, for the reasoning behind overriding the base `reindex_all` method.

Trimming log lines before indexing them will probably help with index size. The email log lines contain a lot of "trivial" text that is very unlikely to be searched (timestamps, server name which appears on every line, "postfix", etc...).
This would probably require a separate SQL function for each MTA.

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
