### PR TITLE
Add admin search for public bodies

### DIFF
--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -246,55 +246,67 @@ class AdminPublicBodyController < AdminController
       @page = nil if @page == ""
       @search_engine = params[:search_engine] || 'new'
 
-      if @search_engine == 'legacy' then
-        query = if @query
-          query_str = <<-EOF.strip_heredoc
-          (lower(public_body_translations.name)
-           LIKE lower('%'||?||'%')
-           OR lower(public_body_translations.short_name)
-           LIKE lower('%'||?||'%')
-           OR lower(public_body_translations.request_email)
-           LIKE lower('%'||?||'%' ))
-           AND (public_body_translations.locale = '#{@locale}')
-          EOF
-
-          [query_str, @query, @query, @query]
-        else
-          <<-EOF.strip_heredoc
-          public_body_translations.locale = '#{@locale}'
-          EOF
-        end
-
-        @public_bodies =
-          PublicBody.
-            joins(:translations).
-              where(query).
-                merge(PublicBody::Translation.order(:name)).
-                  paginate(page: @page, per_page: 100)
+      if @search_engine == 'legacy'
+        lookup_query_legacy
       else
-        if @query
-          @public_bodies =
-            PublicBody.
-              search_scope(@query,
-                           backend: :postgresql,
-                           admin_mode: true).
-                includes(:tags, :translations).
-                  paginate(page: @page, per_page: 100)
-        else
-          @public_bodies =
-            PublicBody.
-              includes(:tags, :translations).
-                references(:translations).
-                  where(public_body_translations: { locale: @locale }).
-                    merge(PublicBody::Translation.order(:name)).
-                      paginate(page: @page, per_page: 100)
-        end
+        lookup_query_new
+      end
+    end
+  end
+
+  def lookup_query_legacy
+    begin # increase nested to minimise the whitespace changes in diff
+      query = if @query
+        query_str = <<-EOF.strip_heredoc
+        (lower(public_body_translations.name)
+         LIKE lower('%'||?||'%')
+         OR lower(public_body_translations.short_name)
+         LIKE lower('%'||?||'%')
+         OR lower(public_body_translations.request_email)
+         LIKE lower('%'||?||'%' ))
+         AND (public_body_translations.locale = '#{@locale}')
+        EOF
+
+        [query_str, @query, @query, @query]
+      else
+        <<-EOF.strip_heredoc
+        public_body_translations.locale = '#{@locale}'
+        EOF
       end
 
-      @public_bodies_by_tag = PublicBody.
-          find_by_tag(@query).
-            includes(:tags, :translations)
+      @public_bodies =
+        PublicBody.
+          joins(:translations).
+            where(query).
+              merge(PublicBody::Translation.order(:name)).
+                paginate(page: @page, per_page: 100)
     end
+
+    @public_bodies_by_tag = PublicBody.find_by_tag(@query)
+  end
+
+  def lookup_query_new
+    if @query
+      @public_bodies =
+        PublicBody.
+          search_scope(@query,
+                       backend: :postgresql,
+                       admin_mode: true).
+            includes(:tags, :translations).
+              paginate(page: @page, per_page: 100)
+    else
+      @public_bodies =
+        PublicBody.
+          includes(:tags, :translations).
+            references(:translations).
+              where(public_body_translations: { locale: @locale }).
+                merge(PublicBody::Translation.order(:name)).
+                  paginate(page: @page, per_page: 100)
+    end
+
+    @public_bodies_by_tag = PublicBody.
+      find_by_tag(@query).
+        includes(:tags, :translations)
   end
 
   def public_body_params

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -278,12 +278,12 @@ class AdminPublicBodyController < AdminController
               search_scope(@query,
                            backend: :postgresql,
                            admin_mode: true).
-                joins(:translations).
+                includes(:tags, :translations).
                   paginate(page: @page, per_page: 100)
         else
           @public_bodies =
             PublicBody.
-              joins(:translations).
+              includes(:tags, :translations).
                 references(:translations).
                   where(public_body_translations: { locale: @locale }).
                     merge(PublicBody::Translation.order(:name)).
@@ -291,7 +291,9 @@ class AdminPublicBodyController < AdminController
         end
       end
 
