### PR TITLE
Fix Xapian after development code reload

### DIFF
--- a/config/initializers/acts_as_xapian.rb
+++ b/config/initializers/acts_as_xapian.rb
@@ -24,6 +24,6 @@ end
 
 require 'acts_as_xapian/acts_as_xapian'
 
-Rails.application.config.after_initialize do
+Rails.application.config.to_prepare do
   Search::Adapters::Xapian::Indexing.configure!
 end


### PR DESCRIPTION
acts_as_xapian mutates the model class: to includes InstanceMethods and registers the after_save and after_destroy callbacks.

Calling it from an after_initialize hook applies that once at boot, so after a code reload InfoRequestEvent, PublicBody and User are rebuilt without it.

Expiring a request would then raise:
`NoMethodError for xapian_mark_needs_index.`

This only affects development. Production and test both set enable_reloading to false, so the models are never rebuilt and the configuration applied at boot stands for the life of the process.

Move the call to to_prepare so it is reapplied after every reload.

[skip changelog]
