### PR TITLE
Update docs/installing/ pages for Alaveteli 0.46.7.0

### DIFF
--- a/docs/installing/ami.md
+++ b/docs/installing/ami.md
@@ -34,7 +34,7 @@ you must
     <strong>What's in the AMI?</strong>
     The AMI gives you exactly the same thing as the
     <a href="{{ page.baseurl }}/docs/installing/script/">installation script</a>
-    does. You get an Alaveteli website powered by Rails running the Thin
+    does. You get an Alaveteli website powered by Rails running the Puma
     application server under nginx, using a postgreSQL database. All this
     running on Amazon's EC2 servers, ready to be
     <a href="{{ page.baseurl }}/docs/customising/">configured and customised</a>.

--- a/docs/installing/cron_and_daemons.md
+++ b/docs/installing/cron_and_daemons.md
@@ -45,6 +45,7 @@ Change the variables to suit your installation.
       DEPLOY_USER=alaveteli \
       VHOST_DIR=/var/www \
       VCSPATH=alaveteli \
+      SITE=alaveteli \
       MAILTO=alaveteli \
       CRONTAB=/var/www/alaveteli/config/crontab-example > /etc/cron.d/alaveteli
     popd
@@ -226,7 +227,7 @@ useful to you. Change the variables to suit your installation.
       DEPLOY_USER=alaveteli \
       VHOST_DIR=/var/www \
       VCSPATH=alaveteli \
-      DAEMON=poll-for-incoming.service > /etc/systemd/system/alaveteli-poll-for-incoming.service
+      DAEMON=poll-for-incoming > /etc/systemd/system/alaveteli-poll-for-incoming.service
     popd
 
     chown root:alaveteli /etc/systemd/system/alaveteli-poll-for-incoming.service

--- a/docs/installing/deploy.md
+++ b/docs/installing/deploy.md
@@ -13,6 +13,15 @@ title: Deploying
   Alaveteli provides a deployment mechanism using Capistrano.
 </p>
 
+<div class="attention-box danger">
+  <p>
+    The Capistrano deployment mechanism has not been actively maintained for
+    some years and has been removed from Alaveteli's <code>develop</code>
+    branch, so it will not be included in releases after the 0.46.5 series.
+    We do not recommend setting up new deployments with it.
+  </p>
+</div>
+
 ## Why deploy?
 
 Although you can [install Alaveteli]({{ page.baseurl }}/docs/installing/) in a number
@@ -81,7 +90,7 @@ Next, on your local machine:
 
 * install Capistrano:
    * Capistrano requires Ruby 1.9 or more, and can be installed using rubygems
