### PR TITLE
Add PostgreSQL search weights/exclude options

### DIFF
--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -42,7 +42,8 @@ class AdminUserController < AdminController
         backend: :postgresql,
         admin_mode: true,
         exact_mode: true,
-        case_sensitive: false
+        case_sensitive: false,
+        except: [:email_bounce_message]
       )
     end
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -60,12 +60,12 @@ module Searchable
     Rails.logger.info("Searching through instance #{self.class}.#{id}")
   end
 
-  # We can't just use the raw_content here, because it has lost the
-  # weight from various columns.
+  # We can't build the tsvector from the raw content, because that keeps the
+  # weight each field was indexed under but not the tokenisation.
   def search_content_from_db_query(idx_name, language)
     opts = @@searchable_models[self.class.to_s]
 
-    raw_content_bits = []
+    raw_content_bits = Hash.new { |bits, label| bits[label] = [] }
     content_tsv_bits = []
     opts[idx_name].each do |col, w|
       if col.start_with?(".")
@@ -74,15 +74,20 @@ module Searchable
         c = "(SELECT concat(#{col}, ' ') FROM #{self.class.table_name} WHERE id=$1)"
       end
 
-      raw_content_bits.push(c)
+      raw_content_bits[w.to_s.upcase].push(c)
       content_tsv_bits.push(
         "setweight(to_tsvector('#{language}'::regconfig, unaccent(coalesce(#{c}, ''))), '#{w}')"
       )
     end
 
+    raw_object_bits = raw_content_bits.map do |label, bits|
+      quoted = ActiveRecord::Base.connection.quote(label)
+      "#{quoted}, concat(#{bits.join(',')})"
+    end
+
     query = <<-SQL
       SELECT
-        concat(#{raw_content_bits.join(',')}) as raw,
+        jsonb_build_object(#{raw_object_bits.join(',')}) as raw,
         #{content_tsv_bits.join("||")} AS tsv
       FROM #{self.class.table_name}
       WHERE id=$1
@@ -99,7 +104,7 @@ module Searchable
     if search_cfg[idx_name].nil? || search_cfg[idx_name].empty?
       {}
     else
-      ActiveRecord::Base.
+      row = ActiveRecord::Base.
         connection.
         exec_query(
           search_content_from_db_query(idx_name, language),
@@ -110,6 +115,8 @@ module Searchable
             ActiveRecord::Type::Integer.new
           )]
         ).to_a.first
+
+      row.merge('raw' => ActiveSupport::JSON.decode(row['raw']))
     end
   end
 

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -13,7 +13,12 @@ module Searchable
   extend ActiveSupport::Concern
 
   class_methods do
-    def search_scope(query, **options)
+    def search_scope(query, except: nil, **options)
+      if except
+        options[:except] = except_labels_for(
+          except, admin_mode: options.fetch(:admin_mode, false)
+        )
+      end
       Search.search_scope(query, all, **options)
     end
   end
@@ -209,6 +214,40 @@ module Searchable
       Searchable.class_variable_get(:@@searchable_models)[name] = options
     end
 
+    # The +searchable+ options for this model, raising when it was never made
+    # searchable.
+    def searchable_config
+      Searchable.class_variable_get(:@@searchable_models).fetch(name) do
+        raise(
+          NotImplementedError,
+          "Call #{self}.searchable to make the model searchable"
+        )
+      end
+    end
+
+    # Resolve indexed field names to tsvector labels, for SearchDocument's
+    # +except+ option.
+    def except_labels_for(fields, admin_mode: false)
+      fields = Array(fields).map(&:to_s)
+      return [] if fields.empty?
+
+      index = admin_mode ? :admin_index : :index
+      indexes_fields = searchable_config[index] || {}
+
+      unknown = fields - indexes_fields.keys.map(&:to_s)
+      raise(
+        ArgumentError,
+        "#{name} does not index #{unknown.join(', ')} in #{index}"
+      ) unless unknown.empty?
+
+      excluded, kept = indexes_fields.partition do |f, _|
+        fields.include?(f.to_s)
+      end
+
+      ensure_labels_unshared(excluded, kept)
+      excluded.map(&:last).uniq
+    end
+
     # TODO: rename this to `search`
     # The main entry point to the search API. All search calls should go through
     # this method.
@@ -262,6 +301,26 @@ module Searchable
       end
       elapsed = Time.zone.now - start
       Rails.logger.info("Reindexed #{count} #{name} in #{elapsed} seconds")
+    end
+
+    private
+
+    # Refuse to exclude a field whose weight also carries a field being kept,
+    # as removing the label would silently remove that one from the search too.
+    def ensure_labels_unshared(excluded, kept)
+      conflicts = excluded.filter_map do |field, label|
+        neighbours = kept.select { |_, l| l == label }.map(&:first)
+        next if neighbours.empty?
+
+        "#{field} (weight #{label} also carries #{neighbours.join(', ')})"
+      end
+      return if conflicts.empty?
+
+      raise(
+        ArgumentError,
+        "cannot exclude #{conflicts.join('; ')}. Exclusion works per weight, " \
+        'so these fields need distinct weights to be excluded separately'
+      )
     end
   end
 