-      @public_bodies_by_tag = PublicBody.find_by_tag(@query)
+      @public_bodies_by_tag = PublicBody.
+          find_by_tag(@query).
+            includes(:tags, :translations)
     end
   end
 

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -244,34 +244,55 @@ class AdminPublicBodyController < AdminController
       @query = nil if @query == ""
       @page = params[:page]
       @page = nil if @page == ""
+      @search_engine = params[:search_engine] || 'new'
 
-      query = if @query
-        query_str = <<-EOF.strip_heredoc
-        (lower(public_body_translations.name)
-         LIKE lower('%'||?||'%')
-         OR lower(public_body_translations.short_name)
-         LIKE lower('%'||?||'%')
-         OR lower(public_body_translations.request_email)
-         LIKE lower('%'||?||'%' ))
-         AND (public_body_translations.locale = '#{@locale}')
-        EOF
+      if @search_engine == 'legacy' then
+        query = if @query
+          query_str = <<-EOF.strip_heredoc
+          (lower(public_body_translations.name)
+           LIKE lower('%'||?||'%')
+           OR lower(public_body_translations.short_name)
+           LIKE lower('%'||?||'%')
+           OR lower(public_body_translations.request_email)
+           LIKE lower('%'||?||'%' ))
+           AND (public_body_translations.locale = '#{@locale}')
+          EOF
 
-        [query_str, @query, @query, @query]
+          [query_str, @query, @query, @query]
+        else
+          <<-EOF.strip_heredoc
+          public_body_translations.locale = '#{@locale}'
+          EOF
+        end
+
+        @public_bodies =
+          PublicBody.
+            joins(:translations).
+              where(query).
+                merge(PublicBody::Translation.order(:name)).
+                  paginate(page: @page, per_page: 100)
       else
-        <<-EOF.strip_heredoc
-        public_body_translations.locale = '#{@locale}'
-        EOF
+        if @query
+          @public_bodies =
+            PublicBody.
+              search_scope(@query,
+                           backend: :postgresql,
+                           admin_mode: true).
+                joins(:translations).
+                  paginate(page: @page, per_page: 100)
+        else
+          @public_bodies =
+            PublicBody.
+              joins(:translations).
+                references(:translations).
+                  where(public_body_translations: { locale: @locale }).
+                    merge(PublicBody::Translation.order(:name)).
+                      paginate(page: @page, per_page: 100)
+        end
       end
 
-      @public_bodies =
-        PublicBody.
-          joins(:translations).
-            where(query).
-              merge(PublicBody::Translation.order(:name)).
-                paginate(page: @page, per_page: 100)
+      @public_bodies_by_tag = PublicBody.find_by_tag(@query)
     end
-
-    @public_bodies_by_tag = PublicBody.find_by_tag(@query)
   end
 
   def public_body_params

--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -129,6 +129,20 @@ class PublicBody < ApplicationRecord
   translates :name, :short_name, :request_email, :url_name, :first_letter,
              :publication_scheme, :disclosure_log
 
+  searchable index: {
+               ".name": "A",
+               ".short_name": "A",
+               "home_page": "B",
+               ".notes_for_search": "C",
+               ".disclosure_log": "D",
+               ".publication_scheme": "D",
+             },
+             admin_index: {
+               ".request_email": "A",
+               "last_edit_editor": "D",
+               "last_edit_comment": "D",
+             }
+
   # Cannot be grouped at top as it depends on the `translates` macro
   include Translatable
 
@@ -215,6 +229,13 @@ class PublicBody < ApplicationRecord
     def editor
       User.find_by(url_name: last_edit_editor)
     end
+  end
+
+  # return only the notes attached to the body itself, excluding
+  # notes brought it by tags, as they pollute search results because
+  # they tend to be non-specific.
+  def notes_for_search
+    concrete_notes.map(&:body).join(' ')
   end
 
   # Public: Search for Public Bodies whose name, short_name, request_email or

--- a/app/views/admin_public_body/index.html.erb
+++ b/app/views/admin_public_body/index.html.erb
@@ -21,15 +21,31 @@
 <div class="row">
   <%= form_tag nil, method: :get, class: 'form form-search span12' do %>
     <div class="input-append">
