### PR TITLE
Added right_column_extra_content partial to blog page

### DIFF
--- a/app/views/general/blog.html.erb
+++ b/app/views/general/blog.html.erb
@@ -59,4 +59,6 @@
     <i class="act-link-icon act-link-icon--rss"></i>
     <a href="<%= @feed_url %>"><%= _("Subscribe to blog") %></a>
   </div>
+
+  <%= render partial: 'general/right_column_extra_content' %>
 </div>


### PR DESCRIPTION
## Relevant issue(s)
Fixes part of: https://github.com/mysociety/whatdotheyknow-private/issues/423
Related to: https://github.com/mysociety/whatdotheyknow-theme/pull/2135

## What does this do?
This allows to add optional content like donation and newsletter prompts to the sidebar in the blog page.

## Why was this needed?
To add newsletter on WDTK blog page.

## Implementation notes

## Screenshots
<img width="1088" height="644" alt="Screenshot 2026-07-30 at 12 18 30" src="https://github.com/user-attachments/assets/6faaff47-5e27-4de3-bd71-7cb18b38d152" />


## Notes to reviewer

<hr>

[skip changelog]