-   * do: `gem install capistrano -v 2.15.9`
+   * do: `gem install capistrano -v 2.15.11`
 * install Bundler if you don't have it already -- do: `gem install bundler`
 * checkout the [Alaveteli repo](https://github.com/mysociety/alaveteli/) (you
   need some of the files available locally even though you might not be running

--- a/docs/installing/deploy.md
+++ b/docs/installing/deploy.md
@@ -6,199 +6,34 @@ title: Deploying
 # Deploying Alaveteli
 
 <p class="lead">
-  Although you can install Alaveteli and just change it when you need it, we
-  recommend you adopt a way of <strong>deploying</strong> it automatically,
-  especially on your
-  <a href="{{ page.baseurl }}/docs/glossary/#production" class="glossary__link">production server</a>.
-  Alaveteli provides a deployment mechanism using Capistrano.
+  Alaveteli used to ship with a deployment mechanism based on Capistrano.
+  This mechanism is deprecated and is being removed from Alaveteli.
 </p>
 
 <div class="attention-box danger">
   <p>
     The Capistrano deployment mechanism has not been actively maintained for
     some years and has been removed from Alaveteli's <code>develop</code>
-    branch, so it will not be included in releases after the 0.46.5 series.
-    We do not recommend setting up new deployments with it.
+    branch. It still ships in the 0.46.7.0 release, but it will not be
+    included in future releases. Do not set up new deployments with it. The
+    detailed Capistrano instructions that used to live on this page have been
+    removed.
   </p>
 </div>
 
-## Why deploy?
-
-Although you can [install Alaveteli]({{ page.baseurl }}/docs/installing/) in a number
-of ways, once you're running, sooner or later you'll need to make changes to
-the site. A common example is updating your site when we issue a new release.
-
-The deployment mechanism takes care of putting all the right files into the
-right place, so when you need to put changes live, there's no risk of you
-forgetting the update all the files you've changed, or breaking the
-configuration by accident. Instead, deployment does all this for you
-automatically. It's also more efficient because it is faster than making
-changes or copying files by hand, so your site will be down for the shortest
-possible time.
-
-We **strongly recommend** you use the deployment mechanism for your
+We still recommend adopting a repeatable, automated way of deploying changes
+to your
 <a href="{{ page.baseurl }}/docs/glossary/#production" class="glossary__link">production server</a>
-and, if you're running one, your
-<a href="{{ page.baseurl }}/docs/glossary/#staging" class="glossary__link">staging server</a> too.
+— it means there's no risk of forgetting to update a file by hand, and your
+site is down for the shortest possible time when you put changes live.
 
-## Capistrano
+To set up a server, follow the
+[manual installation instructions]({{ page.baseurl }}/docs/installing/manual_install/)
+(or use the [installation script]({{ page.baseurl }}/docs/installing/script/)).
+To automate subsequent deployments, use standard deployment tooling of your
+choice (for example configuration management or your own scripts around
+`git pull` and `script/rails-post-deploy`), and remember to run
+`script/rails-post-deploy` after each software update.
 
-<a href="{{ page.baseurl }}/docs/glossary/#capistrano" class="glossary__link">Capistrano</a>
-is included as part of Alaveteli as a standard deployment system.
-
-The basic principle of Capistrano is that you execute `cap [do-something]`
-commands on your local machine, and Capistrano connects to your server (using
-`ssh`) and does the corresponding task there for you.
-
-### Set up
-
-Capistrano requires things to be set up at both ends -- that is, on the server
-where you want Alaveteli to run, and on your own local machine.
-
-* *the server* is the machine that will be running the Alaveteli
-  instance you're deploying
-
-* your *local machine* may be your laptop or similar device -- as well as those
-  belonging to anyone in your team whom you want to be able to deploy
-
-In order to allow the Capistrano deployment mechanism work, you need to set up
-the server so that the Alaveteli app is being served from a directory called
-`current`. Once you've done that, deploying a new version is essentially
-creating a timestamped sister directory to the `current` directory, and
-switching the symlink `current` from the old timestamped directory to the new
-one. Things that need to persist between deployments, like config files, are
-kept in a `shared` directory that is at the same level, and symlinked-to from
-each timestamped deploy directory.
-
-We're [working on making this easier](https://github.com/mysociety/alaveteli/issues/1596),
-but for now, here's the manual process you need to follow to set up this
-deployment mechanism. Remember, you only have to do this once to set it up,
-and thereafter you'll be able to deploy very easily (see [usage, below](#usage)).
-
-First, on the server:
-
-* [install Alaveteli]({{ page.baseurl }}/docs/installing/)
-* give the Unix user that runs Alaveteli the ability to ssh to your server. Either give them a password or, preferably, set up ssh keys for them so they can ssh from your local machine to the server:
-   * to give them a password (if they don't already have one) - `sudo passwd [UNIX-USER]`. Store this password securely on your local machine e.g in a password manager
-   * to set up ssh keys for them, follow the instructions in the [capistrano documentation](http://capistranorb.com/documentation/getting-started/authentication-and-authorisation/). There's no need to set up ssh keys to the git repository as it is public.
-* make sure the Unix user that runs Alaveteli has write permissions on the parent directory of your Alaveteli app
-* move the Alaveteli app to a temporary place on the server, like your home
-  directory (temporarily, your site will be missing, until the deployment puts
-  new files in place)
-
-Next, on your local machine:
-
-* install Capistrano:
-   * Capistrano requires Ruby 1.9 or more, and can be installed using rubygems
-   * do: `gem install capistrano -v 2.15.11`
-* install Bundler if you don't have it already -- do: `gem install bundler`
-* checkout the [Alaveteli repo](https://github.com/mysociety/alaveteli/) (you
-  need some of the files available locally even though you might not be running
-  Alaveteli on this machine)
-* copy the example file `config/deploy.yml.example` to `config/deploy.yml`
-* now customise the deployment settings in that file: edit
-  `config/deploy.yml` appropriately -- for example, edit the name of the
-  server. Also, change `deploy_to` to be the path where Alaveteli is
-  currently installed on the server -- if you used the installation
-  script , this will be `/var/www/[HOST or alaveteli]/alaveteli`. Set
-  `daemon_name` to the name you used in setting up the [application
-  daemon]({{ page.baseurl }}/docs/installing/cron_and_daemons/#generate-application-daemon). The
-  default should be `alaveteli`.
-* `cd` into the Alaveteli repo you checked out (otherwise the `cap` commands you're about to
-  execute won't work)
-* still on your local machine, run `cap -S stage=staging deploy:setup` to setup capistrano on the server
-
-If you get an error `SSH::AuthenticationFailed`, and are not prompted for the password of the deployment user, you may have run into [a bug](http://stackoverflow.com/questions/21560297/capistrano-sshauthenticationfailed-not-prompting-for-password) in the net-ssh gem version 2.8.0. Try installing version 2.7.0 instead:
-
-    gem uninstall net-ssh
-
-    gem install net-ssh -v 2.7.0
-
-Back on the server:
-
-* copy the following config files from the temporary copy of Alaveteli you made at
-  the beginning (perhaps in your home directory) to the `shared` directory that
-  Capistrano just created on the server:
-   * `general.yml`
-   * `database.yml`
-   * `rails_env.rb`
-   * `aliases` &larr; if you're using Exim as your MTA
-* if you're using Exim as your MTA, edit the `aliases` file you just copied across
-  so that the path to Alaveteli includes the `current` element. If it was
-  `/var/www/alaveteli/alaveteli/script/mailin`, it should now be
-  `/var/www/alaveteli/alaveteli/current/script/mailin`.
-* copy the following directories from your temporary copy of Alaveteli to the
-  `shared` directory created by Capistrano on the server:
-   * `cache/`
-   * `files/`
-   * `lib/acts_as_xapian/xapiandbs` (copy this to straight into `shared` so it becomes `shared/xapiandbs`)
-   * `log/`
-
-If you're using [rbenv](https://github.com/mysociety/alaveteli/wiki/Migrating-an-existing-Alaveteli-site-from-ruby-1.8.7#3-install-a-ruby-version-manager-optional), you can add a
-`rbenv-version` containing the ruby string to the `shared` directory.
-Alaveteli's deployment configuration will automatically recognise this and use
-the specified Ruby version.
-
-Now, back on your local machine:
-
-* make sure you're still in the Alaveteli repo (if not, `cd` back into it)
-* run `cap -S stage=staging  deploy:update_code` to get a code checkout on the server.
-* create a deployment directory on the server by running *one* of these commands:
-   * `cap deploy` if you're deploying a <a href="{{ page.baseurl }}/docs/glossary/#staging" class="glossary__link">staging site</a>, or...
-   * `cap -S stage=production deploy` for <a href="{{ page.baseurl }}/docs/glossary/#production" class="glossary__link">production</a>
-
-Back on the server:
-
-* update the webserver config (either apache or nginx) to add the `current` element
-  to the path where it is serving Alaveteli from. If you installed using the
-  installation script, this will be replacing `/var/www/alaveteli/alaveteli/` with
-  `/var/www/alaveteli/alaveteli/current` in `/etc/nginx/sites-available/default`.
-* edit the server crontab so that the paths in the cron jobs also include the
-  `current` element. If you used the installation script the crontab will be in
-  `etc/cron.d/alaveteli`.
-* Update the MTA config to include the `current` element in the paths it uses.
-  If you installed using the installation script, the MTA will be postfix,
-  and you will need to edit  `/etc/postfix/master.cf` to replace
-  `argv=/var/www/alaveteli/alaveteli/script/mailin` with
-  `argv=/var/www/alaveteli/alaveteli/current/script/mailin`.
-  If you're using Exim as your MTA, edit `etc/exim4/conf.d/04_alaveteli_options`
-  to update the `ALAVETELI_HOME` variable to the new Alaveteli path. Restart the MTA after you've made these changes.
-
-* You will also need to update the path to Alaveteli in your [init scripts]({{ page.baseurl }}/docs/installing/manual_install/#cron-jobs-and-init-scripts).
-  You should have a script for running the alert tracks
-  (`/etc/init.d/foi-alert-tracks`), and possibly scripts for purging the
-  varnish cache (`/etc/init.d/foi-purge-varnish`), and restarting the
-  app server (`/etc/init.d/alaveteli`).
-
-Phew, you're done!
-
-You can delete the temporary copy of Alaveteli (perhaps in your
-home directory) now.
-
-### Usage
-
-Before you issue any Capistrano commands, `cd` into the checkout of the
-Alaveteli repo on your local machine (because that's where it will look
-for the config that you've set up).
-
-Ensure you've got a `config/deploy.yml` file with the correct settings for your
-site. If there are other people in your team who need to deploy, you'll need to
-share it with them too -- it might be a good idea to keep the latest
-version in a private [Gist](http://gist.github.com/).
-
-* to deploy to staging, just run `cap deploy`
-* to deploy to production, run `cap -S stage=production deploy`
-
-You might notice that, after deploying, the old deploy directory is still there
--- that is, the one that was `current` until you replaced it with the new one.
-By default, the deploy mechanism keeps the last five deployments there. Run
-`cap deploy:cleanup` to tidy up older versions.
-
-For additional usage instructions, see the [Capistrano
-website](http://capistranorb.com/).
-
-### Whoops, that's not what I expected
-
-If a deployment goes wrong, or you discover after doing it that you're not
-ready for the latest version after all, don't panic! Run `cap deploy:rollback`
-and it will switch `current` back to the previous deployment.
+If you have questions about deploying Alaveteli, ask on the
+[alaveteli-dev Google group](https://groups.google.com/forum/#!forum/alaveteli-dev).

--- a/docs/installing/docker.md
+++ b/docs/installing/docker.md
@@ -57,6 +57,13 @@ create your own <a href="{{ page.baseurl }}/docs/glossary/#theme" class="glossar
 The supplied scripts in the `./docker` directory will create you a Docker
 container which has everything you need to work on Alaveteli.
 
+The setup script expects to find a directory named `alaveteli-themes` alongside
+your Alaveteli checkout (this is where it will clone the default theme, and
+where the container looks for your themes). Create it if it doesn't already
+exist:
+
+        mkdir -p ../alaveteli-themes
+
 To create a Docker container with Alaveteli installed, run the setup script:
 
         ./docker/setup

--- a/docs/installing/email.md
+++ b/docs/installing/email.md
@@ -639,8 +639,8 @@ valid "To" address for a request in your system.  You can do this
 through your site's admin interface, or from the command line,
 like so:
 
-    $ ./script/console
-    Loading development environment (Rails 2.3.14)
+    $ bin/rails console
+    Loading development environment
     >> InfoRequest.find_by_url_title("why_do_you_have_such_a_fancy_dog").incoming_email
     => "request-101-50929748@localhost"
 
@@ -658,7 +658,7 @@ means there was a problem.  For example:
 The `mailin` script emails the details of any errors to
 `CONTACT_EMAIL` (from your `general.yml` file). A common problem is
 for the user that the MTA runs as not to have write access to
-`files/raw_emails/`.
+the `storage/` directory, where raw emails are stored.
 
 If everything seems fine locally, you should also check from another
 computer connected to the Internet that the DNS for your chosen

--- a/docs/installing/index.md
+++ b/docs/installing/index.md
@@ -27,8 +27,8 @@ not really getting lots of traffic).
 A **production** site is different: you want your production site to run as
 efficiently as possible, so things like caching are switched on, and debug
 messages switched off. It's also important to be able to deploy changes to a
-production site quickly and efficiently, so we recommend you use a
-[deployment mechanism]({{ page.baseurl }}/docs/installing/deploy/) too.
+production site quickly and efficiently, so we recommend you adopt a
+repeatable [deployment process]({{ page.baseurl }}/docs/installing/deploy/) too.
 
 ## The installation path
 
@@ -97,7 +97,8 @@ The other install methods will do this for you.
 
 ## Deployment
 
-When you set up your production server, we **strongly recommend** you
-use the Capistrano [deployment mechanism]({{ page.baseurl }}/docs/installing/deploy/)
-that's included with Alaveteli. Set this up and you never have to edit files on
-those servers, because Capistrano takes care of that for you.
+When you set up your production server, we recommend you adopt a repeatable,
+automated [deployment process]({{ page.baseurl }}/docs/installing/deploy/).
+Set this up and you never have to edit files on those servers by hand. Note
+that the Capistrano deployment mechanism that used to ship with Alaveteli is
+deprecated and is being removed.

--- a/docs/installing/index.md
+++ b/docs/installing/index.md
@@ -61,7 +61,7 @@ Depending on the resources you have available, it might be that your staging ser
 
 <div class="attention-box info">
     Although we recommend Docker for development, there are of course other ways
-    to install Alaveteli. Our Dockerdile is not suitable for production (but
+    to install Alaveteli. Our Dockerfile is not suitable for production (but
     remember that you won't need a production site until you've done a
     development deployment). For your own server, there's an installation script
     which does most of the work for you, or you can follow the manual

--- a/docs/installing/macos.md
+++ b/docs/installing/macos.md
@@ -6,154 +6,25 @@ title: Installing on MacOS X
 # Installation on MacOS X
 
 <p class="lead">
-  We don't recommend using OS X in production, but if you want to get
-  Alaveteli running on your Mac for development, these guidelines should
-  help.
+  Native installation on macOS is no longer maintained. If you want to get
+  Alaveteli running on your Mac for development, we recommend using Docker.
 </p>
 
 Note that there are [other ways to install Alaveteli]({{ page.baseurl }}/docs/installing/).
 
-## MacOS X 10.7
+## Use Docker for development on macOS
 
-Follow these instructions to get Alaveteli running locally on an OS X machine. These instructions have been tested with Xcode 4.1 on OS X Lion (10.7). We do not recommend using OS X in production.
+The older native macOS installation instructions (covering Homebrew, RVM and
+old versions of Ruby and PostgreSQL) are out of date and no longer supported.
 
-**Note:** This guide is currently incomplete. Please help by posting issues to the [alaveteli-dev Google group](https://groups.google.com/group/alaveteli-dev) or by submitting pull requests.
+Instead, the recommended way to get a development site running on a Mac is to
+[install into a Docker development container]({{ page.baseurl }}/docs/installing/docker/).
+Docker takes care of the dependencies for you and gives you a consistent
+environment that matches the one we test against, so you don't need to install
+and configure everything by hand on macOS.
 
-## Xcode
+## Advanced or production installations
 
-If you are using OS X Lion, download *Command Line Tools for Xcode* from [Apple](https://developer.apple.com/downloads/index.action). This is a new package from Apple that provides the command-line build tools separate from the rest of Xcode. You need to register for a free Apple Developer account.
-
-**Note:** As of Xcode 4.2, a non-LLVM version of GCC is no longer included. Homebrew has dealt with it by [switching to Clang](https://github.com/mxcl/homebrew/issues/6852). However, you may encounter errors installing RVM. *Please report these on the [mailing list](https://groups.google.com/group/alaveteli-dev).* The following instructions have been tested with Xcode 4.1. If necessary, you can install GCC from Xcode 4.1 by running:
-
-    brew install https://github.com/adamv/homebrew-alt/raw/master/duplicates/apple-gcc42.rb
-
-## Homebrew
-
-Homebrew is a package manager for OS X. It is preferred over alternatives such as MacPorts and Fink. If you haven't already installed Homebrew, run the command:
-
-    ruby <(curl -fsSkL raw.github.com/mxcl/homebrew/go)
-
-Next, install packages required by Alaveteli:
-
-    brew install catdoc elinks gnuplot gs imagemagick libmagic libyaml links mutt poppler tnef wkhtmltopdf wv xapian unrtf
-
-
-### Install postgresql
-
-Alaveteli uses PostgreSQL by default. If you've tested Alaveteli with MySQL or SQLite, let us know in the [alaveteli-dev Google group](https://groups.google.com/group/alaveteli-dev).
-
-    brew install postgresql
-    initdb /usr/local/var/postgres
-    mkdir -p ~/Library/LaunchAgents
-    cp /usr/local/Cellar/postgresql/9.0.4/org.postgresql.postgres.plist ~/Library/LaunchAgents/
-    launchctl load -w ~/Library/LaunchAgents/org.postgresql.postgres.plist
-
-## PDF Toolkit
-
-[Download the installer package](https://github.com/downloads/robinhouston/pdftk/pdftk.pkg) and install.
-
-## Ruby
-
-### Install RVM
-
-RVM is the preferred way to install multiple Ruby versions on OS X. Alaveteli uses Ruby 1.8.7. The following commands assume you are using the Bash shell.
-
-    curl -L https://get.rvm.io | bash -s stable
-
-Read `rvm notes` and `rvm requirements` carefully for further instructions. Then, install Ruby:
-
-    rvm install 1.8.7
-    rvm install 1.9.3
-    rvm use 1.9.3 --default
-
-### Install mahoro and pg with flags
-
-The `mahoro` and `pg` gems require special installation commands. Rubygems must be downgraded to 1.6.2 to avoid deprecation warnings when running tests.
-
-    rvm 1.8.7
-    gem update --system  2.1.11
-    gem install mahoro -- --with-ldflags="-L/usr/local/Cellar/libmagic/5.09/lib" --with-cppflags="-I/usr/local/Cellar/libmagic/5.09/include"
-    env ARCHFLAGS="-arch x86_64" gem install pg
-
-#### Update
-
-As of August 22, 2012 or earlier, you can install `mahoro` in Ruby 1.9.3 on OS X 10.7 Lion with:
-
-    brew install libmagic
-    gem install mahoro
-
-## Alaveteli
-
-The following is mostly from [the manual installation process]({{ page.baseurl }}/docs/installing/manual_install).
-
-### Configure database
-
-Create a database for your Mac user as homebrew doesn't create one by default:
-
-    createdb
-
-Create a `foi` user from the command line, like this:
-
-    createuser -s -P foi
-
-_Note:_ After running this command you will be prompted to set a
-password for the user. Don't leave it blank if you are new to
-PostgreSQL, or it could be difficult to set later for you.
-
-We'll create a template for our Alaveteli databases:
-
-    createdb -T template0 -E UTF-8 template_utf8
-    echo "update pg_database set datistemplate=true where datname='template_utf8';" | psql
-
-Then create the databases:
-
-    createdb -T template_utf8 -O foi alaveteli_production
-    createdb -T template_utf8 -O foi alaveteli_test
-    createdb -T template_utf8 -O foi alaveteli_development
-
-### Clone Alaveteli
-
-    git clone https://github.com/mysociety/alaveteli.git
-    cd alaveteli
-    git submodule init
-    git submodule update
-
-
-### Configure Alaveteli
-
-Copy the example configuration files and configure `database.yml`.
-
-    cp -f config/general.yml-example config/general.yml
-    cp -f config/memcached.yml-example config/memcached.yml
-    cp -f config/database.yml-example config/database.yml
-    sed -i~ 's/<username>/foi/' config/database.yml
-    sed -i~ 's/<password>/foi/' config/database.yml
-    sed -i~ 's/  port: 5432//' config/database.yml
-    sed -i~ 's/ # PostgreSQL 8.1 pretty please//' config/database.yml
-
-### Bundler
-
-Install the gems and finish setting up Alaveteli.
-
-    rvm 1.8.7
-    bundle
-    bundle exec rake db:create:all
-    bundle exec rake db:migrate
-    bundle exec rake db:test:prepare
-
-## Troubleshooting
-
-### Ruby version
-
-Ensure you are using the latest versions of Ruby. For example, some versions of Ruby 1.8.7 will segmentation fault, for example:
-
-```
-/Users/james/.rvm/gems/ruby-1.8.7-p357/gems/json-1.5.4/ext/json/ext/json/ext/parser.bundle: [BUG] Segmentation fault
-ruby 1.8.7 (2011-12-28 patchlevel 357) [i686-darwin11.3.0]
-```
-
-Running `rvm install 1.8.7` should install the latest Ruby 1.8.7 patch level. Remember to switch to the new Ruby version before continuing.
-
-### Rake tasks
-
-Remember to run Rake tasks with `bundle exec`. To run the tests, for example, run `bundle exec rake`.
+Docker is intended for local development and is not suitable for production.
+When you're ready to run a production site, install on a Linux server by
+following the [manual installation instructions]({{ page.baseurl }}/docs/installing/manual_install/).

--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -27,13 +27,13 @@ Note that there are [other ways to install Alaveteli]({{ page.baseurl }}/docs/in
 
 ### Target operating system
 
-These instructions assume a 64-bit version of Debian 7 (Wheezy)
-or 14.04 LTS (Trusty). Debian is the best supported deployment platform. We also
+These instructions assume a 64-bit version of Debian (bullseye, bookworm or
+trixie) or Ubuntu (focal or jammy). Debian is the best supported deployment platform. We also
 have instructions for [installing on MacOS]({{ page.baseurl }}/docs/installing/macos/).
 
 ### Set the locale
 
-**Debian Wheezy**
+**Debian**
 
 Follow the [Debian guide](https://wiki.debian.org/Locale#Standard) for configuring the locale of the operating system.
 
@@ -43,7 +43,7 @@ Generate the locales you wish to make available. When the interactive screen ask
 
 Start a new SSH session to use your SSH locale.
 
-**Ubuntu Trusty**
+**Ubuntu**
 
 Unset the default locale, as the SSH session should provide the locale required.
 
@@ -74,82 +74,8 @@ These are packages that the software depends on: third-party software used to
 parse documents, host the site, and so on. There are also packages that contain
 headers necessary to compile some of the gem dependencies in the next step.
 
-#### Using other repositories to get more recent packages
-
-Add the following repositories to `/etc/apt/sources.list`:
-
-**Debian Wheezy**
-
-    cat > /etc/apt/sources.list.d/debian-extra.list <<EOF
-    # Debian mirror to use, including contrib and non-free:
-    deb http://the.earth.li/debian/ wheezy main contrib non-free
-    deb-src http://the.earth.li/debian/ wheezy main contrib non-free
-
-    # Security Updates:
-    deb http://security.debian.org/ wheezy/updates main non-free
-    deb-src http://security.debian.org/ wheezy/updates main non-free
-    EOF
-
-
-#### Packages customised by mySociety
-
-If you're using Debian or Ubuntu, you should add the mySociety Debian archive to your
-apt sources. Note that mySociety packages are currently only built for 64-bit Debian.
-
-**Debian Wheezy**
-
-    cat > /etc/apt/sources.list.d/mysociety-debian.list <<EOF
-    deb http://debian.mysociety.org squeeze main
-    EOF
-
-The repository above lets you install `wkhtmltopdf-static` using `apt`.
-
-Add the GPG key from the
-[mySociety Debian Package Repository](http://debian.mysociety.org/).
-
-    wget -O - https://debian.mysociety.org/debian.mysociety.org.gpg.key | apt-key add -
-
-You should also configure package-pinning to reduce the priority of the
-mysociety Debian repository - we only want to pull wkhtmltopdf-static
-from mysociety.
-
-    cat >> /etc/apt/preferences <<EOF
-
-    Package: *
-    Pin: origin debian.mysociety.org
-    Pin-Priority: 50
-    EOF
-
-#### Other platforms
-If you're using some other linux platform, you can optionally install these
-dependencies manually, as follows:
-
-1. If you would like users to be able to get pretty PDFs as part of the
-downloadable zipfile of their request history, install
-[wkhtmltopdf](http://code.google.com/p/wkhtmltopdf/downloads/list). We
-recommend downloading the latest, statically compiled version from the project
-website, as this allows running headless (that is, without a graphical interface
-running) on Linux. If you do install `wkhtmltopdf`, you need to edit a setting
-in the config file to point to it (see below). If you don't install it,
-everything will still work, but users will get ugly, plain text versions of
-their requests when they download them.
-
-2. Version 1.44 of `pdftk` contains a bug which makes it loop forever in
-certain edge conditions. This is fixed in the standard 1.44.7 package which is available in wheezy (Debian) and raring (Ubuntu).
-
-If you can't get an official release for your OS with the fix, you can
-either hope you don't encounter the bug (it ties up a rails process
-until you kill it), patch it yourself, or use the
-[Debian](http://debian.mysociety.org/dists/squeeze/main/binary-amd64/)
-or
-[Ubuntu](https://launchpad.net/~mysociety/+archive/ubuntu/alaveteli/+packages)
-packages compiled by mySociety.
-
-#### Refresh sources
-
-Refresh the sources after adding the extra repositories:
-
-    apt-get -y update
+All the packages needed are available from the standard repositories of the
+supported Debian and Ubuntu releases, so no extra apt sources are required.
 
 ### Create Alaveteli User
 
@@ -185,26 +111,21 @@ The `--recursive` option installs mySociety's common libraries which are require
 
 Now install the packages relevant to your system:
 
-    # Debian Wheezy
-    apt-get -y install $(cat /var/www/alaveteli/config/packages.debian-wheezy)
-
-Some of the files also have a version number listed in config/packages - check
-that you have appropriate versions installed. Some also list "`|`" and offer a
-choice of packages.
+    xargs -a /var/www/alaveteli/config/packages.generic apt-get -y install
 
 <div class="attention-box">
 <strong>Note:</strong> To install Alaveteli's Ruby dependencies, you need to install bundler. In
 Debian and Ubuntu, this is provided as a package (installed as part of the
 package install process above). For other OSes, you could also install it as a gem:
 
-   <pre><code>sudo -u alaveteli gem install --user-install bundler --no-rdoc --no-ri</code></pre>
+   <pre><code>sudo -u alaveteli gem install --user-install bundler --no-document</code></pre>
 
 You should see a warning telling you that gem executables will not run as the application
 user doesn't have their local gem bin path in their path. Add it, making sure you use the ruby version
 directory you see in the warning message:
 
 <pre><code>cat >> /home/alaveteli/.bashrc <<EOF
-export PATH="\$HOME/.gem/ruby/1.9.1/bin:\$PATH"
+export PATH="\$HOME/.gem/ruby/3.4.0/bin:\$PATH"
 EOF
 exec $SHELL</code></pre>
 
@@ -244,7 +165,8 @@ send and receive emails.
 Full configuration for an MTA is beyond the scope of this document -- see the guide for [configuring the Exim4 or Postfix MTAs]({{ page.baseurl }}/docs/installing/email/).
 
 Note that in development mode mail is handled by [`mailcatcher`](http://mailcatcher.me/) by default so
-that you can see the mails in a browser. Start mailcatcher by running `bundle exec mailcatcher` in the application directory.
+that you can see the mails in a browser. Mailcatcher is not part of the application bundle, so install it
+with `gem install mailcatcher`, then start it by running `mailcatcher` in the application directory.
 
 ## Configure Alaveteli
 
@@ -321,7 +243,7 @@ compile native dependencies for `xapian-full`.
 Create the index for the search engine (Xapian):
 
     sudo -u alaveteli RAILS_ENV=production \
-      /var/www/alaveteli/script/rebuild-xapian-index
+      /var/www/alaveteli/script/destroy-and-rebuild-xapian-index
 
 If this fails, the site should still mostly run, but it's a core component so
 you should really try to get this working.
@@ -336,7 +258,7 @@ you should really try to get this working.
 
 Alaveteli can run under many popular application servers. mySociety recommends
 the use of [Phusion Passenger](https://www.phusionpassenger.com) (AKA
-mod_rails) or [thin](http://code.macournoyer.com/thin).
+mod_rails) or [Puma](https://puma.io).
 
 ### Using Phusion Passenger
 
@@ -348,31 +270,25 @@ run independently.
 
 See later in the guide for configuring the Apache web server with Passenger.
 
-### Using Thin
+### Using Puma
 
-Thin is a lighter-weight application server which can be run independently of
-a web server. Thin will be installed in the application bundle and used to run Alaveteli by default.
+Puma is a lighter-weight application server which can be run independently of
+a web server. Puma is installed in the application bundle and used to run Alaveteli by default.
 
 Run the following to get the server running:
 
     cd /var/www/alaveteli
-    bundle exec thin \
-      --environment=production \
-      --user=alaveteli \
-      --group=alaveteli \
-      --servers=1 \
-      start
+    sudo -u alaveteli RAILS_ENV=production \
+      bundle exec puma -C config/puma.rb
 
-By default the server listens on all interfaces. You can restrict it to the
-localhost interface by adding `--address=127.0.0.1`
+By default the server listens on all interfaces on port 3000. You can restrict
+it to the localhost interface by adding `-b tcp://127.0.0.1:3000`
 
 The server should have told you the URL to access in your browser to see the
 site in action.
 
-You can daemonize the process by starting it with the `--daemonize` option.
-
-Next we'll actually create a SysVinit daemon to run the application, so stop any
-thin processes you've started here.
+Next we'll actually create a systemd service to run the application, so stop any
+puma processes you've started here.
 
 ## Cron jobs and Daemons
 
@@ -389,9 +305,9 @@ going through the Rails stack, which improves performance.
 We recommend two main combinations of application and web server:
 
 - Apache &amp; Passenger
-- Nginx &amp; Thin
+- Nginx &amp; Puma
 
-There are ways to run Passenger with Nginx, and indeed Thin with Apache, but
+There are ways to run Passenger with Nginx, and indeed Puma with Apache, but
 that's out of scope for this guide. If you want to do something that isn't
 documented here, get in touch on [alaveteli-dev](https://groups.google.com/forum/#!forum/alaveteli-dev) and we'll
 be more than happy to help you get set up.
@@ -404,7 +320,7 @@ this guide, so pick the appropriate web server to configure.
 Install Apache with the Suexec wrapper:
 
     apt-get install -y apache2
-    apt-get install -y apache2-suexec
+    apt-get install -y apache2-suexec-pristine
 
 Enable the required modules
 
@@ -424,24 +340,10 @@ Create a directory for optional Alaveteli configuration
 Copy the example VirtualHost configuration file. You will need to change all
 occurrences of `www.example.com` to your URL
 
-**Debian Wheezy**
-
-    cp /var/www/alaveteli/config/httpd.conf-example \
-      /etc/apache2/sites-available/alaveteli
-
-**Ubuntu Trusty**
-
     cp /var/www/alaveteli/config/httpd.conf-example \
       /etc/apache2/sites-available/alaveteli.conf
 
 Disable the default site and enable the `alaveteli` VirtualHost
-
-**Debian Wheezy**
-
-    a2dissite default
-    a2ensite alaveteli
-
-**Ubuntu Trusty**
 
     a2dissite 000-default.conf
     a2ensite alaveteli.conf
@@ -463,14 +365,6 @@ Enable the SSL apache mod
 
 Copy the SSL configuration – again changing `www.example.com` to your domain –
 and enable the VirtualHost
-
-**Debian Wheezy**
-
-    cp /var/www/alaveteli/config/httpd-ssl.conf.example \
-      /etc/apache2/sites-available/alaveteli_https
-    a2ensite alaveteli_https
-
-**Ubuntu Trusty**
 
     cp /var/www/alaveteli/config/httpd-ssl.conf.example \
       /etc/apache2/sites-available/alaveteli_https.conf
@@ -504,7 +398,7 @@ Passenger (the application server).
 
     service apache2 graceful
 
-### Nginx (with Thin)
+### Nginx (with Puma)
 
 Install nginx
 
@@ -542,20 +436,16 @@ production server**. Replace `www.example.com` with your domain name.
       -subj /CN=www.example.com
     chmod 640 /etc/ssl/certs/www.example.com.cert
 
-If you have configured thin to use more than one server, you will need to edit the Alaveteli upstream
-directive in your <code>/etc/nginx/sites-enabled/alaveteli_https</code> file so
-that it has a `server` line for each instance you are running (otherwise nginx
-will only know how to send requests to the first server process). Each address
-line needs to have a unique port number - start at `3000` and add `1` for each
-new process. For example if you started your cluster with 4 servers, the
-upstream directive should look like this:
+Puma serves the site on port `3000` by default, which matches the Alaveteli
+upstream directive in your <code>/etc/nginx/sites-enabled/alaveteli_https</code> file:
 
     upstream alaveteli {
         server 127.0.0.1:3000;
-        server 127.0.0.1:3001;
-        server 127.0.0.1:3002;
-        server 127.0.0.1:3003;
     }
+
+If you run Puma on a different port, update the `server` line to match. To
+increase capacity, configure Puma to run more workers or threads (see
+`config/puma.rb`) rather than adding more `server` lines.
 
 Check the configuration and fix any issues
 
@@ -564,7 +454,7 @@ Check the configuration and fix any issues
 Reload the new nginx configuration and restart the application
 
     service nginx reload
-    service alaveteli restart
+    systemctl restart alaveteli-puma.service
 
 #### Running without SSL
 
@@ -584,28 +474,24 @@ Disable the default site and enable the `alaveteli` server
     ln -s /etc/nginx/sites-available/alaveteli \
       /etc/nginx/sites-enabled/alaveteli
 
-If you have configured thin to use more than one server, you will need to edit the Alaveteli upstream
-directive in your <code>/etc/nginx/sites-enabled/alaveteli</code> file so
-that it has a `server` line for each instance you are running (otherwise nginx
-will only know how to send requests to the first server process). Each address
-line needs to have a unique port number - start at `3000` and add `1` for each
-new process. For example if you started your cluster with 4 servers, the
-upstream directive should look like this:
+Puma serves the site on port `3000` by default, which matches the Alaveteli
+upstream directive in your <code>/etc/nginx/sites-enabled/alaveteli</code> file:
 
     upstream alaveteli {
         server 127.0.0.1:3000;
-        server 127.0.0.1:3001;
-        server 127.0.0.1:3002;
-        server 127.0.0.1:3003;
     }
+
+If you run Puma on a different port, update the `server` line to match. To
+increase capacity, configure Puma to run more workers or threads (see
+`config/puma.rb`) rather than adding more `server` lines.
 
 Check the configuration and fix any issues
 
     service nginx configtest
 
-Start the rails application with thin (if you haven't already).
+Start the rails application with Puma (if you haven't already).
 
-    service alaveteli start
+    systemctl start alaveteli-puma.service
 
 Reload the nginx configuration
 
@@ -618,7 +504,7 @@ Reload the nginx configuration
 
 Under all but light loads, it is strongly recommended to run the server behind
 an http accelerator like Varnish. A sample varnish VCL is supplied in
-`conf/varnish-alaveteli.vcl`.
+`config/varnish-alaveteli.vcl`.
 
 If you are using SSL you will need to configure an SSL terminator to sit in
 front of Varnish. If you're already using Apache as a web server you could

--- a/docs/installing/manual_install.md
+++ b/docs/installing/manual_install.md
@@ -76,6 +76,9 @@ headers necessary to compile some of the gem dependencies in the next step.
 
 All the packages needed are available from the standard repositories of the
 supported Debian and Ubuntu releases, so no extra apt sources are required.
+The packages themselves are listed in `config/packages.generic` and are
+installed in the [Install the dependencies](#install-the-dependencies) step
+below, once you have a copy of the Alaveteli source code.
 
 ### Create Alaveteli User
 
@@ -125,11 +128,48 @@ user doesn't have their local gem bin path in their path. Add it, making sure yo
 directory you see in the warning message:
 
 <pre><code>cat >> /home/alaveteli/.bashrc <<EOF
-export PATH="\$HOME/.gem/ruby/3.4.0/bin:\$PATH"
+export PATH="\$HOME/.gem/ruby/3.2.0/bin:\$PATH"
 EOF
 exec $SHELL</code></pre>
 
 </div>
+
+## Install Ruby
+
+Alaveteli requires Ruby 3.2.6 (see `.ruby-version.example` in the source).
+Most of the supported Debian and Ubuntu releases package an older version of
+Ruby, so unless your distribution's `ruby` package is at least this version,
+install the required version with [rbenv](https://github.com/rbenv/rbenv) and
+the [ruby-build](https://github.com/rbenv/ruby-build) plugin rather than using
+the system `ruby` package. (This is what the installation script does too.)
+
+First install the packages needed to build Ruby. These are listed in
+`config/packages.ruby-build`:
+
+    xargs -a /var/www/alaveteli/config/packages.ruby-build apt-get -y install
+
+Next, as the `alaveteli` user, install rbenv and the ruby-build plugin into
+that user's home directory:
+
+    su - alaveteli
+    git clone https://github.com/rbenv/rbenv.git ~/.rbenv
+    cd ~/.rbenv && src/configure && make -C src
+    git clone https://github.com/rbenv/ruby-build.git \
+      ~/.rbenv/plugins/ruby-build
+
+Add rbenv to the user's `PATH` and initialise it on login:
+
+    cat >> ~/.bashrc <<'EOF'
+    export PATH="$HOME/.rbenv/bin:$PATH"
+    eval "$(rbenv init -)"
+    EOF
+    exec $SHELL
+
+Install Ruby 3.2.6, set it as the default for this user, and install bundler:
+
+    rbenv install 3.2.6
+    rbenv global 3.2.6
+    gem install bundler
 
 ## Configure Database
 
@@ -167,6 +207,8 @@ Full configuration for an MTA is beyond the scope of this document -- see the gu
 Note that in development mode mail is handled by [`mailcatcher`](http://mailcatcher.me/) by default so
 that you can see the mails in a browser. Mailcatcher is not part of the application bundle, so install it
 with `gem install mailcatcher`, then start it by running `mailcatcher` in the application directory.
+This behaviour is controlled by the `USE_MAILCATCHER_IN_DEVELOPMENT` setting
+(default `true`) in `config/general.yml`.
 
 ## Configure Alaveteli
 
@@ -287,8 +329,9 @@ it to the localhost interface by adding `-b tcp://127.0.0.1:3000`
 The server should have told you the URL to access in your browser to see the
 site in action.
 
-Next we'll actually create a systemd service to run the application, so stop any
-puma processes you've started here.
+Next we'll actually create a systemd service to run the application (generated
+from `config/puma.service.example` in the cron jobs and daemons step below), so
+stop any puma processes you've started here.
 
 ## Cron jobs and Daemons
 
@@ -449,7 +492,7 @@ increase capacity, configure Puma to run more workers or threads (see
 
 Check the configuration and fix any issues
 
-    service nginx configtest
+    nginx -t
 
 Reload the new nginx configuration and restart the application
 
@@ -487,7 +530,7 @@ increase capacity, configure Puma to run more workers or threads (see
 
 Check the configuration and fix any issues
 
-    service nginx configtest
+    nginx -t
 
 Start the rails application with Puma (if you haven't already).
 
@@ -552,15 +595,6 @@ You should then be able to run the tests. Don't forget to restore <code>config/r
 
     See the [general email troubleshooting guide]({{ page.baseurl }}/docs/installing/email#general-email-troubleshooting).
 
-*   **Various tests fail with "Your PostgreSQL connection does not support
-    unescape_bytea. Try upgrading to pg 0.9.0 or later."**
-
-    You have an old version of `pg`, the ruby postgres driver.  In
-    Ubuntu, for example, this is provided by the package `libdbd-pg-ruby`.
-
-    Try upgrading your system's `pg` installation, or installing the pg
-    gem with `gem install pg`
-
 *   **Some of the tests relating to mail are failing, with messages like
     "when using TMail should load an email with funny MIME settings'
     FAILED"**
@@ -587,13 +621,12 @@ You should then be able to run the tests. Don't forget to restore <code>config/r
 
 *   **I'm seeing `rake: command not found` when running the post install script**
 
-    The script uses `rake`.
-
-    It may be that the binaries installed by bundler are not put in the
-    system `PATH`; therefore, in order to run `rake` (needed for
-    deployments), you may need to do something like:
-
-        ln -s /usr/lib/ruby/gems/1.8/bin/rake /usr/local/bin/
+    The script uses `rake`, which is installed by bundler. This usually means
+    the gem executables installed by bundler are not on your `PATH`. If you
+    installed Ruby with rbenv (see [Install Ruby](#install-ruby)), make sure
+    rbenv is initialised in your shell (`eval "$(rbenv init -)"`) and run
+    `rbenv rehash`. Otherwise, prefix the command with `bundle exec`, for
+    example `bundle exec rake`.
 
 
 

--- a/docs/installing/next_steps.md
+++ b/docs/installing/next_steps.md
@@ -34,7 +34,7 @@ First, in the browser:
 * Go to `/profile/sign_in` and create a user by signing up.
 * Check your email and confirm your account.
 * Type `bin/rails console` in the root of your Alaveteli installation (or if
-  using Docker, type `docker exec -it app bin/rails console`).
+  using Docker, type `docker compose exec app bin/rails console`).
 * Type `User.find_by(email: 'you@example.com').add_role(:admin)`, replacing the
   email with the email you used during sign up.
 

--- a/docs/installing/script.md
+++ b/docs/installing/script.md
@@ -11,6 +11,11 @@ title: Installation script
 
 Note that there are [other ways to install Alaveteli]({{ page.baseurl }}/docs/installing/).
 
+For a local development site we recommend the
+[Docker installation]({{ page.baseurl }}/docs/installing/docker/) instead, which
+takes care of the dependencies for you. The installation script described here
+is for setting up Alaveteli on your own server.
+
 ## Installing with the installation script
 
 If you have a clean installation of 64-bit Debian (bullseye, bookworm or
@@ -75,6 +80,19 @@ When the script has finished, you should have a working copy of the website,
 accessible via the hostname you supplied to the script. So, for this example, you could access the site in a browser at `http://alaveteli.10.10.10.30.nip.io`. The site runs using the Puma application server, behind the nginx webserver. By default, Alaveteli will be installed into `/var/www/[HOST]` on the server.
 
 The server will also be configured to accept replies to information request emails (as long as the MX record for the domain is pointing at the server). Incoming mail handling is set up using Postfix as the MTA.
+
+Behind the scenes, the commonlib `install-site.sh` script runs two scripts that
+live in the Alaveteli repository. You don't run these yourself; `install-site.sh`
+calls them for you:
+
+* `script/site-specific-install.sh` does the server-level setup as root:
+  installing system packages, nginx and Postfix, creating the PostgreSQL
+  user and database template, and installing the required Ruby version
+  (using rbenv and ruby-build) if the system Ruby is too old.
+* `script/install-as-user` then runs as the Unix user you specified to do the
+  user-level setup: installing the gems with Bundler, writing the
+  `config/general.yml` and `config/database.yml` files, creating the
+  databases, and loading the sample data.
 
 ## What next?
 

--- a/docs/installing/script.md
+++ b/docs/installing/script.md
@@ -13,10 +13,13 @@ Note that there are [other ways to install Alaveteli]({{ page.baseurl }}/docs/in
 
 ## Installing with the installation script
 
-If you have a clean installation of Debian Wheezy 64-bit or Ubuntu Trusty, you can
+If you have a clean installation of 64-bit Debian (bullseye, bookworm or
+trixie) or Ubuntu (focal or jammy), you can
 use an install script in our commonlib repository to set up a working instance
-of Alaveteli. This is not suitable for production (it runs in development mode,
-for example) but should set up a functional installation of the site, which can send and receive email.
+of Alaveteli. By default this sets up the site running in production mode; you
+can pass the `--dev` option instead to set up a local development environment.
+Either way, the script should set up a functional installation of the site,
+which can send and receive email.
 
 **Warning: only use this script on a newly installed server – it will make
 significant changes to your server’s setup, including modifying your nginx
@@ -29,10 +32,16 @@ To download the script, run the following command:
 
 If you run this script with `sh install-site.sh`, you'll see its usage message:
 
-    Usage: ./install-site.sh [--default] <SITE-NAME> <UNIX-USER> [HOST]
+    Usage: ./install-site.sh [--dev] [--default] [--systemd] [--docker] [--slim] <SITE-NAME> <UNIX-USER> [HOST]
     HOST is only optional if you are running this on an EC2 instance.
     --default means to install as the default site for this server,
     rather than a virtualhost for HOST.
+    --dev sets things up for a local development environment.
+    --docker is intended when running this script from a Dockerfile and
+    sets a number of other local variables controlling behaviour.
+    --slim similar to Docker, intended for builds without databases and other
+    backend applications included.
+    --systemd try and use a native systemd unit file rather than a sysvinit script.
 
 In this case `<SITE-NAME>` should be `alaveteli`. `<UNIX-USER>` is the name of
 the Unix user that you want to own and run the code. (This user will be created
@@ -44,12 +53,12 @@ you specified the `--default` option. This parameter is optional if you are on
 an EC2 instance, in which case the hostname of that instance will be used.
 
 For example, if you wish to use a new user called `alaveteli` and the hostname
-`alaveteli.127.0.0.1.xip.io`, creating a virtualhost just for that hostname,
+`alaveteli.127.0.0.1.nip.io`, creating a virtualhost just for that hostname,
 you could download and run the script with:
 
-    sudo sh install-site.sh alaveteli alaveteli alaveteli.127.0.0.1.xip.io
+    sudo sh install-site.sh alaveteli alaveteli alaveteli.127.0.0.1.nip.io
 
-([xip.io](http://xip.io/) is a helpful domain for development.)
+([nip.io](https://nip.io/) is a helpful domain for development.)
 
 Or, if you want to set this up as the default site on an EC2 instance, you
 could download the script, make it executable and then invoke it with:
@@ -63,7 +72,7 @@ If you have any problems or questions, please ask on the [Alaveteli Google
 ## What the install script does
 
 When the script has finished, you should have a working copy of the website,
-accessible via the hostname you supplied to the script. So, for this example, you could access the site in a browser at `http://alaveteli.10.10.10.30.xip.io`. The site runs using the thin application server, and the nginx webserver. By default, Alaveteli will be installed into `/var/www/[HOST]` on the server.
+accessible via the hostname you supplied to the script. So, for this example, you could access the site in a browser at `http://alaveteli.10.10.10.30.nip.io`. The site runs using the Puma application server, behind the nginx webserver. By default, Alaveteli will be installed into `/var/www/[HOST]` on the server.
 
 The server will also be configured to accept replies to information request emails (as long as the MX record for the domain is pointing at the server). Incoming mail handling is set up using Postfix as the MTA.
 

--- a/docs/installing/storage.md
+++ b/docs/installing/storage.md
@@ -39,8 +39,8 @@ options.
 
 ## Cloud services
 
-There are examples of the different cloud services (Amazon S3, Microsoft Azure,
-Google Cloud) supported by Active Storage in the example configuration.
+There are examples of the different cloud services (Amazon S3, Google Cloud)
+supported by Active Storage in the example configuration.
 
 ```
 amazon:
@@ -49,12 +49,6 @@ amazon:
   secret_access_key: ''
   region: ''
   bucket: ''
-
-azure:
-  service: AzureStorage
-  storage_account_name: ''
-  storage_access_key: ''
-  container: ''
 
 google:
   service: GCS

--- a/docs/installing/vagrant.md
+++ b/docs/installing/vagrant.md
@@ -5,8 +5,10 @@ title: Vagrant
 
 <div class="attention-box danger">
   <p>
-    Installing Alaveteli using Vagrant has been depreciated. We recommend using
-    <a href="{{ page.baseurl }}/docs/installing/docker/">Docker</a> instead.
+    Installing Alaveteli using Vagrant has been deprecated and the
+    <code>Vagrantfile</code> has been removed from the repository. We recommend
+    using <a href="{{ page.baseurl }}/docs/installing/docker/">Docker</a>
+    instead.
   </p>
 </div>
 


### PR DESCRIPTION
## Relevant issue(s)

N/A

## What does this do?

Brings the English `docs/installing/` pages up to date with what the Alaveteli 0.46.7.0 release and the commonlib install script actually ship:

- **script.md**: supported platforms are now Debian bullseye/bookworm/trixie and Ubuntu focal/jammy (was Wheezy/Trusty); reproduces the current `install-site.sh` usage message including the `--dev`, `--systemd`, `--docker` and `--slim` options; notes the default install now runs in production mode (with `--dev` for development); the site runs under Puma, not Thin; replaces the defunct xip.io development domain with nip.io; recommends Docker for local development sites; adds a "behind the scenes" explanation of the two repository scripts `install-site.sh` runs (`script/site-specific-install.sh` and `script/install-as-user`).
- **manual_install.md**: targets currently supported Debian/Ubuntu releases; removes the obsolete mySociety apt repository, wkhtmltopdf and pdftk sections; installs packages from `config/packages.generic` (the `packages.debian-wheezy` file no longer exists); adds an "Install Ruby" section covering rbenv/ruby-build and Ruby 3.2.6 (per `.ruby-version.example`, and matching what the install scripts do), with the user gem bin path corrected to `~/.gem/ruby/3.2.0`; replaces Thin with Puma throughout (matching the Gemfile, `config/puma.rb` and `config/puma.service.example`); fixes the renamed `script/destroy-and-rebuild-xapian-index`; notes mailcatcher must be installed as a gem and mentions the `USE_MAILCATCHER_IN_DEVELOPMENT` setting; fixes the varnish VCL path (`config/`, not `conf/`); modernises `gem install` flags, Apache site commands and nginx config checks (`nginx -t`); drops the obsolete pg-gem troubleshooting entry and updates the `rake: command not found` one for bundler/rbenv.
- **macos.md**: replaces the unmaintained native install walkthrough (OS X Lion, Xcode 4.1, Ruby 1.8.7, RVM) with a short page pointing developers at the Docker development setup, and at the manual install guide for production.
- **deploy.md / index.md**: the Capistrano deployment mechanism is deprecated — it has been removed from `develop` and, while it still ships in 0.46.7.0, it will not be in future releases. The detailed Capistrano instructions are removed and the page reduced to a notice pointing at the manual install guide and standard deployment tooling; the installing index no longer recommends Capistrano.
- **cron_and_daemons.md**: adds the required `SITE=` variable to the `config_files:convert_crontab` invocation and fixes the mail poller daemon name to `DAEMON=poll-for-incoming` — both commands failed as previously written.
- **docker.md / next_steps.md**: documents the `../alaveteli-themes` directory that `docker/bootstrap` requires before `./docker/setup` will run, and fixes the Rails console command to `docker compose exec app bin/rails console`.
- **vagrant.md**: notes the Vagrantfile has been removed from the repository and fixes a "depreciated" typo.
- **storage.md / email.md**: removes the Azure example no longer present in `config/storage.yml-example`; replaces `script/console` with `bin/rails console`; updates the raw email storage location to `storage/` (Active Storage); fixes a "Dockerdile" typo in index.md.
- **ami.md**: the AMI provides the same stack as the installation script, which now sets up Puma rather than Thin.

## Why was this needed?

Several of these pages still described a Debian Wheezy / Ubuntu Trusty / Thin / Capistrano era stack. Some documented commands fail outright against the current codebase (the crontab and poller daemon rake invocations, the Thin server commands, the `packages.debian-wheezy` file, `bundle exec mailcatcher`, `script/rebuild-xapian-index`), xip.io no longer exists as a service, and the macOS page documented a Ruby 1.8.7 toolchain that cannot run current Alaveteli. Capistrano is being dropped from Alaveteli, so the detailed setup instructions would send new installs down a dead end.

## Implementation notes

Every change was verified against the 0.46.7.0 release source: `Gemfile` (Puma 7.1; Capistrano still pinned at 2.15.11 in the release but removed on `develop`), `.ruby-version.example` (3.2.6), `lib/tasks/config_files.rake` (daemon names — including that `DAEMON=poll-for-incoming` takes no `.service` suffix — and required env vars), `config/packages.generic` and `config/packages.ruby-build`, `config/puma.rb` and `config/puma.service.example`, `config/nginx.conf.example` (single port-3000 upstream), `config/storage.yml-example` (`storage/raw_emails`, no Azure service), `script/site-specific-install.sh` and `script/install-as-user` (rbenv flow, config files written, databases created, sample data), `docker/ bootstrap` and `docker-compose.yml`, and commonlib `bin/install-site.sh` at the submodule commit pinned by 0.46.7.0 (supported distro list, usage message, production-by-default). English pages only; the `es/` tree is untouched. Jekyll front matter and Liquid tags are unchanged.

## Screenshots

N/A

## Notes to reviewer

- References to `spec/fixtures/files/incoming-request-plain.email` in `email.md` are correct for 0.46.7.0; the fixture is renamed to `.eml` on `develop`, so this page will need a touch-up at the next release.
- Deliberately left unchanged: the old TMail/elinks troubleshooting entries in `manual_install.md` (historical content, low harm, not verifiable against the current test suite).
- `apt-get install apache2-suexec` was updated to `apache2-suexec-pristine`; this comes from Debian packaging rather than the Alaveteli source, so please double-check it matches mySociety's preferred suexec variant.
- `ami.md` still describes the historical 2015 AMI workflow overall; only the factually wrong Thin reference was corrected, since the page already carries an "unsupported" warning.

## AI disclosure

This change was prepared with the assistance of AI coding agents (opencode, coordinated via Orca orchestration), working under human direction. All edits were verified by the agents against the Alaveteli source at the 0.46.7.0 release tag. Please review with the usual scrutiny and flag anything that reads as unverified.

---

Have you updated the changelog? [skip changelog] - documentation-site-only change.