-      <%= text_field_tag 'query', params[:query], size: 30, class: 'input-large search-query' %>
-      <%= submit_tag 'Search', class: 'btn' %>
+      <%= text_field_tag "query",
+      params[:query],
+      size: 30,
+      class: "input-large search-query" %>
+      <%= submit_tag "Search", class: "btn" %>
+    </div>
+
+    <div>
+      <%= radio_button_tag "search_engine", "legacy", checked: "legacy" == @search_engine %>
+      <%= label_tag "search_engine_legacy",
+      "legacy engine: substring search in names and emails; exact match of tags",
+      class: "help-inline" %>
+      <br>
+      <%= radio_button_tag "search_engine",
+      "new",
+      checked: "new" == @search_engine %>
+      <%= label_tag "search_engine_new",
+      "new engine: whole word search in names, emails and notes; please report poor search results!",
+      class: "help-inline" %>
     </div>
 
     <% if @query %>
       <%= link_to 'Show all', admin_bodies_path, class: 'btn' %>
     <% end %>
 
-    <span class="help-inline">(substring search in names and emails; exact match of tags)</span>
   <% end %>
 </div>
 
@@ -42,7 +58,13 @@
   <% if @query.nil? %>
     <h2>All authorities</h2>
   <% else %>
-    <h2>Substring search matches (<%= @public_bodies.total_entries %> total)</h2>
+    <% if @search_engine == "new" %>
+      <h2>Search engine matches (<%= @public_bodies.total_entries %>
+        total)</h2>
+    <% else %>
+      <h2>Substring search matches (<%= @public_bodies.total_entries %>
+        total)</h2>
+    <% end %>
   <% end %>
   <%= render :partial => 'one_list', :locals => { :bodies => @public_bodies, :table_name => 'substring' } %>
 <% end %>

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -7,15 +7,28 @@ RSpec.describe AdminPublicBodyController do
       expect(response).to be_successful
     end
 
-    it "searches for 'humpa'" do
-      get :index, params: { query: "humpa" }
+    it "searches for 'humpa' with the legacy search" do
+      get :index, params: { query: "humpa", search_engine: "legacy" }
       expect(assigns[:public_bodies]).
         to eq([public_bodies(:humpadink_public_body)])
     end
 
-    it "searches for 'humpa' in another locale" do
+    it "searches for 'humpa' in another locale  with the legacy search" do
       cookies[:locale] = 'es'
-      get :index, params: { query: "humpa" }
+      get :index, params: { query: "humpa", search_engine: "legacy" }
+      expect(assigns[:public_bodies]).
+        to eq([public_bodies(:humpadink_public_body)])
+    end
+
+    it "lists all authorities in name order" do
+      get :index
+      names = assigns[:public_bodies].map(&:name)
+      expect(names).to eq(names.sort_by(&:downcase))
+    end
+
+    it "searches for a request email with the new search", :postgresql do
+      get :index, params: { query: "humpadink-requests@localhost",
+                            search_engine: "new" }
       expect(assigns[:public_bodies]).
         to eq([public_bodies(:humpadink_public_body)])
     end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe Searchable, 'index lifecycle' do
   end
 
   it 'does not index models that are not registered as searchable' do
-    body = FactoryBot.create(:public_body)
-    expect(body.search_documents.count).to eq(0)
+    body = FactoryBot.create(:initial_request)
+    expect(SearchDocument.where(searchable_type: "InfoRequest").count).to eq(0)
   end
 
   describe '.reindex_all' do

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -2074,6 +2074,116 @@ RSpec.describe PublicBody, " when override all public body request emails set" d
   end
 end
 
