### PR TITLE
Pro page improvements

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
@@ -217,11 +217,20 @@ label.input-account-request-button {
   }
 }
 
-.marketing__roles__columns div {
-  @include grid-column($columns: 12);
+.marketing__roles__columns {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+
   @include respond-min($main_menu-mobile_menu_cutoff) {
-    @include grid-column($columns: 4);
+    flex-direction: row;
   }
+
+  div {
+    max-width: 22rem;
+    margin: 0 auto;
+  }
+
   img {
     max-height: 160px;
   }

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
@@ -329,3 +329,24 @@ label.input-account-request-button {
 .image-credits {
   @include grid-column($columns: 12);
 }
+
+.alaveteli-quote {
+  text-align: var(--alaveteli-quote-text-align, center);
+  // // Center is the default, but to make it reusable I think a variable is better, for example you could put two quotes side by side, aligning the first one -> left and the second one -> right.
+  max-width: var(--alaveteli-quote-max-width, 50rem);
+  margin: 0 auto;
+
+  q {
+    display: block;
+    // Using a CSS variable so it can be overridden in the same template and the actual quote. Because the quotes can be very variable in the numbers of characters, you might want to use bigger font sizes for shorter quotes while using smaller sizes for longer quotes. Finally using clamp to make it responsive.
+    font-size: var(--alaveteli-quote-font-size, clamp(1.3rem, 3vw, 2rem));
+    font-style: italic;
+    font-weight: 700;
+    line-height: 130%;
+    margin-bottom: 0.25em;
+  }
+
+  cite {
+    font-size: 1.2rem;
+  }
+}

--- a/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
@@ -1,8 +1,13 @@
 //@include grid-column($columns: 12, $collapse: true);
 .marketing__section {
   @include grid-row;
-  margin-bottom: 5em;
+
   margin-top: 2em;
+  margin-bottom: 3em;
+
+  @include respond-min($main_menu-mobile_menu_cutoff) {
+    margin-bottom: 5em;
+  }
 }
 
 .marketing__hero {

--- a/app/views/alaveteli_pro/account_request/_marketing_quotes.html.erb
+++ b/app/views/alaveteli_pro/account_request/_marketing_quotes.html.erb
@@ -1,0 +1,6 @@
+<section class="marketing__section">
+  <div class="alaveteli-quote">
+    <q>I have made FOI requests for more than ten years. During that time I’ve made a few cool spreadsheets to help me track requests. But none of them provided anything like the convenience and power of WhatDoTheyKnow Pro – it has been a total gamechanger. <br>If you use FOI, WhatDoTheyKnow Pro is the only way to go.</q>
+    <cite>— Lucas Amin</cite>
+  </div>
+</section>

--- a/app/views/alaveteli_pro/account_request/_marketing_roles.html.erb
+++ b/app/views/alaveteli_pro/account_request/_marketing_roles.html.erb
@@ -60,8 +60,6 @@
           <%= _('The Wales Governance Centre sent FOI requests through Pro ' \
                 'to discover the prison populations across Wales and England ' \
                 'for their report ‘Sentencing and Imprisonment in Wales’.') %>
-          <br />
-          <br />
         </p>
 
         <%= link_to pro_page_path('researchers') do %>

--- a/app/views/alaveteli_pro/account_request/index.html.erb
+++ b/app/views/alaveteli_pro/account_request/index.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: 'marketing_hero' %>
 <%= render partial: 'marketing_roles' %>
+<%= render partial: 'marketing_quotes' %>
 <%= render partial: 'marketing_pro_features' %>
 <%= render partial: 'marketing_standard_features' %>
 <%= render partial: 'marketing_batch_features' %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -212,6 +212,7 @@ to update overrides in your theme to match the new templates.
 ## Highlighted Features
 
 * Check `PostRedirect#circumstance` when changing password (Gareth Rees)
+* Added optional quotes section to Pro page. Uses a new CSS class(`alaveteli-quote`) that allows you to set different font-sizes to each quote.
 
 # 0.46.4.0
 


### PR DESCRIPTION
## Relevant issue(s)
Fixes: https://github.com/mysociety/whatdotheyknow-theme/issues/2132

## What does this do?
- Modifies the `margin-bottom` of `marketing-section` so on mobile is `3em` instead of `5em`
- Adds a reusable class `alaveteli-quote`. I left some notes for the CSS variables.
- I noticed the items inside `marketing__roles__columns` didn't have a gap between elements on mobile. and I took the opportunity to change it to flex to use its `gap` property.
- Added `marketing_quote` partial


## Why was this needed?
It started just as a PR to add a quote to the page. But during the testing I noticed some things to improve:

The "Research" item had some extra space.
<img width="1861" height="498" alt="Screenshot 2026-07-29 at 07 55 44" src="https://github.com/user-attachments/assets/96c02933-d905-4052-a2b2-3a4cf7bfdc6d" />

Also the spacing between sections on mobile seem a bit much.


## Implementation notes

## Screenshots
<img width="1295" height="956" alt="Screenshot 2026-07-29 at 06 40 17" src="https://github.com/user-attachments/assets/c8d5f5ed-6336-4073-b87d-8b918fdf9904" />

<img width="359" height="642" alt="Screenshot 2026-07-29 at 06 44 05" src="https://github.com/user-attachments/assets/62688494-86fd-49b8-b6dc-88ed5e8b941e" />


### `marketing__roles__columns`

https://github.com/user-attachments/assets/c3bbf32b-a9f2-4cf4-9dcb-2ac175344706


## Notes to reviewer
Should I update the changelog as well advising the addition of `marketing_quote` partial?

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
