### PR TITLE
WIP: Make public body change requests searchable

### DIFF
--- a/app/models/public_body_change_request.rb
+++ b/app/models/public_body_change_request.rb
@@ -17,6 +17,8 @@
 #
 
 class PublicBodyChangeRequest < ApplicationRecord
+  include Searchable
+
   belongs_to :user,
              inverse_of: :public_body_change_requests,
              counter_cache: true,
@@ -46,6 +48,15 @@ class PublicBodyChangeRequest < ApplicationRecord
 
   singleton_class.undef_method :open # Undefine Kernel.open to avoid warning
   scope :open, -> { where(is_open: true) }
+
+  searchable admin_index: {
+    "notes": "A",
+    "public_body_email": "A",
+    "public_body_name": "A",
+    "source_url": "A",
+    "user_email": "A",
+    "user_name": "A"
+  }
 
   def self.from_params(params, user)
     change_request = new


### PR DESCRIPTION
## Relevant issue(s)

#8814

## What does this do?

This makes `PublicBodyChangeRequest`s searchable via the new postgres search engine.

## Why was this needed?

## Implementation notes

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