--- a/app/models/search/adapters/postgresql.rb
+++ b/app/models/search/adapters/postgresql.rb
@@ -18,7 +18,8 @@ module Search
         # ActiveRecord::Relation directly so callers can compose further
         # conditions and ordering.
         def search_scope(query, relation, admin_mode: false, exact_mode: false,
-                         case_sensitive: true, language: nil, limit: 1000, **)
+                         case_sensitive: true, language: nil, limit: 1000,
+                         weights: nil, **)
           SearchDocument.hybrid_search(
             query,
             relation: relation,
@@ -26,7 +27,8 @@ module Search
             exact_mode: exact_mode,
             case_sensitive: case_sensitive,
             language: language,
-            limit: limit
+            limit: limit,
+            weights: weights
           )
         end
 

--- a/app/models/search/adapters/postgresql.rb
+++ b/app/models/search/adapters/postgresql.rb
@@ -19,7 +19,7 @@ module Search
         # conditions and ordering.
         def search_scope(query, relation, admin_mode: false, exact_mode: false,
                          case_sensitive: true, language: nil, limit: 1000,
-                         weights: nil, **)
+                         weights: nil, except: nil, **)
           SearchDocument.hybrid_search(
             query,
             relation: relation,
@@ -28,7 +28,8 @@ module Search
             case_sensitive: case_sensitive,
             language: language,
             limit: limit,
-            weights: weights
+            weights: weights,
+            except: except
           )
         end
 

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -17,14 +17,14 @@
 #  sd_id             :bigint           not null, primary key
 #  searchable_type   :string           not null, primary key
 #  searchable_id     :bigint
-#  raw_content       :text
-#  raw_admin_content :text
 #  section_ref       :text
 #  language          :text
 #  content_tsv       :tsvector
 #  admin_content_tsv :tsvector
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  raw_content       :jsonb
+#  raw_admin_content :jsonb
 #
 class SearchDocument < ApplicationRecord
   belongs_to :searchable, polymorphic: true
@@ -36,6 +36,10 @@ class SearchDocument < ApplicationRecord
 
   INDEX_TSV_COLUMNS = {
     index: 'content_tsv', admin_index: 'admin_content_tsv'
+  }.freeze
+
+  INDEX_RAW_COLUMNS = {
+    index: 'raw_content', admin_index: 'raw_admin_content'
   }.freeze
 
   # build the sql query for the search. This should be injection-safe.
@@ -118,19 +122,24 @@ class SearchDocument < ApplicationRecord
       # escape LIKE wildcards so the query text is matched literally
       query_values[:like_query] = "%#{sanitize_sql_like(sanitized_query)}%"
       like_op = case_sensitive ? "LIKE" : "ILIKE"
+
+      # The raw_* columns store the indexed text keyed by the tsvector label it
+      # was weighted with, so the substring search skips the labels the caller
+      # excluded rather than skipping the whole column.
+      like_conditions = raw_label_predicates(:index, content_except, like_op)
       if admin_mode
-        adm_q = "OR raw_admin_content #{like_op} :like_query"
-      else
-        adm_q = ""
+        like_conditions += raw_label_predicates(
+          :admin_index, admin_except, like_op
+        )
       end
+
       search_queries << <<~SQL.chomp
         SELECT
           sd_id,
           rank() OVER (ORDER BY sd_id DESC) AS rank
         FROM search_documents
         WHERE
