### PR TITLE
Add admin search for info requests

### DIFF
--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -15,20 +15,14 @@ class AdminRequestController < AdminController
 
   def index
     @query = params[:query]
-    if @query
-      info_requests = InfoRequest.where(["lower(title) like lower('%'||?||'%')", @query])
+    @query = nil if @query == ''
+    @search_engine = params[:search_engine] || 'new'
+
+    if @search_engine == 'legacy'
+      index_legacy
     else
-      info_requests = InfoRequest
+      index_new
     end
-
-    if cannot? :admin, AlaveteliPro::Embargo
-      info_requests = info_requests.not_embargoed
-    end
-
-    @info_requests =
-      info_requests.
-      order(sort_query).
-      paginate(page: params[:page], per_page: 100)
   end
 
   def show
@@ -210,6 +204,44 @@ class AdminRequestController < AdminController
   end
 
   private
+
+  def index_legacy
+    if @query
+      info_requests = InfoRequest.where(["lower(title) like lower('%'||?||'%')", @query])
+    else
+      info_requests = InfoRequest
+    end
+
+    if cannot? :admin, AlaveteliPro::Embargo
+      info_requests = info_requests.not_embargoed
+    end
+
+    @info_requests =
+      info_requests.
+      order(sort_query).
+      paginate(page: params[:page], per_page: 100)
+  end
+
+  def index_new
+    info_requests =
+      if @query
+        InfoRequest.search_scope(@query,
+                                 backend: :postgresql,
+                                 admin_mode: true)
+      else
+        InfoRequest
+      end
+
+    if cannot? :admin, AlaveteliPro::Embargo
+      info_requests = info_requests.not_embargoed
+    end
+
+    @info_requests =
+      info_requests.
+      includes(:embargo, :user, public_body: :translations).
+      order(sort_query).
+      paginate(page: params[:page], per_page: 100)
+  end
 
   def info_request_params
     if params[:info_request]

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -48,6 +48,10 @@ module Searchable
     @@locale_to_language_map[locale]
   end
 
+  def self.partition_table_name(model)
+    "search_documents_#{model.downcase.gsub('::', '_')}"
+  end
+
   # TODO: rename to `search`
   # Search entry point for searching a single instance of a model.
   # Override per model as each one will have custom logic
@@ -254,6 +258,18 @@ module Searchable
     # This would normally not be run beyond the initial indexing of a
     # pre-existing database.
     def reindex_all(batch_size: 1000)
+      options = search_options
+      return if options.nil?
+
+      columns = (options[:index] || {}).keys +
+                (options[:admin_index] || {}).keys
+
+      # if none of the index keys starts with a '.', we don't need to call ruby
+      # attributes so we can index within a DB query
+      if columns.none? { |column| column.start_with?('.') }
+        return reindex_all_inside_db
+      end
+
       start = Time.zone.now
       count = 0
       indexable.find_each(batch_size: batch_size) do |record|
@@ -262,6 +278,80 @@ module Searchable
       end
       elapsed = Time.zone.now - start
       Rails.logger.info("Reindexed #{count} #{name} in #{elapsed} seconds")
+    end
+
+    # alternative implementation of reindex_all that works for models
+    # whose searchable.index and searchable.admin_index only contain
+    # SQL column names, and no ruby attributes. In that case, it is
+    # possible to send a single request to the db to generate the entire
+    # set of search_documents.
+    def reindex_all_inside_db
+      language = Searchable.lang_from_locale(
+        AlaveteliLocalization.default_locale
+      )
+      table = Searchable.partition_table_name(name)
+
+      rows = indexable.select(Arel.sql(<<~SQL.chomp))
+        #{connection.quote(name)},
+        id,
+        #{connection.quote(language)},
+        '1',
+        #{raw_content_query(:index)},
+        #{raw_content_query(:admin_index)},
+        #{content_tsv_query(:index, language)},
+        #{content_tsv_query(:admin_index, language)},
+        CURRENT_TIMESTAMP,
+        CURRENT_TIMESTAMP
+      SQL
+
+      insert = <<~SQL
+        INSERT INTO "#{table}" (
+          "searchable_type",
+          "searchable_id",
+          "language",
+          "section_ref",
+          "raw_content",
+          "raw_admin_content",
+          "content_tsv",
+          "admin_content_tsv",
+          "created_at",
+          "updated_at"
+        )
+        #{rows.to_sql}
+      SQL
+
+      start = Time.zone.now
+      count = transaction do
+        connection.execute(%(TRUNCATE "#{table}"))
+        connection.exec_update(insert, "Reindex #{name}")
+      end
+      elapsed = Time.zone.now - start
+      Rails.logger.info(
+        "Reindexed #{count} #{name} in #{elapsed} seconds (in database)"
+      )
+    end
+
+    def search_options
+      Searchable.class_variable_get(:@@searchable_models)[name]
+    end
+
+    private
+
+    def raw_content_query(idx_name)
+      columns = search_options[idx_name]
+      return "''" if columns.nil?
+
+      "concat(#{columns.keys.join(", ' ', ")})"
+    end
+
+    def content_tsv_query(idx_name, language)
+      columns = search_options[idx_name]
+      return "''" if columns.nil?
+
+      columns.map { |column, weight|
+        "setweight(to_tsvector('#{language}'::regconfig, " \
+        "unaccent(coalesce(#{column}, ''))), '#{weight}')"
+      }.join('||')
     end
   end
 

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -45,6 +45,7 @@ class InfoRequest < ApplicationRecord
   include LinkToHelper
 
   include Categorisable
