### PR TITLE
Add drift tolerance to one time password checks

### DIFF
--- a/app/models/otp_enrolment.rb
+++ b/app/models/otp_enrolment.rb
@@ -27,7 +27,8 @@ class OtpEnrolment
   private
 
   def code_matches_secret
-    return if ROTP::TOTP.new(secret).verify(otp_code.to_s)
+    return if ROTP::TOTP.new(secret).
+              verify(otp_code.to_s, drift_behind: User::OneTimePassword::DRIFT)
 
     errors.add(:otp_code, _('That code did not match. Please try again.'))
   end

--- a/app/models/user/one_time_password.rb
+++ b/app/models/user/one_time_password.rb
@@ -2,6 +2,8 @@
 module User::OneTimePassword
   extend ActiveSupport::Concern
 
+  DRIFT = 15.seconds
+
   included do
     has_one_time_password after_column_name: :otp_last_used_at
 
@@ -31,7 +33,7 @@ module User::OneTimePassword
       otp_counter.present?
     end
 
-    # Override the gem's `authenticate_otp` for two reasons:
+    # Override the gem's `authenticate_otp` for three reasons:
     #
     # 1. The gem checks backup codes before the primary factor. Try the primary
     #    factor first so a valid authenticator code never spends one of the
@@ -47,6 +49,9 @@ module User::OneTimePassword
     #    in-progress authentication so the re-entrant validation skips
     #    re-verifying.
     #
+    # 3. The gem defaults to no drift, rejecting a code the moment its step
+    #    ends. Apply DRIFT as the default, still letting a caller override it.
+    #
     # The override must live here (on the class) rather than in the module
     # body so `super` reaches the gem's method, which is included into the
     # class by `has_one_time_password` above.
@@ -54,7 +59,8 @@ module User::OneTimePassword
       return false if code.blank?
 
       @authenticating_otp = true
-      super || authenticate_backup_code(code)
+      super(code, { drift: DRIFT }.merge(options)) ||
+        authenticate_backup_code(code)
     ensure
       @authenticating_otp = false
     end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Accept a two factor code briefly after it expires (Graeme Porteous)
 * Safely recover from attachment masking timeouts (Graeme Porteous)
 * Add PostgreSQL full-text search indexing, initially enabled for users only
   (Laurent Savaete, Graeme Porteous)

--- a/spec/models/otp_enrolment_spec.rb
+++ b/spec/models/otp_enrolment_spec.rb
@@ -59,6 +59,30 @@ RSpec.describe OtpEnrolment do
       enrolment.valid?
       expect(enrolment.errors[:otp_code]).to be_present
     end
+
+    context 'with a code submitted just after its step ended' do
+      let(:period_start) { Time.utc(2026, 8, 5, 10, 0, 0) }
+      let(:period_end) { period_start + 30.seconds }
+      let(:window_closes) { period_end + User::OneTimePassword::DRIFT }
+
+      before do
+        travel_to(period_end - 1.second) do
+          enrolment.otp_code = ROTP::TOTP.new(secret).now
+        end
+      end
+
+      it 'is true inside the drift window' do
+        travel_to(window_closes - 1.second) do
+          expect(enrolment.valid?).to eq(true)
+        end
+      end
+
+      it 'is false once the drift window has closed' do
+        travel_to(window_closes) do
+          expect(enrolment.valid?).to eq(false)
+        end
+      end
+    end
   end
 
   describe '#save' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1112,6 +1112,46 @@ RSpec.describe User do
     end
   end
 
+  describe 'TOTP drift tolerance' do
+    let(:user) { FactoryBot.create(:user, :enable_totp) }
+    let(:period_start) { Time.utc(2026, 8, 5, 10, 0, 0) }
+    let(:period_end) { period_start + 30.seconds }
+    let(:window_closes) { period_end + User::OneTimePassword::DRIFT }
+
+    # Read at the end of a step, submitted after it has ended
+    def expiring_code
+      travel_to(period_end - 1.second) { user.otp_code }
+    end
+
+    it 'accepts it until the drift window closes' do
+      code = expiring_code
+
+      travel_to(window_closes - 1.second) do
+        expect(user.authenticate_otp(code)).to eq(true)
+      end
+    end
+
+    it 'rejects a code once the drift window has closed' do
+      code = expiring_code
+
+      travel_to(window_closes) do
+        expect(user.authenticate_otp(code)).to eq(false)
+      end
+    end
+
+    it 'refuses to replay a code accepted inside the drift window' do
+      code = expiring_code
+
+      travel_to(window_closes - 2.seconds) do
+        expect(user.authenticate_otp(code)).to eq(true)
+      end
+
+      travel_to(window_closes - 1.second) do
+        expect(user.authenticate_otp(code)).to eq(false)
+      end
+    end
+  end
+
   describe '#disable_otp' do
     it 'sets otp_enabled to false' do
       user = User.new(otp_enabled: true)


### PR DESCRIPTION
Codes were verified with no drift, so one was rejected the instant its 30 seconds window ended.

RFC 6238 recommends comparing against past timestamps within the transmission delay, allowing at most one step.

Default the drift to 15 seconds - half a step. so we accepts the code that has just expired for the first 15 seconds of the next step.

Nothing becomes replayable: authenticate_totp still passes otp_last_used_at as `after`, so ROTP drops any step at or before the one already used, and OtpRateLimit still caps repeat attempts.

This fixes flaky tests where codes rolled over into the next window.