-          (raw_content #{like_op} :like_query
-          #{adm_q})
+          (#{like_conditions.join(' OR ')})
           #{doc_type_q}
         LIMIT #{limit * limit_ratio}
       SQL
@@ -188,10 +197,10 @@ class SearchDocument < ApplicationRecord
   #          indexed field names instead and resolves them to labels against
   #          the same index, which is what callers outside this class want.
   #
-  #                 This only covers the tsvector matching. +exact_mode+
-  #                 searches raw_content/raw_admin_content, which are plain
-  #                 concatenations carrying no label information, so an
-  #                 excluded label can still match there.
+  #          Excluding labels also narrows +exact_mode+'s substring search
+  #          rather than disabling it: the raw column it reads is keyed by the
+  #          same labels, so the excluded text is skipped there too while the
+  #          rest of the column stays searchable.
   def self.hybrid_search(query,
                          relation: nil,
                          model: nil,
@@ -318,4 +327,15 @@ sql[:values])
     "AND websearch_to_tsquery(:language, unaccent(:query)) @@ #{tsv_expr}"
   end
   private_class_method :label_recheck_q
+
+  # A substring predicate for each label of +index+'s raw column that aren't
+  # excluded.
+  def self.raw_label_predicates(index, except_labels, like_op)
+    column = INDEX_RAW_COLUMNS.fetch(index)
+    excluded = Array(except_labels).map { |label| label.to_s.upcase }
+    kept = DEFAULT_RANK_WEIGHTS.keys - excluded
+
+    kept.map { |label| "#{column} ->> '#{label}' #{like_op} :like_query" }
+  end
+  private_class_method :raw_label_predicates
 end

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -34,6 +34,10 @@ class SearchDocument < ApplicationRecord
     'A' => 1.0, 'B' => 0.4, 'C' => 0.2, 'D' => 0.1
   }.freeze
 
+  INDEX_TSV_COLUMNS = {
+    index: 'content_tsv', admin_index: 'admin_content_tsv'
+  }.freeze
+
   # build the sql query for the search. This should be injection-safe.
   def self.hybrid_search_internal(
     query,
@@ -44,13 +48,27 @@ class SearchDocument < ApplicationRecord
     exact_mode:,
     case_sensitive:,
     limit_ratio:,
-    weights: nil
+    weights: nil,
+    except: nil
   )
     # coerce values that are interpolated into the SQL rather than bound,
     # so a non-numeric value raises instead of reaching the query.
     limit = Integer(limit)
     limit_ratio = Integer(limit_ratio)
     weights_literal = rank_weights_literal(weights)
+
+    # A search matches against one index, and +admin_mode+ says which:
+    # admin_content_tsv for an admin search, content_tsv otherwise. The index
+    # an excluded label belongs to is therefore this flag rather than
+    # something the caller has to key by hand.
+    except = Array(except)
+    admin_except = admin_mode ? except : []
+    content_except = admin_mode ? [] : except
+
+    admin_tsv = tsv_expression(:admin_index, admin_except)
+    content_tsv = tsv_expression(:index, content_except)
+    admin_recheck_q = label_recheck_q(:admin_index, admin_tsv)
+    content_recheck_q = label_recheck_q(:index, content_tsv)
 
     sanitized_language = if language.nil? || language == ''
                            Searchable.
@@ -82,11 +100,12 @@ class SearchDocument < ApplicationRecord
           SELECT
               sd_id,
               rank() OVER (
-                ORDER BY ts_rank_cd(#{weights_literal}, admin_content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
+                ORDER BY ts_rank_cd(#{weights_literal}, #{admin_tsv}, websearch_to_tsquery(:language, unaccent(:query))) DESC
               ) AS rank
           FROM search_documents
           WHERE
               websearch_to_tsquery(:language, unaccent(:query)) @@ admin_content_tsv
+              #{admin_recheck_q}
               #{doc_type_q}
           ORDER BY rank
           LIMIT #{limit * limit_ratio}
@@ -122,11 +141,12 @@ class SearchDocument < ApplicationRecord
         SELECT
             sd_id,
             rank() OVER (
-              ORDER BY ts_rank_cd(#{weights_literal}, content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
+              ORDER BY ts_rank_cd(#{weights_literal}, #{content_tsv}, websearch_to_tsquery(:language, unaccent(:query))) DESC
             ) AS rank
         FROM search_documents
         WHERE
             websearch_to_tsquery(:language, unaccent(:query)) @@ content_tsv
+            #{content_recheck_q}
             AND language = :language
             #{doc_type_q}
         ORDER BY rank
@@ -161,6 +181,17 @@ class SearchDocument < ApplicationRecord
   # +weights+ an optional label => weight hash overriding the numeric weight
   #           each tsvector label (A/B/C/D) contributes to relevance ranking.
   #           Missing labels fall back to DEFAULT_RANK_WEIGHTS.
+  # +except+ an optional list of tsvector labels to remove from the index this
+  #          search matches against, so they contribute to neither matching nor
+  #          ranking. Which index that is follows +admin_mode+, as a label
+  #          means different things in each. Searchable's +except+ takes the
+  #          indexed field names instead and resolves them to labels against
+  #          the same index, which is what callers outside this class want.
+  #
+  #                 This only covers the tsvector matching. +exact_mode+
+  #                 searches raw_content/raw_admin_content, which are plain
+  #                 concatenations carrying no label information, so an
+  #                 excluded label can still match there.
   def self.hybrid_search(query,
                          relation: nil,
                          model: nil,
@@ -170,7 +201,8 @@ class SearchDocument < ApplicationRecord
                          exact_mode: false,
                          case_sensitive: true,
                          limit_ratio: 3,
-                         weights: nil)
+                         weights: nil,
+                         except: nil)
     # validate all inputs before any SQL is built from them. This must
     # run in every environment as it is part of keeping the query
     # injection-safe.
@@ -209,7 +241,8 @@ class SearchDocument < ApplicationRecord
       exact_mode: exact_mode,
       case_sensitive: case_sensitive,
       limit_ratio: limit_ratio,
-      weights: weights
+      weights: weights,
+      except: except
     )
 
     if model.nil?
@@ -249,4 +282,40 @@ sql[:values])
     "'{#{ordered.join(',')}}'::float4[]"
   end
   private_class_method :rank_weights_literal
+
+  # The tsvector expression to match and rank against for +index+, with any
+  # excluded labels removed by ts_filter
+  def self.tsv_expression(index, except_labels)
+    column = INDEX_TSV_COLUMNS.fetch(index)
+    excluded = Array(except_labels).map { |label| label.to_s.upcase }
+    unknown = excluded - DEFAULT_RANK_WEIGHTS.keys
+    unless unknown.empty?
+      raise(
+        ArgumentError,
+        "unknown tsvector label(s) to exclude: #{unknown.join(', ')}"
+      )
+    end
+
+    return column if excluded.empty?
+
+    kept = DEFAULT_RANK_WEIGHTS.keys - excluded
+    if kept.empty?
+      raise(
+        ArgumentError,
+        "cannot exclude every tsvector label from the #{index} search"
+      )
+    end
+
+    # ts_filter takes lowercase labels
+    "ts_filter(#{column}, '{#{kept.map(&:downcase).join(',')}}')"
+  end
+  private_class_method :tsv_expression
+
+  # An extra narrowing of matches to the labels that aren't exclude
+  def self.label_recheck_q(index, tsv_expr)
+    return '' if tsv_expr == INDEX_TSV_COLUMNS.fetch(index)
+
+    "AND websearch_to_tsquery(:language, unaccent(:query)) @@ #{tsv_expr}"
+  end
+  private_class_method :label_recheck_q
 end

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -30,6 +30,10 @@ class SearchDocument < ApplicationRecord
   belongs_to :searchable, polymorphic: true
   self.primary_key = [:searchable_type, :sd_id]
 
+  DEFAULT_RANK_WEIGHTS = {
+    'A' => 1.0, 'B' => 0.4, 'C' => 0.2, 'D' => 0.1
+  }.freeze
+
   # build the sql query for the search. This should be injection-safe.
   def self.hybrid_search_internal(
     query,
@@ -39,12 +43,14 @@ class SearchDocument < ApplicationRecord
     admin_mode:,
     exact_mode:,
     case_sensitive:,
-    limit_ratio:
+    limit_ratio:,
+    weights: nil
   )
     # coerce values that are interpolated into the SQL rather than bound,
     # so a non-numeric value raises instead of reaching the query.
     limit = Integer(limit)
     limit_ratio = Integer(limit_ratio)
+    weights_literal = rank_weights_literal(weights)
 
     sanitized_language = if language.nil? || language == ''
                            Searchable.
@@ -76,7 +82,7 @@ class SearchDocument < ApplicationRecord
           SELECT
               sd_id,
               rank() OVER (
-                ORDER BY ts_rank_cd(admin_content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
+                ORDER BY ts_rank_cd(#{weights_literal}, admin_content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
               ) AS rank
           FROM search_documents
           WHERE
@@ -116,7 +122,7 @@ class SearchDocument < ApplicationRecord
         SELECT
             sd_id,
             rank() OVER (
-              ORDER BY ts_rank_cd(content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
+              ORDER BY ts_rank_cd(#{weights_literal}, content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
             ) AS rank
         FROM search_documents
         WHERE
@@ -152,6 +158,9 @@ class SearchDocument < ApplicationRecord
   # +case_sensitive+ only affects exact_mode's substring matching; when false
   #                  it matches regardless of case (ILIKE). Full-text matching
   #                  is always case-insensitive via tsvector normalisation.
+  # +weights+ an optional label => weight hash overriding the numeric weight
+  #           each tsvector label (A/B/C/D) contributes to relevance ranking.
+  #           Missing labels fall back to DEFAULT_RANK_WEIGHTS.
   def self.hybrid_search(query,
                          relation: nil,
                          model: nil,
@@ -160,7 +169,8 @@ class SearchDocument < ApplicationRecord
                          admin_mode: false,
                          exact_mode: false,
                          case_sensitive: true,
-                         limit_ratio: 3)
+                         limit_ratio: 3,
+                         weights: nil)
     # validate all inputs before any SQL is built from them. This must
     # run in every environment as it is part of keeping the query
     # injection-safe.
@@ -198,7 +208,8 @@ class SearchDocument < ApplicationRecord
       admin_mode: admin_mode,
       exact_mode: exact_mode,
       case_sensitive: case_sensitive,
-      limit_ratio: limit_ratio
+      limit_ratio: limit_ratio,
+      weights: weights
     )
 
     if model.nil?
@@ -221,4 +232,21 @@ sql[:values])
       scoped.distinct
     end
   end
+
+  # Build an injection-safe '{D,C,B,A}'::float4[] literal for ts_rank_cd
+  def self.rank_weights_literal(weights)
+    weights = (weights || {}).transform_keys(&:to_s)
+    unknown = weights.keys - DEFAULT_RANK_WEIGHTS.keys
+    unless unknown.empty?
+      raise(
+        ArgumentError,
+        "unknown tsvector label(s) in weights: #{unknown.join(', ')}"
+      )
+    end
+
+    merged = DEFAULT_RANK_WEIGHTS.merge(weights)
+    ordered = %w[D C B A].map { |label| Float(merged.fetch(label)) }
+    "'{#{ordered.join(',')}}'::float4[]"
+  end
+  private_class_method :rank_weights_literal
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -230,7 +230,8 @@ class User < ApplicationRecord
     "name": "A",
     "url_name": "A",
     "ban_text": "A",
-    "about_me": "A"
+    "about_me": "A",
+    "email_bounce_message": "C"
   }
 
   def self.pro

--- a/db/migrate/20260730093000_change_search_documents_raw_columns_to_jsonb.rb
+++ b/db/migrate/20260730093000_change_search_documents_raw_columns_to_jsonb.rb
@@ -1,0 +1,17 @@
+class ChangeSearchDocumentsRawColumnsToJsonb < ActiveRecord::Migration[8.0]
+  def up
+    remove_column(:search_documents, :raw_content)
+    remove_column(:search_documents, :raw_admin_content)
+
+    add_column(:search_documents, :raw_content, :jsonb)
+    add_column(:search_documents, :raw_admin_content, :jsonb)
+  end
+
+  def down
+    remove_column(:search_documents, :raw_content)
+    remove_column(:search_documents, :raw_admin_content)
+
+    add_column(:search_documents, :raw_content, :text)
+    add_column(:search_documents, :raw_admin_content, :text)
+  end
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow searches to weight and exclude indexed fields (Graeme Porteous)
 * Add PostgreSQL full-text search indexing, initially enabled for users only
   (Laurent Savaete, Graeme Porteous)
 * Fix reCAPTCHA blocked by Content Security Policy (Graeme Porteous)

--- a/doc/SEARCH.md
+++ b/doc/SEARCH.md
@@ -488,11 +488,13 @@ For each set, there are 2 columns:
 
 #### raw_content
 
-`raw_content` (respectively `raw_admin_content`) stores plain text for a model instance, typically a concatenation of the various fields we want to be able to search. This field can be expensive to rebuild (eg. it can contain multiple ruby method calls, or even require pulling a file from S3).
+`raw_content` (respectively `raw_admin_content`) stores plain text for a model instance as a `jsonb` object keyed by the tsvector weight label (`A` to `D`) each field was indexed under, with the fields sharing a label concatenated together. This field can be expensive to rebuild (eg. it can contain multiple ruby method calls, or even require pulling a file from S3).
+
+Keying by label is what lets the "exact" search honour the same `except` exclusions the tsvector search does: it can skip the excluded labels and still search the rest. A single concatenation would leave a `LIKE` match unable to tell excluded text from kept text.
 
 It is kept in the database to back the "exact" search (using SQL `LIKE`, or `ILIKE` when `case_sensitive: false` is passed). A use case for this is finding all users whose email address uses `@somedomain.com`. It would be possible to get rid of this column, and implement an "exact" search using a SQL query for each model. This would not work for models that do not store all their content in the database (`FoiAttachment` for instance).
 
-There is no index to back this search type at the moment (it would use the built-in `pg_trgm` index type, which is quite heavy to build and maintain), but it can be added if it becomes apparent that it is needed. This would allow typo-tolerant search, on top of speeding up "exact" searches.
+There is no index to back this search type at the moment (it would use the built-in `pg_trgm` index type, which is quite heavy to build and maintain), but it can be added if it becomes apparent that it is needed. As the column is keyed by label, such an index would have to be per expression, eg. `USING gin ((raw_content->>'A') gin_trgm_ops)`. This would allow typo-tolerant search, on top of speeding up "exact" searches.
 
 #### content_tsv
 
@@ -539,7 +541,7 @@ The letter that follows `A|B|C|D` defines the weights assigned to the field for 
 
 When you run `object.reindex`, the following happens:
 - the `raw_content` is built from the model's `searchable` definition,
-- the `content_tsv` is built from the same definition, pulling data directly from the model's fields (it cannot be built from `raw_content` because there is no weight information in it)
+- the `content_tsv` is built from the same definition, pulling data directly from the model's fields (it cannot be built from `raw_content` because that text has not been stemmed or tokenised)
 - the same process is done for the `admin_index` elements.
 - all fields are upserted in `search_documents`. postgresql automatically updates its indices to reflect the data in the table.
 

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -109,6 +109,22 @@ RSpec.describe AdminUserController do
       expect(assigns[:admin_users]).to include(user)
     end
 
+    it 'does not find users by their email bounce message' do
+      user = FactoryBot.create(:user)
+      user.record_bounce('mail delivery failed: mailbox full')
+      user.reindex
+      get :index, params: { query: 'mailbox full' }
+      expect(assigns[:admin_users]).to_not include(user)
+    end
+
+    it 'still finds a fragment of a field that is not excluded' do
+      user = FactoryBot.create(:user, email: 'julie@example.com')
+      user.record_bounce('mail delivery failed: mailbox full')
+      user.reindex
+      get :index, params: { query: '@example.com' }
+      expect(assigns[:admin_users]).to include(user)
+    end
+
     it 'will search the about me text' do
       # PostgreSQL tokenises a URL by host, so the about me link is found by
       # its domain rather than an arbitrary substring.

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -37,6 +37,118 @@ RSpec.describe Searchable, :xapian do
              backend: :postgresql, admin_mode: true)
       User.search_scope('bob', backend: :postgresql, admin_mode: true)
     end
+
+    it 'resolves excluded field names to labels for the backend' do
+      expect(Search).to receive(:search_scope).
+        with('bob', kind_of(ActiveRecord::Relation),
+             admin_mode: true, except: ['C'])
+      User.search_scope('bob', admin_mode: true,
+                               except: [:email_bounce_message])
+    end
+
+    it 'resolves the names against the index the search will read' do
+      expect { User.search_scope('bob', except: [:email_bounce_message]) }.
+        to raise_error(ArgumentError, /does not index/)
+    end
+  end
+
+  describe '.except_labels_for' do
+    it 'resolves a field name to the label it is weighted with' do
+      expect(User.except_labels_for([:email_bounce_message],
+                                    admin_mode: true)).to eq(['C'])
+    end
+
+    it 'accepts field names given as strings' do
+      expect(User.except_labels_for(['email_bounce_message'],
+                                    admin_mode: true)).to eq(['C'])
+    end
+
+    it 'resolves a single field given on its own' do
+      expect(User.except_labels_for(:email_bounce_message,
+                                    admin_mode: true)).to eq(['C'])
+    end
+
+    it 'returns nothing to exclude when given no fields' do
+      expect(User.except_labels_for(nil, admin_mode: true)).to eq([])
+      expect(User.except_labels_for([], admin_mode: true)).to eq([])
+    end
+
+    it 'rejects a field the model does not index' do
+      expect { User.except_labels_for([:no_such_field], admin_mode: true) }.
+        to raise_error(ArgumentError, /does not index no_such_field/)
+    end
+
+    it 'rejects a field the searched index does not carry' do
+      # email_bounce_message is only in the admin index, so a public search
+      # has nothing to exclude and asking is a mistake rather than a no-op.
+      expect { User.except_labels_for([:email_bounce_message]) }.
+        to raise_error(ArgumentError,
+                       /does not index email_bounce_message in index/)
+    end
+
+    it 'rejects a field whose weight also carries a field being kept' do
+      # email, name, url_name, ban_text and about_me all share weight A, so
+      # dropping A would drop all of them.
+      expect { User.except_labels_for([:email], admin_mode: true) }.
+        to raise_error(ArgumentError, /also carries/)
+    end
+
+    it 'accepts fields that between them cover the whole weight' do
+      expect(
+        User.except_labels_for(
+          %i[email name url_name ban_text about_me], admin_mode: true
+        )
+      ).to eq(['A'])
+    end
+
+    it 'raises for models that have not been made searchable' do
+      expect { Comment.except_labels_for([:body]) }.
+        to raise_error(NotImplementedError)
+    end
+
+    context 'for a model indexing both publicly and for admins' do
+      let(:model) do
+        stub_const('DualIndexed', Class.new do
+          extend Searchable::SearchableMethods
+
+          def self.name
+            'DualIndexed'
+          end
+        end)
+      end
+
+      before do
+        # title shares weight A with notes in the admin index, but has A to
+        # itself in the public one.
+        model.searchable index: { title: 'A', body: 'B' },
+                         admin_index: { title: 'A', notes: 'A' }
+      end
+
+      after do
+        Searchable.class_variable_get(:@@searchable_models).
+          delete('DualIndexed')
+      end
+
+      it 'ignores the admin index when resolving a public search' do
+        expect(model.except_labels_for([:title])).to eq(['A'])
+      end
+
+      it 'ignores the public index when resolving an admin search' do
+        expect(model.except_labels_for([:notes, :title], admin_mode: true)).
+          to eq(['A'])
+      end
+
+      it 'resolves the same field to each index separately' do
+        expect(model.except_labels_for([:body])).to eq(['B'])
+        expect { model.except_labels_for([:body], admin_mode: true) }.
+          to raise_error(ArgumentError, /does not index body in admin_index/)
+      end
+
+      it 'still rejects a shared weight within the searched index' do
+        expect { model.except_labels_for([:title], admin_mode: true) }.
+          to raise_error(ArgumentError, /also carries notes/)
+      end
+    end
   end
 end
 

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -163,8 +163,20 @@ RSpec.describe Searchable, 'index lifecycle' do
     user.update!(name: 'Updated Name')
 
     content = user.search_documents.reload.first.raw_admin_content
-    expect(content).to include('Updated Name')
-    expect(content).not_to include('Original Name')
+    expect(content['A']).to include('Updated Name')
+    expect(content['A']).not_to include('Original Name')
+  end
+
+  # a string handed to a jsonb column is stored as a JSON string rather than
+  # an object, which would leave every ->> lookup NULL, so assert the shape.
+  it 'keys the indexed content by tsvector label' do
+    user = FactoryBot.create(:user, name: 'Rita Raw')
+    user.record_bounce('mail delivery failed: mailbox full')
+
+    content = user.search_documents.reload.first.raw_admin_content
+    expect(content).to be_a(Hash)
+    expect(content['A']).to include('Rita Raw')
+    expect(content['C']).to include('mailbox full')
   end
 
   it 'removes search documents when the record is destroyed' do

--- a/spec/models/search/adapters/postgresql_spec.rb
+++ b/spec/models/search/adapters/postgresql_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Search::Adapters::Postgresql::Adapter, :postgresql do
 
       expect(scope).to include(user)
     end
+
+    it 'forwards custom rank weights to the query' do
+      expect(SearchDocument).to receive(:hybrid_search).
+        with('bob', hash_including(weights: { 'C' => 0.05 })).
+        and_return(User.none)
+
+      adapter.search_scope(
+        'bob', User.all, admin_mode: true, weights: { 'C' => 0.05 }
+      )
+    end
   end
 
   describe '#reindex_later' do

--- a/spec/models/search/adapters/postgresql_spec.rb
+++ b/spec/models/search/adapters/postgresql_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe Search::Adapters::Postgresql::Adapter, :postgresql do
         'bob', User.all, admin_mode: true, weights: { 'C' => 0.05 }
       )
     end