+  include Searchable
   include Taggable
   include Notable
   include RateLimited
@@ -211,6 +212,16 @@ class InfoRequest < ApplicationRecord
   after_update :reindex_request_events, if: :reindexable_attribute_changed?
   before_destroy :expire
   after_destroy :notify_associations, :update_counter_cache
+
+  searchable index: {
+               "title": "A",
+               "url_title": "B"
+             },
+             admin_index: {
+               "external_user_name": "A",
+               "external_url": "A",
+               "prominence_reason": "D"
+             }
 
   # Return info request corresponding to an incoming email address, or nil if
   # none found. Checks the hash to ensure the email came from the public body -

--- a/app/views/admin_request/index.html.erb
+++ b/app/views/admin_request/index.html.erb
@@ -14,7 +14,19 @@
     <%= submit_tag 'Search', class: 'btn' %>
   </div>
 
-  <span class="help-inline">(substring search, titles only)</span>
+  <div>
+    <%= radio_button_tag "search_engine", "legacy", checked: "legacy" == @search_engine %>
+    <%= label_tag "search_engine_legacy",
+    "legacy engine: substring search in titles only",
+    class: "help-inline" %>
+    <br>
+    <%= radio_button_tag "search_engine",
+    "new",
+    checked: "new" == @search_engine %>
+    <%= label_tag "search_engine_new",
+    "new engine: whole word search in titles; please report poor search results!",
+    class: "help-inline" %>
+  </div>
 <% end %>
 
 <%= render partial: 'some_requests', locals: { info_requests: @info_requests } %>

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe AdminRequestController, "when administering requests" do
       end
     end
 
