### PR TITLE
Removed background color from `.correspondence`

### DIFF
--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -122,6 +122,11 @@ a.track-request-action {
   }
 }
 
+.correspondence_text,
+.event_actions {
+  background-color: #fff;
+}
+
 .correspondence__footer {
   background-color: #f4f4f4;
   border-top: 1px solid #ddd;


### PR DESCRIPTION
## Relevant issue(s)

Fixes part of: https://github.com/mysociety/alaveteli/issues/9294

## What does this do?
Instead the white background is being applied to the correspondence text and event actions. This prevents the odd white corners on top of the correspondence when it has rounded corners.

## Why was this needed?
When `.correspondence` has round corners there is an odd sharp edge coming from the white background from the element. Normally you would apply `overflow: hidden` to prevent it from happening, but we are using `position: sticky`, so we can't use overflow hidden.

## Implementation notes
This PR precedes this [WDTK one](https://github.com/mysociety/whatdotheyknow-theme/pull/2142)

## Screenshots
It's a two part PR. [Screenshots here](https://github.com/mysociety/whatdotheyknow-theme/pull/2142)

## Notes to reviewer

<hr>

[skip changelog]