+
+    it 'forwards excluded labels to the query' do
+      expect(SearchDocument).to receive(:hybrid_search).
+        with('bob', hash_including(except: ['C'])).
+        and_return(User.none)
+
+      adapter.search_scope(
+        'bob', User.all, admin_mode: true, except: ['C']
+      )
+    end
   end
 
   describe '#reindex_later' do

--- a/spec/models/search_document_spec.rb
+++ b/spec/models/search_document_spec.rb
@@ -134,6 +134,86 @@ RSpec.describe SearchDocument do
     end
   end
 
+  context 'excluding tsvector labels' do
+    def query_for(labels, admin_mode: true)
+      SearchDocument.hybrid_search_internal(
+        'anything',
+        model: User, language: nil, limit: 10, admin_mode: admin_mode,
+        exact_mode: false, case_sensitive: true, limit_ratio: 3,
+        except: labels
+      )[:query]
+    end
+
+    it 'leaves the query untouched when nothing is excluded' do
+      expect(query_for(nil)).to_not include('ts_filter')
+    end
+
+    it 'filters the excluded label out of the admin index in admin mode' do
+      sql = query_for(['C'])
+      expect(sql).to include("ts_filter(admin_content_tsv, '{a,b,d}')")
+      expect(sql).to_not include('ts_filter(content_tsv')
+    end
+
+    # admin_mode is what says which index the labels belong to, so the same
+    # list lands on the other tsvector for a public search.
+    it 'filters the excluded label out of the public index otherwise' do
+      sql = query_for(['C'], admin_mode: false)
+      expect(sql).to include("ts_filter(content_tsv, '{a,b,d}')")
+      expect(sql).to_not include('ts_filter(admin_content_tsv')
+    end
+
+    it 'keeps the indexable predicate alongside the ts_filter recheck' do
+      sql = query_for(['C'])
+      expect(sql).to include('@@ admin_content_tsv')
+      expect(sql).to include("@@ ts_filter(admin_content_tsv, '{a,b,d}')")
+    end
+
+    it 'rejects an unrecognised label' do
+      expect { query_for(['E']) }.
+        to raise_error(ArgumentError, /unknown tsvector label/)
+    end
+
+    it 'rejects excluding every label' do
+      expect { query_for(%w[A B C D]) }.
+        to raise_error(ArgumentError, /cannot exclude every/)
+    end
+
+    it 'accepts a single label given on its own' do
+      expect(query_for('C')).
+        to include("ts_filter(admin_content_tsv, '{a,b,d}')")
+    end
+
+    context 'against indexed records' do
+      let!(:bounced) do
+        FactoryBot.create(:user, name: 'Bertha Bounce').tap do |u|
+          u.record_bounce('mail delivery failed: mailbox zzqxunique full')
+        end
+      end
+
+      it 'drops records matching only through the excluded label' do
+        expect(
+          User.newsearch('zzqxunique', admin_mode: true)
+        ).to include(bounced)
+
+        expect(
+          SearchDocument.hybrid_search(
+            'zzqxunique', model: User, admin_mode: true,
+                          except: ['C']
+          )
+        ).to match_array([])
+      end
+
+      it 'still matches the record through a label that is kept' do
+        expect(
+          SearchDocument.hybrid_search(
+            'Bertha', model: User, admin_mode: true,
+                      except: ['C']
+          )
+        ).to match_array([bounced])
+      end
+    end
+  end
+
   context 'exact mode' do
     it 'treats LIKE wildcards in the query as literal characters' do
       legit = FactoryBot.create(:user, name: 'Legitimate 100% Prospect')