-    context 'when passed a query' do
+    context 'when passed a query with the legacy search engine' do
       let!(:dog_request) { FactoryBot.create(:info_request,
                                             title: 'A dog request') }
       let!(:cat_request) { FactoryBot.create(:info_request,
@@ -55,7 +55,7 @@ RSpec.describe AdminRequestController, "when administering requests" do
 
       it 'assigns info requests with titles matching the query to the view
           case insensitively' do
-        get :index, params: { query: 'Cat' }
+        get :index, params: { query: 'Cat', search_engine: 'legacy' }
         expect(assigns[:info_requests].include?(dog_request)).to be false
         expect(assigns[:info_requests].include?(cat_request)).to be true
       end
@@ -63,7 +63,7 @@ RSpec.describe AdminRequestController, "when administering requests" do
       it 'does not include embargoed requests if the current user is an
           admin user' do
         cat_request.create_embargo
-        get :index, params: { query: 'cat' }
+        get :index, params: { query: 'cat', search_engine: 'legacy' }
         expect(assigns[:info_requests].include?(cat_request)).to be false
       end
 
@@ -72,7 +72,7 @@ RSpec.describe AdminRequestController, "when administering requests" do
             admin user' do
           with_feature_enabled(:alaveteli_pro) do
             cat_request.create_embargo
-            get :index, params: { query: 'cat' }
+            get :index, params: { query: 'cat', search_engine: 'legacy' }
             expect(assigns[:info_requests].include?(cat_request)).to be false
           end
         end
@@ -82,10 +82,45 @@ RSpec.describe AdminRequestController, "when administering requests" do
           with_feature_enabled(:alaveteli_pro) do
             cat_request.create_embargo
             sign_in pro_admin_user
-            get :index, params: { query: 'cat' }
+            get :index, params: { query: 'cat', search_engine: 'legacy' }
             expect(assigns[:info_requests].include?(cat_request)).to be true
           end
         end
+      end
+    end
+
+    context 'when passed a query with the new search engine', :postgresql do
+      let!(:dog_request) do
+        FactoryBot.create(:info_request, title: 'A dog request')
+      end
+
+      let!(:cat_request) do
+        FactoryBot.create(:info_request, title: 'A cat request')
+      end
+
+      it 'assigns info requests with titles matching the query to the view' do
+        get :index, params: { query: 'Cat' }
+        expect(assigns[:info_requests]).to include(cat_request)
+        expect(assigns[:info_requests]).not_to include(dog_request)
+      end
+
+      it 'searches fields only admins can see' do
+        external = FactoryBot.create(:external_request,
+                                     external_user_name: 'Winston Smith')
+        get :index, params: { query: 'Winston Smith' }
+        expect(assigns[:info_requests]).to include(external)
+      end
+
+      it 'assigns all info requests to the view when the query is blank' do
+        get :index, params: { query: '' }
+        expect(assigns[:info_requests]).to match_array(InfoRequest.all)
+      end
+
+      it 'does not include embargoed requests if the current user is an
+          admin user' do
+        cat_request.create_embargo
+        get :index, params: { query: 'cat' }
+        expect(assigns[:info_requests]).not_to include(cat_request)
       end
     end
   end

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe Searchable, 'index lifecycle' do
   end
 
   it 'does not index models that are not registered as searchable' do
-    body = FactoryBot.create(:initial_request)
-    expect(SearchDocument.where(searchable_type: "InfoRequest").count).to eq(0)
+    n = FactoryBot.create(:notification)
+    expect(SearchDocument.where(searchable_type: "Notification").count).to eq(0)
   end
 
   describe '.reindex_all' do

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -76,5 +76,54 @@ RSpec.describe Searchable, 'index lifecycle' do
         SearchDocument.where(searchable_type: 'User').count
       ).to eq(User.count)
     end
+
+    it 'reads models with ruby attributes one record at a time' do
+      expect(PublicBody).not_to receive(:reindex_all_inside_db)
+      PublicBody.reindex_all
+    end
+
+    it 'builds the documents inside the database for column only models' do
+      FactoryBot.create(:user)
+      SearchDocument.delete_all
+
+      expect(User).to receive(:reindex_all_inside_db).and_call_original
+      User.reindex_all
+
+      expect(SearchDocument.where(searchable_type: 'User')).to be_any
+    end
+
+    it 'leaves the other partitions alone' do
+      FactoryBot.create(:public_body)
+      body_documents = SearchDocument.where(searchable_type: 'PublicBody').count
+
+      User.reindex_all
+
+      expect(
+        SearchDocument.where(searchable_type: 'PublicBody').count
+      ).to eq(body_documents)
+    end
+
+    it 'skips records the indexable scope filters out' do
+      banned = FactoryBot.create(:user, ban_text: 'Spammer')
+      allow(User).to receive(:indexable).
+        and_return(User.where.not(id: banned.id))
+
+      User.reindex_all
+
+      expect(
+        SearchDocument.where(searchable_type: 'User', searchable_id: banned.id)
+      ).to be_empty
+    end
+
+    it 'copies the indexed columns into the raw content' do
+      user = FactoryBot.create(:user, name: 'Winston Smith')
+
+      User.reindex_all
+
+      document = SearchDocument.find_by(searchable_type: 'User',
+                                        searchable_id: user.id)
+      expect(document.raw_admin_content).to include('Winston Smith')
+      expect(User.newsearch('Winston Smith', admin_mode: true)).to eq([user])
+    end
   end
 end

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -5056,3 +5056,34 @@ RSpec.describe InfoRequest do
     end
   end
 end
+
+RSpec.describe InfoRequest, "when indexing for postgres search" do
+  it 'updates the search index after updating the request' do
+    request = FactoryBot.create(:info_request, title: 'Council of things')
+    expect(InfoRequest.newsearch('Council of things')).to eq([request])
+
+    request.update!(title: 'Ministry of Stuff')
+
+    expect(InfoRequest.newsearch('Council of things')).to eq([])
+    expect(InfoRequest.newsearch('Ministry of Stuff')).to eq([request])
+  end
+
+  it 'finds a request by the name of its external user in admin mode' do
+    request = FactoryBot.create(:external_request,
+                                external_user_name: 'Winston Smith')
+
+    expect(InfoRequest.newsearch('Winston Smith')).to eq([])
+    expect(InfoRequest.newsearch('Winston Smith', admin_mode: true)).
+      to eq([request])
+  end
+
+  it 'keeps the reason a request was hidden out of the public index' do
+    request = FactoryBot.create(:info_request)
+    request.update!(prominence: 'hidden',
+                    prominence_reason: 'Names a living person')
+
+    expect(InfoRequest.newsearch('living person')).to eq([])
+    expect(InfoRequest.newsearch('living person', admin_mode: true)).
+      to eq([request])
+  end
+end

--- a/spec/support/postgresql_index.rb
+++ b/spec/support/postgresql_index.rb
@@ -1,6 +1,6 @@
 # Rebuild the PostgreSQL search index (the +search_documents+ table) from the
 # current fixtures, for specs tagged `:postgresql`.
-def rebuild_postgresql_index(models = [PublicBody, User])
+def rebuild_postgresql_index(models = [InfoRequest, PublicBody, User])
   SearchDocument.delete_all
   models.each(&:reindex_all)
 end


### PR DESCRIPTION
## Relevant issue(s)

#8814 

## What does this do?

This PR marks `InfoRequest` as searchable with the new search engine.

## Why was this needed?

## Implementation notes

This is mostly adapted from the previous PR for `PublicBody`.
I took the opportunity to optimise the view a bit as well. For a full page of requests, the rendering time is divided by 2-4 locally, and number of requests to db drop from ~416 to ~20.

This is probably one of the models where initial indexing time is going to matter a bit, at least for WDTK. If it runs at roughly the same speed as my local test, you're looking at ~6.5h of indexing time. I will try to implement a more generic version of the `reindex_all` I wrote in https://github.com/mysociety/alaveteli/pull/9415/changes, which can be used by the various models that don't need any ruby attributes in their `SearchDocument`s.

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