+RSpec.describe PublicBody, "when indexing for postgres search" do
+  it 'updates the search index after updating the public body' do
+    pb = FactoryBot.create(:public_body, name: 'Council of things')
+    expect(PublicBody.newsearch('Council of things')).to eq([pb])
+    pb.update(name: 'Ministry of Stuff')
+    pb.save
+    expect(PublicBody.newsearch('Council of things')).to eq([])
+    expect(PublicBody.newsearch('Ministry of Stuff')).to eq([pb])
+  end
+
+  it 'PublicBody has one SearchDocument per translation' do
+    name_en = "Some public authority ABCD"
+    name_fr = "Une administration ABCD"
+    body = FactoryBot.create(:public_body, name: name_en)
+    body.translations.create(locale: 'fr',
+                             name: name_fr)
+    expect(body.translations.size).to eq(2)
+    expect(body.name(:fr)).to eq(name_fr)
+
+    body.reindex
+
+    expect(SearchDocument.count).to eq(2)
+    expect(PublicBody.newsearch("ABCD", language: 'french')).to eq([body])
+    expect(PublicBody.newsearch("ABCD")).to eq([body])
+    expect(PublicBody.newsearch(
+             "authority",
+             language: 'french'
+           )).to match_array([])
+    expect(PublicBody.newsearch(
+             "administration",
+             language: 'english'
+           )).to match_array([])
+  end
+
+  context 'handles known problematic searches from various sites' do
+    # from https://github.com/mysociety/alaveteli/issues/1179
+    it 'finds UK public bodies' do
+      with_default_locale(:en) do
+        nhs = FactoryBot.create(:public_body, name: "NHS England")
+        bodies = [
+          nhs,
+          FactoryBot.create(:public_body, name: "NHS Improving Quality"),
+          FactoryBot.create(:public_body, name: "NHSX"),
+          FactoryBot.create(
+            :public_body,
+            name: "Northern England NHS fictitious center"
+          )
+        ]
+        bodies.each(&:reindex)
+        expect(PublicBody.newsearch("NHS England").first).to eq(nhs)
+      end
+    end
+
+    it 'finds French public bodies' do
+      with_default_locale(:fr_FR) do
+        AlaveteliLocalization.with_locale(:fr_FR) do
+          body = FactoryBot.create(
+            :public_body,
+            name: "Ministère de l'Intérieur"
+          )
+          body.reindex
+          expect(PublicBody.newsearch(
+                   "ministere intérieur",
+            language: 'french'
+                 )).to match_array([body])
+          expect(
+            PublicBody.newsearch("ministere interieur")
+          ).to match_array([body])
+          expect(
+            PublicBody.newsearch("ministere de l'intérieur")
+          ).to match_array([body])
+        end
+      end
+    end
+
+    it 'finds the Australian attorney general' do
+      # from https://github.com/mysociety/alaveteli/issues/1179#issuecomment-304157132
+      with_default_locale(:en) do
+        ag = FactoryBot.create(:public_body,
+name: "WA Department of the Attorney General")
+        ag.reindex
+        expect(PublicBody.newsearch("WA Attorney General")).to match_array([ag])
+        expect(PublicBody.newsearch("Attorney General")).to match_array([ag])
+      end
+    end
+
+    it 'finds the Swedish name of a public body in either locale' do
+      with_default_locale(:sv) do
+        st = FactoryBot.create(:public_body, name: "Skånetrafiken")
+        st.translations.create(locale: "sv",
+                               name: "Skånetrafiken")
+        st.reindex
+        s = SearchDocument.first
+        AlaveteliLocalization.with_locale(:sv) do
+          expect(PublicBody.newsearch(
+                   "Skånetrafiken",
+               language: 'swedish'
+                 )).to match_array([st])
+        end
+        AlaveteliLocalization.with_locale(:en) do
+          expect(PublicBody.newsearch(
+                   "Skånetrafiken",
+               language: 'english'
+                 )).to match_array([st])
+        end
+      end
+    end
+  end
+end
+
 RSpec.describe PublicBody, "when calculating statistics" do
   it "should not include hidden requests in totals" do
     with_hidden_and_successful_requests do


### PR DESCRIPTION
## Relevant issue(s)

Relates to #8814 

## What does this do?

This sets up a simple UI in /admin/bodies to allow admins to use either the legacy search or the new postgres search engine to find public bodies.

## Why was this needed?

We need to test the new search engine on actual data with actual use cases. Making it available on live sites without breaking existing workflows seems like a good way to do this.

## Implementation notes

I have included the few tests we had from previous commits to ensure a base level of consistency in results. We need a lot more!

To allow admin search through all the history of edits, I had to add an extra method. Naming improvements welcome :)

## Screenshots

## Notes to reviewer

With Ma Dada data, searching for `mairie` (cityhall) leads to 35k+ results under the "exact tag match" section. As there is no pagination on that part of the page, the server has to issue something like 100k db queries to fetch translations+tags, then sends 100+MB to the browser. The client then struggles to render the result. I would suggest we remove the tag based search from this page, and rely on /admin/tags for that purpose, as it handles pagination and all (and we don't actually do partial tag matches anyway, so there is no additional use case handled here).

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