--- a/spec/models/search_document_spec.rb
+++ b/spec/models/search_document_spec.rb
@@ -5,14 +5,14 @@
 #  sd_id             :bigint           not null, primary key
 #  searchable_type   :string           not null, primary key
 #  searchable_id     :bigint
-#  raw_content       :text
-#  raw_admin_content :text
 #  section_ref       :text
 #  language          :text
 #  content_tsv       :tsvector
 #  admin_content_tsv :tsvector
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  raw_content       :jsonb
+#  raw_admin_content :jsonb
 #
 
 require 'spec_helper'
@@ -197,6 +197,76 @@ RSpec.describe SearchDocument do
     it 'accepts a single label given on its own' do
       expect(query_for('C')).
         to include("ts_filter(admin_content_tsv, '{a,b,d}')")
+    end
+
+    context 'alongside exact mode' do
+      def exact_query_for(labels, admin_mode: true)
+        SearchDocument.hybrid_search_internal(
+          'anything',
+          model: User, language: nil, limit: 10, admin_mode: admin_mode,
+          exact_mode: true, case_sensitive: false, limit_ratio: 3,
+          except: labels
+        )[:query]
+      end
+
+      it 'searches every label of both raw columns by default' do
+        sql = exact_query_for(nil)
+        expect(sql).to include("raw_content ->> 'A' ILIKE")
+        expect(sql).to include("raw_admin_content ->> 'A' ILIKE")
+        expect(sql).to include("raw_admin_content ->> 'C' ILIKE")
+      end
+
+      it 'skips only the excluded label of the searched raw column' do
+        sql = exact_query_for(['C'])
+        expect(sql).to_not include("raw_admin_content ->> 'C'")
+        expect(sql).to include("raw_admin_content ->> 'A' ILIKE")
+        # the public index carries no exclusion, so it keeps every label
+        expect(sql).to include("raw_content ->> 'C' ILIKE")
+      end
+
+      it 'keeps searching the public raw column without its label' do
+        sql = exact_query_for(['C'], admin_mode: false)
+        expect(sql).to_not include('raw_admin_content')
+        expect(sql).to_not include("raw_content ->> 'C'")
+        expect(sql).to include("raw_content ->> 'A' ILIKE")
+      end
+
+      # tsv_expression raises before the exact mode branch is built, so the
+      # predicate list can never come out empty.
+      it 'rejects excluding every label before exact mode is built' do
+        expect { exact_query_for(%w[A B C D]) }.
+          to raise_error(ArgumentError, /cannot exclude every/)
+      end
+
+      # a fragment like this is not a token, so it can only ever match through
+      # the substring search. It is what the old column-dropping broke.
+      it 'still matches a substring of a kept label when excluding' do
+        user = FactoryBot.create(:user, email: 'zqx@example.com')
+
+        expect(
+          User.search_scope('@example.com', backend: :postgresql,
+                                            admin_mode: true,
+                                            exact_mode: true,
+                                            case_sensitive: false,
+                                            except: [:email_bounce_message])
+        ).to include(user)
+      end
+
+      it 'does not leak an excluded label through a substring fragment' do
+        bounced = FactoryBot.create(:user, name: 'Bertha Bounce')
+        bounced.record_bounce('mail delivery failed: mailbox zzqxunique full')
+
+        expect(
+          User.search_scope('zqxuniq', backend: :postgresql, admin_mode: true,
+                                       exact_mode: true, case_sensitive: false)
+        ).to include(bounced)
+
+        expect(
+          User.search_scope('zqxuniq', backend: :postgresql, admin_mode: true,
+                                       exact_mode: true, case_sensitive: false,
+                                       except: [:email_bounce_message])
+        ).to match_array([])
+      end
     end
 
     context 'against indexed records' do

