### PR TITLE
Update docs/developers/ pages for Alaveteli 0.46.7.0

### DIFF
--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -77,6 +77,10 @@ as follows:
     * attachments to the correspondence.  Attachments can only be attached to messages in the `response` direction
 * `/api/v2/request/<id>/update.json` - POST a new state for the request:
   * as form variable `state` - the user's assessment of the `state` of a request that has received a response from the authority. Allowable values: `waiting_response`, `rejected`, `successful` and `partially_successful`. Should only be used for the user's feedback, an authority wishing to update the request `state` should use `/api/v2/request/<id>.json` instead
+* `/api/v2/body/<id>/request_events.<feed_type>` - GET a feed of the events (the messages sent) for requests made to the authority with the given `<id>`. This is only permitted for the authority that owns the API key `k`, so `<id>` must match that authority. `<feed_type>` is either `atom` or `json`. Optional query parameters:
+  * `since_date` - only include events on or after this date (format `yyyy-mm-dd`)
+  * `since_event_id` - only include events after the event with this id
+  The JSON feed returns an array of events, each with `request_id`, `event_id`, `created_at`, `event_type`, `request_url`, `request_email`, `title`, `body`, `user_name` and (where the request has an associated user) `user_url`
 
 
 

--- a/docs/developers/api.md
+++ b/docs/developers/api.md
@@ -60,7 +60,7 @@ All requests must include an API key as a variable `k`. This key can be viewed
 on each authority's page in the admin interface. Other variables should be sent
 as follows:
 
-* `/api/v2/request` - POST the following json data as a form variable `json` to create a new request:
+* `/api/v2/request.json` - POST the following json data as a form variable `request_json` to create a new request:
   * `title` - title for the request
   * `body` - body of the request
   * `external_user_name` - name of the person who originated the request
@@ -68,16 +68,15 @@ as follows:
   Returns JSON containing a `url` for the new request, and its `id`
 * `/api/v2/request/<id>.json` - GET full information about a request
 * `/api/v2/request/<id>.json` - POST additional correspondence regarding a request:
-  * as form variable `json`:
+  * as form variable `correspondence_json`:
     * `direction` - either `request` (from the user - might be a followup, reminder, etc) or `response` (from the authority)
     * `body` - the message itself
-    * `state` - optional, allows the authority to include an updated request `state` value when sending an update. Allowable values: `waiting_response`, `rejected`, `successful` and `partially_successful`. Only used in the `response` direction
     * `sent_at` - ISO-8601 formatted time that the correspondence was sent
+  * (optionally) the form variable `state` - allows the authority to include an updated request `state` value when sending an update. Allowable values: `waiting_response`, `rejected`, `successful` and `partially_successful`. Only used in the `response` direction
   * (optionally) the variable `attachments` as `multipart/form-data`:
     * attachments to the correspondence.  Attachments can only be attached to messages in the `response` direction
 * `/api/v2/request/<id>/update.json` - POST a new state for the request:
-  * as form variable `json`:
-    * `state` - the user's assessment of the `state` of a request that has received a response from the authority. Allowable values: `waiting_response`, `rejected`, `successful` and `partially_successful`. Should only be used for the user's feedback, an authority wishing to update the request `state` should use `/api/v2/request/<id>.json` instead
+  * as form variable `state` - the user's assessment of the `state` of a request that has received a response from the authority. Allowable values: `waiting_response`, `rejected`, `successful` and `partially_successful`. Should only be used for the user's feedback, an authority wishing to update the request `state` should use `/api/v2/request/<id>.json` instead
 
 
 

