### PR TITLE
Add searchable to Citation

### DIFF
--- a/app/controllers/admin/citations_controller.rb
+++ b/app/controllers/admin/citations_controller.rb
@@ -6,7 +6,12 @@ class Admin::CitationsController < AdminController
 
     citations = (
       if @query
-        Citation.search(@query)
+        Citation.search_scope(
+          @query,
+          backend: :postgresql,
+          exact_mode: true,
+          case_sensitive: false
+        )
       else
         Citation
       end

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -20,6 +20,7 @@
 class Citation < ApplicationRecord
   include Rails.application.routes.url_helpers
   include LinkToHelper
+  include Searchable
 
   self.inheritance_column = nil
 
@@ -64,6 +65,10 @@ class Citation < ApplicationRecord
     where(citable: info_request_batch).
       or(where(citable: info_request_batch.info_requests))
   end
+
+  searchable index: {
+    "source_url": "A"
+  }
 
   def self.search(query)
     where(<<~SQL, query: query)

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -70,12 +70,6 @@ class Citation < ApplicationRecord
     "source_url": "A"
   }
 
-  def self.search(query)
-    where(<<~SQL, query: query)
-      lower(citations.source_url) LIKE lower('%'||:query||'%')
-    SQL
-  end
-
   def applies_to_batch_request?
     citable.is_a?(InfoRequestBatch)
   end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,8 +2,8 @@
 
 ## Highlighted Features
 
-* Add PostgreSQL full-text search indexing, initially enabled for users only
-  (Laurent Savaete, Graeme Porteous)
+* Add PostgreSQL full-text search indexing, initially enabled for users and
+  citations only (Laurent Savaete, Graeme Porteous)
 * Fix reCAPTCHA blocked by Content Security Policy (Graeme Porteous)
 * Recognise macro-enabled Office files (Graeme Porteous)
 * Preserve attachment filenames supplied only in the Content-Type name

--- a/spec/models/citation_spec.rb
+++ b/spec/models/citation_spec.rb
@@ -154,23 +154,6 @@ RSpec.describe Citation, type: :model do
     end
   end
 
-  describe '.search' do
-    subject { described_class.search(query) }
-
-    let!(:net) do
-      FactoryBot.create(:citation, source_url: 'https://example.net/story')
-    end
-
-    let!(:org) do
-      FactoryBot.create(:citation, source_url: 'https://example.org/story')
-    end
-
-    let(:query) { 'example.net' }
-
-    it { is_expected.to include(net) }
-    it { is_expected.not_to include(org) }
-  end
-
   subject(:citation) { FactoryBot.build(:citation) }
 
   describe 'associations' do


### PR DESCRIPTION
## Relevant issue(s)

Alterative to #9412

## What does this do?

Add searchable to Citation

Declare Citation searchable on its source_url, allowing instances to be
searched through the new SearchDocument and the new interface.