--- a/spec/models/search_document_spec.rb
+++ b/spec/models/search_document_spec.rb
@@ -50,6 +50,22 @@ RSpec.describe SearchDocument do
     end
   end
 
+  context 'bounce text indexing' do
+    let!(:bounced) do
+      FactoryBot.create(:user).tap do |u|
+        u.record_bounce('mail delivery failed: mailbox full')
+      end
+    end
+
+    it 'finds users by bounce text in admin mode' do
+      expect(User.newsearch('mailbox full', admin_mode: true)).to include(bounced)
+    end
+
+    it 'does not expose bounce text to non-admin search' do
+      expect(User.newsearch('mailbox full')).to match_array([])
+    end
+  end
+
   context 'input validation' do
     it 'rejects a model given as a string' do
       expect { SearchDocument.hybrid_search('anything', model: 'User') }.

--- a/spec/models/search_document_spec.rb
+++ b/spec/models/search_document_spec.rb
@@ -64,6 +64,22 @@ RSpec.describe SearchDocument do
     it 'does not expose bounce text to non-admin search' do
       expect(User.newsearch('mailbox full')).to match_array([])
     end
+
+    it 'excludes bounce text from an admin search on request' do
+      expect(
+        User.search_scope('zzqxunique', backend: :postgresql,
+                                        admin_mode: true,
+                                        except: [:email_bounce_message])
+      ).to match_array([])
+    end
+
+    it 'keeps the other admin fields searchable when bounce text is excluded' do
+      expect(
+        User.search_scope('Florence', backend: :postgresql,
+                                      admin_mode: true,
+                                      except: [:email_bounce_message])
+      ).to match_array([user])
+    end
   end
 
   context 'input validation' do