--- a/docs/developers/directory_structure.md
+++ b/docs/developers/directory_structure.md
@@ -39,9 +39,6 @@ website](http://guides.rubyonrails.org/getting_started.html).
           <em>static assets that require precompilation before being served</em>
           <dl>
               <dt>
-                  fonts
-              </dt>
-              <dt>
                   images
               </dt>
               <dt>
@@ -63,15 +60,36 @@ website](http://guides.rubyonrails.org/getting_started.html).
         helpers
       </dt>
       <dt>
+        javascript
+      </dt>
+      <dt>
+        jobs
+      </dt>
+      <dt>
+        mailboxes
+      </dt>
+      <dt>
         mailers
       </dt>
       <dt>
         models
       </dt>
+      <dt>
+        services
+      </dt>
+      <dt>
+        validators
+      </dt>
       <dt class="last">
         views
       </dt>
     </dl>
+  </dd>
+  <dt>
+    bin
+  </dt>
+  <dd>
+    <p><em>executable wrapper scripts ("binstubs") for commands provided by the application and its gems, such as <code>rails</code> and <code>rake</code></em></p>
   </dd>
   <dt>cache
   </dt>
@@ -133,6 +151,18 @@ website](http://guides.rubyonrails.org/getting_started.html).
     </p>
   </dd>
   <dt>
+    docker
+  </dt>
+  <dd>
+    <p><em>a <a href="{{ page.baseurl }}/docs/installing/docker/">Docker environment</a> for running Alaveteli in development</em></p>
+  </dd>
+  <dt>
+    gems
+  </dt>
+  <dd>
+    <p><em>internal gems containing parts of Alaveteli's functionality</em></p>
+  </dd>
+  <dt>
     lib
   </dt>
   <dd>
@@ -159,6 +189,12 @@ website](http://guides.rubyonrails.org/getting_started.html).
       The translation strings are stored in <code>.po</code> files in directories specific to
       the locale and encoding. For example, <code>es/</code> contains the translations for the Spanish site.
     </p>
+  </dd>
+  <dt>
+    locale_alaveteli_pro
+  </dt>
+  <dd>
+    <p><em>translations for Alaveteli Pro</em></p>
   </dd>
   <dt>
     log

--- a/docs/developers/directory_structure.md
+++ b/docs/developers/directory_structure.md
@@ -65,9 +65,9 @@ website](http://guides.rubyonrails.org/getting_started.html).
       <dt>
         jobs
       </dt>
-      <dt>
-        mailboxes
-      </dt>
+      <dd>
+          <em>background jobs run via Active Job.</em>
+      </dd>
       <dt>
         mailers
       </dt>
@@ -154,7 +154,12 @@ website](http://guides.rubyonrails.org/getting_started.html).
     docker
   </dt>
   <dd>
-    <p><em>a <a href="{{ page.baseurl }}/docs/installing/docker/">Docker environment</a> for running Alaveteli in development</em></p>
+    <p><em>files for running Alaveteli in Docker containers</em></p>
+    <p>
+      Includes the <code>Dockerfile</code>, entrypoint and bootstrap scripts,
+      and environment defaults used by the
+      <a href="{{ page.baseurl }}/docs/installing/docker/">Docker installation</a>.
+    </p>
   </dd>
   <dt>
     gems
@@ -240,10 +245,18 @@ website](http://guides.rubyonrails.org/getting_started.html).
   <dd class="last">
     <p><em>third-party software</em></p>
     <dl>
-      <dt class="last">bundle</dt>
+      <dt>assets</dt>
+      <dt class="last">javascript</dt>
       <dd class="last">
           <p>
-              <em>the bundle of gems needed to run Alaveteli</em>
+              <em>vendored third-party front-end assets and JavaScript.</em>
+          </p>
+          <p>
+              The gems needed to run Alaveteli are installed by
+              <a href="https://bundler.io/">Bundler</a> (into
+              <code>vendor/bundle</code> unless you configure a different path);
+              that directory is created at install time and is not part of the
+              git repository.
           </p>
       </dd>
     </dl>

--- a/docs/developers/i18n.md
+++ b/docs/developers/i18n.md
@@ -82,7 +82,8 @@ like `en_GB`; the Rails way is like `en-US`. Because we are using gettext and
 Transifex for translations, we must deal with both.
 
    * for the Rails version of the currently selected locale, use `I18n.locale`
-   * for the POSIX version of the locale, use `FastGettext.locale`
+   * for the POSIX version of the locale, use `AlaveteliLocalization.locale`
+     (a wrapper around `FastGettext.locale`)
 
 ## I18n in templates
 
@@ -97,7 +98,7 @@ Some hints for adding the strings into the Alaveteli code:
   strings that can be interpolated, so the variable has meaning. For example,
   ```<%= "Nothing found for '" + h(@query) + "'" %>``` might become ```<%=
   _("Nothing found for '{{search_terms}}'", :search_terms => h(@query)) %>```
-* Strings containing numbers:  ```<%= n_('%d request', '%d requests', @quantity) % @quantity %>```
+* Strings containing numbers:  ```<%= n_('{{count}} request', '{{count}} requests', @quantity, :count => @quantity) %>```
 * We allow some inline HTML where it helps with meaningful context, for example:
 
 ```
@@ -115,17 +116,14 @@ in the PublicBodies.
 The implementation allows for getting different locales of a PublicBody like so:
 
 ```ruby
-    PublicBody.with_locale("es") do
+    AlaveteliLocalization.with_locale("es") do
       puts PublicBody.find(230).name
     end
 ```
 
-Usually, that's all the code you need to know about. There's a method
-```self.locale_from_params()``` available on all models which returns a locale
-specified as ```locale=xx``` in the query string, and which falls back to the
-default locale, that you can use in conjunction with the ```with_locale```
-method above. All the joining on internal translation tables should usually be
-handled automagically -- but there are some exceptions, that follow below.
+Usually, that's all the code you need to know about. All the joining on
+internal translation tables should usually be handled automagically -- but
+there are some exceptions, that follow below.
 
 ### Overriding model field setters
 
@@ -148,24 +146,17 @@ machinery; something like:
 
 ### Searching
 
-The ```find_first_by_<attr>``` and ```find_all_by_<attr>``` magic methods
-should work. If you want to do a more programmatic search, you will need to
-join on the translation table. For example:
+If you want to do a programmatic search that includes a translated attribute,
+you will need to join on the translation table. For example:
 
 ```ruby
-          query = "#{translated_attr_name(someattr) = ? AND #{translated_attr_name('locale')} IN (?)"
-          locales = Globalize.fallbacks(locale || I18n.locale).map(&:to_s)
-          find(
-            :first,
-            :joins => :translations,
-            :conditions => [query, value, locales],
-            :readonly => false
-          )
+          PublicBody.joins(:translations).
+            where("public_body_translations.url_name = ?", name).
+            first
 ```
 
-You may also need to do some lower-level SQL joins or conditions. See
-```PublicBodyController.list``` for an example of a query that has a condition
-that is explicitly locale-aware (look for the ```locale_condition``` variable)
+There are several examples of this pattern in ```app/models/public_body.rb```,
+such as ```PublicBody.find_by_url_name_with_historic```.
 
 ## Internationalised Sorting
 

--- a/docs/developers/i18n.md
+++ b/docs/developers/i18n.md
@@ -59,10 +59,6 @@ To update the
 <a href="{{ page.baseurl }}/docs/glossary/#po" class="glossary__link">`.po` or `.pot` files</a>
 for each language, run:
 
-    bundle exec rake gettext:store_model_attributes
-
-followed by:
-
     bundle exec rake gettext:find
 
 If `gettext:find` only creates the file `locale/im-config.pot` then you need to

--- a/docs/developers/index.md
+++ b/docs/developers/index.md
@@ -9,10 +9,10 @@ title: For developers
     Alaveteli is an open source project. Full-time mySociety developers together with devs from all around the world actively contribute to the codebase. These notes and links will help you if you want to help too.
 </p>
 
-* The software is written in **Ruby on Rails 4.x**. We support postgresql as
+* The software is written in **Ruby on Rails 8.x**. We support postgresql as
   the backend database. A configured mail transfer agent (MTA) like exim,
   postfix or sendmail is necessary to parse incoming emails. We have production
-  sites deployed on Debian (Wheezy) and Ubuntu (14.04 LTS). For performance
+  sites deployed on Debian and Ubuntu. For performance
   reasons, we recommend the use of [Varnish](https://www.varnish-cache.org).
 
 * To help you understand what the code is doing, read this [high-level

--- a/docs/developers/overview.md
+++ b/docs/developers/overview.md
@@ -17,8 +17,8 @@ The main entity is **InfoRequest**, which represents a request for information b
 which represents the initial email.
 
 Once an InfoRequest is made, its state is tracked using **InfoRequestEvents**. For
-example, a new InfoRequest has an initial state of `awaiting_response` and an
-associated InfoRequestEvent of type `initial_request`. An InfoRequest event can
+example, a new InfoRequest has an initial state of `waiting_response` and an
+associated InfoRequestEvent of type `sent`. An InfoRequest event can
 have an OutgoingMessage or an IncomingMessage or neither associated with it.
 
 Replies are received by the system by piping raw emails (represented by a **RawEmail**)
@@ -38,7 +38,7 @@ out.)
 The **MailServerLog** is a representation of the parsed MTA log files.
 MailServerLog entries are created by a cron job that runs
 `script/load-mail-server-logs`. This checks incoming emails and matches them
-to InfoRequests; then `script/check-recent-requests-send` checkes these logs to
+to InfoRequests; then `script/check-recent-requests-sent` checks these logs to
 ensure they have an envelope-from header set (to combat spam).
 
 ## Schema diagram


### PR DESCRIPTION
## Relevant issue(s)

N/A

## What does this do?

Brings the five pages under `docs/developers/` up to date with the latest Alaveteli release (0.46.7.0, Rails 8.0.4):

- **index.md**: Rails 4.x → Rails 8.x; drops the obsolete "Debian (Wheezy) and Ubuntu (14.04 LTS)" version qualifiers.
- **overview.md**: corrects the initial request state to `waiting_response` (was `awaiting_response`) and the initial InfoRequestEvent type to `sent` (was `initial_request`); fixes the script name `check-recent-requests-sent` and a "checkes" typo.
- **api.md**: the create endpoint is `/api/v2/request.json` and takes form variable `request_json` (not `json`); correspondence is posted as `correspondence_json` with `state` as a separate top-level form variable; the update endpoint likewise takes `state` directly rather than nested in a `json` variable; documents the previously-missing `/api/v2/body/<id>/request_events.<feed_type>` feed endpoint, including its `since_date`/`since_event_id` parameters and JSON feed fields.
- **directory_structure.md**: adds the `bin/`, `docker/`, `gems/` and `locale_alaveteli_pro/` top-level directories and the `app/javascript`, `app/jobs`, `app/services` and `app/validators` subdirectories; removes `app/assets/fonts`, which no longer exists; expands the `docker/` description; replaces the `vendor/bundle` listing with the `vendor/assets` and `vendor/javascript` directories that are actually in the repository, noting that `vendor/bundle` is only created at install time.
- **i18n.md**: `PublicBody.with_locale` → `AlaveteliLocalization.with_locale`; removes the reference to the long-gone `locale_from_params` method; replaces the removed `find_first_by_`/`find_all_by_` dynamic finders and Rails 2-era `find(:first, ...)` example with the `joins(:translations)` pattern actually used in `app/models/public_body.rb`; updates the plural translation example to the `{{count}}` interpolation style; points at `AlaveteliLocalization.locale` as the wrapper for `FastGettext.locale`; drops the obsolete `gettext:store_model_attributes` step from the translation-update instructions (its output file is gitignored and consumed by nothing in the codebase).

## Why was this needed?

These pages described Alaveteli as it was around 2014: Rails 4, Debian Wheezy, dynamic finders and API parameter names that no longer match the code. Developers following them would hit wrong API parameters (`json` vs `request_json`/`correspondence_json`), wrong event/state names, a directory listing missing several directories that now exist, and would never learn about the request_events API feed. All corrections were verified against the 0.46.7.0 release source (`app/controllers/api_controller.rb`, `config/routes.rb`, `app/models/info_request.rb`, `app/models/info_request_event.rb`, `app/models/public_body.rb`, `lib/alaveteli_localization.rb`, `lib/tasks/gettext.rake`, `Gemfile`, `config/general.yml-example`, and the actual directory layout).

## Implementation notes

- Changes are deliberately conservative: no restructuring, no prose-style rewrites, Jekyll front matter and Liquid tags untouched, English pages only.
- The api.md nesting change (moving `state` out of the JSON variable) mirrors `ApiController#add_correspondence`/`#update_state`, which read `params["state"]` directly.
- The request_events feed documentation matches `ApiController#body_request_events`: the endpoint is restricted to the authority owning the API key, `<feed_type>` is `atom` or `json`, and the JSON event fields are listed as emitted (with `user_url` only present when the request has an associated user).
- An earlier revision of this branch listed `app/mailboxes`; that directory exists only on `develop`, not in 0.46.7.0, so it was removed again. It (and `develop`'s newer gem versions, e.g. Globalize 7.1.x vs 7.0.0 here) will become relevant in the next release.
- The 2012 schema diagram in overview.md was left as-is; it is presented as a dated snapshot and regenerating it is out of scope.

## Screenshots

N/A

## Notes to reviewer

- index.md still says production sites run on "Debian and Ubuntu" (versions removed rather than replaced, as current production OS versions aren't verifiable from the source repo).
- index.md's mention of a "suitable for volunteers" issue label was left unchanged: the repo now has `x:volunteer` and `more-volunteers` labels, but neither has a description confirming intent.
- The i18n.md "Overriding model field setters" section was left alone; Globalize is still in use (`~> 7.0.0` at 0.46.7.0) and the advice is generic, though no in-codebase example of `globalize.write` setter overrides remains.

## AI disclosure

This change was prepared with the assistance of AI coding agents (opencode, coordinated via Orca orchestration), working under human direction. All edits were verified by the agents against the Alaveteli source at the 0.46.7.0 release tag. Please review with the usual scrutiny and flag anything that reads as unverified.

---

Have you updated the changelog? [skip changelog] - documentation-site-only change.