--- a/spec/models/search_document_spec.rb
+++ b/spec/models/search_document_spec.rb
@@ -76,6 +76,48 @@ RSpec.describe SearchDocument do
     end
   end
 
+  context 'rank weights' do
+    def query_for(weights: nil)
+      SearchDocument.hybrid_search_internal(
+        'anything',
+        model: User, language: nil, limit: 10, admin_mode: true,
+        exact_mode: false, case_sensitive: true, limit_ratio: 3,
+        weights: weights
+      )[:query]
+    end
+
+    it 'ranks with PostgreSQL default weights when none are given' do
+      expect(query_for).to include("'{0.1,0.2,0.4,1.0}'::float4[]")
+    end
+
+    it 'applies a full weight override in {D,C,B,A} order' do
+      sql = query_for(
+        weights: { 'A' => 2.0, 'B' => 0.5, 'C' => 0.3, 'D' => 0.05 }
+      )
+      expect(sql).to include("'{0.05,0.3,0.5,2.0}'::float4[]")
+    end
+
+    it 'merges a partial override over the defaults' do
+      expect(query_for(weights: { 'C' => 0.05 })).
+        to include("'{0.1,0.05,0.4,1.0}'::float4[]")
+    end
+
+    it 'rejects a non-numeric weight' do
+      expect { query_for(weights: { 'A' => '1); DROP TABLE users' }) }.
+        to raise_error(ArgumentError)
+    end
+
+    it 'rejects an unrecognised label rather than ignoring it' do
+      expect { query_for(weights: { 'E' => 0.5 }) }.
+        to raise_error(ArgumentError, /unknown tsvector label/)
+    end
+
+    it 'accepts labels given as symbols' do
+      expect(query_for(weights: { C: 0.05 })).
+        to include("'{0.1,0.05,0.4,1.0}'::float4[]")
+    end
+  end
+
   context 'exact mode' do
     it 'treats LIKE wildcards in the query as literal characters' do
       legit = FactoryBot.create(:user, name: 'Legitimate 100% Prospect')


### PR DESCRIPTION
## Relevant issue(s)

## What does this do?

Add PostgreSQL search weights/exclude options

## Why was this needed?

Makes it possible to:
1. add tsvector label weighting per search
2. exclude fields from search - ie User#email_bounce_message

## Implementation notes

Changes the raw_content/raw_admin_content database columns to keyed JSONB columns so we can exclude the relevant fields based on the exclude option passed in to the search.

## Notes to reviewer

I had help from Claude to get the PG queries correct.
I believe the performance impact of this change is minor. 
