### PR TITLE
Update glossary, getting started and Pro pricing pages for Alaveteli 0.46.7.0

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -112,7 +112,7 @@ advantage if they do.
 You'll also need to source a server. You should ask your tech person to
 help with this. The minimum spec for running a low traffic website is
 512MB RAM and a 20GB disk. 2GB RAM would be ideal. We recommend the
-latest Debian Wheezy (7) 64-bit or Trusty (14.04)
+latest stable 64-bit Debian release
 as the operating system. Rackspace offer suitable cloud servers, which
 start out at around $25 / month. Then your tech person should follow the
 [installation documentation]({{ page.baseurl }}/docs/installing/).
@@ -282,7 +282,7 @@ single translation file called
 You can set up your language and provide translations there; you can also use
 specialise software on your own computer (see the help pages on Transifex)
 
-There are (at the time of writing) around 1000 different sentences or fragments
+There are (at the time of writing) around 1,600 different sentences or fragments
 of sentences (collectively known as "strings") to be translated. The meaning of
 many strings should be fairly obvious, but others less so. Until we write a
 guide for translators, the best route to take is translate everything you can,

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -33,7 +33,6 @@ Definitions
   <li><a href="#disclosure-log">disclosure log</a></li>
   <li><a href="#emergency">emergency user</a></li>
   <li><a href="#foi">freedom of information</a></li>
-  <li><a href="#gaze">gaze</a></li>
   <li><a href="#geoip-database">GeoIP database</a></li>
   <li><a href="#git">git</a></li>
   <li><a href="#holding_pen">holding pen</a></li>
@@ -146,7 +145,7 @@ Definitions
     Alaveteli's <strong>advanced search</strong> lets users search using
     more complex criteria than just words. This includes Boolean operators,
     date ranges, and specific indexes such as <code>status:</code>,
-    <code>requested_by:</code>, <code>status:</code> and so on.
+    <code>requested_by:</code>, <code>variety:</code> and so on.
     <div class="more-info">
       <p>More information:</p>
       <ul>
@@ -252,9 +251,9 @@ Definitions
     href="#authority" class="glossary__link">authority</a>. A <strong>batch
     request</strong> is when a user submits a single request that is then sent
     to <em>multiple</em> authorities. By default, this capability is not
-    enabled, but Alaveteli does support it. To allow batch requests to be sent,
-    you need to both enable the feature and then grant permission to use it
-    on a user-by-user basis.
+    enabled, but Alaveteli does support it as part of
+    <a href="{{ page.baseurl }}/docs/pro/">Alaveteli Professional</a>: Pro
+    users can make batch requests through the Pro interface.
     <div class="more-info">
       <p>More information:</p>
       <ul>
@@ -264,7 +263,10 @@ Definitions
         </li>
         <li>
           The config variable that enables the feature is
-          <code><a href="{{ page.baseurl }}/docs/customising/config/#allow_batch_requests">ALLOW_BATCH_REQUESTS</a></code>.
+          <code><a href="{{ page.baseurl }}/docs/pro/#enable_alaveteli_pro">ENABLE_ALAVETELI_PRO</a></code>.
+          The maximum number of authorities that can be included in a single
+          batch is set with
+          <code><a href="{{ page.baseurl }}/docs/pro/#pro_batch_authority_limit">PRO_BATCH_AUTHORITY_LIMIT</a></code>.
         </li>
         <li>
           Alaveteli <a href="#publish" class="glossary__link">publishes</a> the
@@ -492,34 +494,6 @@ Definitions
   </dd>
 
   <dt>
-    <a name="gaze">gaze</a>
-  </dt>
-  <dd>
-    <p>
-      In the absence of a <a href="#geoip-database">GeoIP database</a>, Alaveteli uses
-      mySociety's gazetteer service, called Gaze, to determine each user's country from
-      their incoming IP address. This lets the site suggest an Alaveteli site in their
-      country, if one exists.
-    </p>
-    <div class="more-info">
-      <p>More information:</p>
-      <ul>
-        <li>The config variable
-          <code><a href="{{ page.baseurl }}/docs/customising/config/#gaze_url">GAZE_URL</a></code>
-          should usually point at...
-        </li>
-        <li>...the <a
-          href="http://gaze.mysociety.org/">Gaze service</a>.
-        </li>
-        <li>
-          See <a href="https://github.com/mysociety/gaze">Gaze source on
-          github</a>.
-        </li>
-      </ul>
-    </div>
-  </dd>
-
-  <dt>
     <a name="geoip-database">GeoIP database</a>
   </dt>
   <dd>
@@ -532,7 +506,7 @@ Definitions
     <div class="more-info">
       <p>More information:</p>
       <ul>
-        <li>More about the free <a href="http://dev.maxmind.com/geoip/legacy/geolite/">GeoLite databases</a> from MaxMind.
+        <li>More about the free <a href="https://dev.maxmind.com/geoip/geolite2-free-geolocation-data">GeoLite2 databases</a> from MaxMind.
         </li>
       </ul>
     </div>
@@ -808,9 +782,9 @@ Definitions
       <ul>
         <li>
           use the config settings
-          <code><a href="{{ page.baseurl }}/docs/customising/config/#recaptcha_public_key">RECAPTCHA_PUBLIC_KEY</a></code>
+          <code><a href="{{ page.baseurl }}/docs/customising/config/#recaptcha_site_key">RECAPTCHA_SITE_KEY</a></code>
           and
-          <code><a href="{{ page.baseurl }}/docs/customising/config/#recaptcha_private_key">RECAPTCHA_PRIVATE_KEY</a></code>
+          <code><a href="{{ page.baseurl }}/docs/customising/config/#recaptcha_secret_key">RECAPTCHA_SECRET_KEY</a></code>
           to set this up.
         </li>
         <li>

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -33,6 +33,7 @@ Definitions
   <li><a href="#disclosure-log">disclosure log</a></li>
   <li><a href="#emergency">emergency user</a></li>
   <li><a href="#foi">freedom of information</a></li>
+  <li><a href="#gaze">gaze</a></li>
   <li><a href="#geoip-database">GeoIP database</a></li>
   <li><a href="#git">git</a></li>
   <li><a href="#holding_pen">holding pen</a></li>
@@ -491,6 +492,19 @@ Definitions
         </li>
       </ul>
     </div>
+  </dd>
+
+  <dt>
+    <a name="gaze">gaze</a>
+  </dt>
+  <dd>
+    <p>
+      Gaze was mySociety's gazetteer service, which older versions of Alaveteli
+      used to determine each user's country from their incoming IP address so the
+      site could suggest an Alaveteli site in their country. Alaveteli no longer
+      uses Gaze: country detection is now handled entirely by the
+      <a href="#geoip-database">GeoIP database</a>.
+    </p>
   </dd>
 
   <dt>

--- a/docs/pro/pricing.md
+++ b/docs/pro/pricing.md
@@ -93,7 +93,9 @@ this name will be displayed to users.
 Once a product is created you'll then be asked to set-up its the pricing plan.
 The pricing plan should be have the ID of `pro`, be for a recurring quantity and
 without multiple price tiers. You should set a memorable nickname for the plan
-but, again, bear in mind that this will be displayed to users.
+but, again, bear in mind that this will be displayed to users. If you want to
+use a different price ID, or offer more than one price, you can configure this
+with the [`STRIPE_PRICES`](#stripe_prices) setting.
 
 Currently we only support monthly or yearly billing interval.
 
@@ -195,6 +197,7 @@ tabs.
 <br> <code><a href="#stripe_publishable_key">STRIPE_PUBLISHABLE_KEY</a></code>
 <br> <code><a href="#stripe_secret_key">STRIPE_SECRET_KEY</a></code>
 <br> <code><a href="#stripe_namespace">STRIPE_NAMESPACE</a></code>
+<br> <code><a href="#stripe_prices">STRIPE_PRICES</a></code>
 <br> <code><a href="#stripe_webhook_secret">STRIPE_WEBHOOK_SECRET</a></code>
 <br> <code><a href="#pro_referral_coupon">PRO_REFERRAL_COUPON</a></code>
 <br> <code><a href="#iso_currency_code">ISO_CURRENCY_CODE</a></code>
@@ -259,6 +262,30 @@ tabs.
   </dd>
 
   <dt>
+    <a name="stripe_prices"><code>STRIPE_PRICES</code></a>
+  </dt>
+  <dd>
+    <p>
+      A hash of the Stripe Prices available for Alaveteli Pro, with each key
+      being a Stripe Price ID and the value being a parameterised,
+      human-readable string. Prices are rendered on the Pro pricing pages in
+      the order defined here.
+    </p>
+
+    <p>
+      Note that historical Stripe Price IDs listed here should include
+      <code>STRIPE_NAMESPACE</code>.
+    </p>
+
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li><code>STRIPE_PRICES:<br>&nbsp;&nbsp;pro: pro</code></li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
     <a name="stripe_webhook_secret"><code>STRIPE_WEBHOOK_SECRET</code></a>
   </dt>
   <dd>
@@ -268,7 +295,7 @@ tabs.
     <div class="more-info">
       <p>Example:</p>
       <ul class="examples">
-        <li><code>WEBHOOK_SECRET: wh_test_UD6BDsARFZIYb8273dbdl</code></li>
+        <li><code>STRIPE_WEBHOOK_SECRET: wh_test_UD6BDsARFZIYb8273dbdl</code></li>
       </ul>
     </div>
   </dd>


### PR DESCRIPTION
## Relevant issue(s)

N/A

## What does this do?

Updates several documentation pages that had drifted out of date relative to the latest Alaveteli release (0.46.7.0):

- **docs/glossary.md**
  - Batch requests: the legacy non-Pro batch request interface and its `ALLOW_BATCH_REQUESTS` config setting were removed in Alaveteli 0.41.1.0. The entry now explains that batch requests are part of Alaveteli Professional and links to `ENABLE_ALAVETELI_PRO` and `PRO_BATCH_AUTHORITY_LIMIT` instead.
  - Rewrote the "gaze" entry as a historical note: `GAZE_URL` no longer exists in `config/general.yml-example` and there is no Gaze fallback in the code — country lookup is done solely via a local MaxMind GeoIP database (`lib/alaveteli_geoip.rb`). The entry (and its anchor, which may be linked externally) is kept, but now explains Gaze is no longer used.
  - GeoIP entry: updated the dead MaxMind "GeoLite legacy" link to the current GeoLite2 page (Alaveteli defaults to `vendor/data/GeoLite2-Country.mmdb`).
  - Recaptcha entry: updated `RECAPTCHA_PUBLIC_KEY` / `RECAPTCHA_PRIVATE_KEY` to the current `RECAPTCHA_SITE_KEY` / `RECAPTCHA_SECRET_KEY` names (renamed at release 0.32) and fixed the anchors.
  - Advanced search entry: fixed a duplicated `status:` in the list of search indexes (now `variety:`, which is a real index shown in `_advanced_search_tips.html.erb`).
- **docs/getting_started.md**
  - Replaced the recommendation of Debian Wheezy (7) / Ubuntu Trusty (14.04) — both long end-of-life and unable to run current Alaveteli — with a generic recommendation of the latest stable 64-bit Debian release.
  - Updated the count of translatable strings from ~1,000 to ~1,600 (`locale/app.pot` currently contains 1,593 msgids).
- **docs/pro/pricing.md**
  - Added the missing `STRIPE_PRICES` setting (default `{ pro: pro }`) to the settings list and reference section, and cross-referenced it from the "Setting up the subscription product" section.
  - Fixed the `STRIPE_WEBHOOK_SECRET` example, which showed `WEBHOOK_SECRET:` without its `STRIPE_` prefix.

`docs/index.md` and `docs/pro/index.md` were reviewed against the source and found to be accurate (all config settings, anchors, role instructions and internal links check out), so they are unchanged.

## Why was this needed?

These pages are the main entry points for new re-users of Alaveteli. They referenced a config option that no longer exists (`ALLOW_BATCH_REQUESTS`), a retired mySociety service (Gaze), renamed config settings, EOL operating systems, and omitted a current Pro Pricing setting — all of which could send a new installer down the wrong path.

## Implementation notes

All corrections were verified against the Alaveteli source at the 0.46.7.0 release tag: `config/general.yml-example` for setting names and defaults (all glossary config links point at options present in the 115-option example file; no links remain to removed options such as `ALLOW_BATCH_REQUESTS` or `GAZE_URL`), `config/routes.rb` for batch request routes (creation is Pro namespace only), `doc/CHANGES.md` for the removal of the legacy batch interface (0.41.1.0), `lib/alaveteli_geoip.rb` for GeoIP behaviour, `locale/app.pot` for the string count, and `lib/tasks/stripe.rake` / `config/initializers/alaveteli_features.rb` for the Pro Pricing claims. Jekyll front matter, Liquid tags and page structure are untouched; the Spanish (`es/`) tree and `_posts` were not modified.

## Screenshots

N/A

## Notes to reviewer

- The batch-requests glossary entry still links to `docs/running/admin_manual/#batch-requests`; that admin manual section (and `docs/customising/config/#allow_batch_requests`) still describe the old `ALLOW_BATCH_REQUESTS` flow and are being updated separately.
- Deliberately left unchanged because they could not be verified from the source tree: the Rackspace "$25/month" hosting suggestion, the `demo.alaveteli.org` references, the old-format Transifex URLs (`/projects/p/alaveteli`, which still redirect), the Queremos Saber / KiMitTud external links, and the "8 hours for a 500-authority batch" throttling claim on the Pro index page.
- `docs/pro/index.md` contains a self-consistent (so still functional) misspelled anchor `#forward_pro_nonbounce_responsed_to`; left as-is to avoid breaking any inbound links.

## AI disclosure

This change was prepared with the assistance of AI coding agents (opencode, coordinated via Orca orchestration), working under human direction. All edits were verified by the agents against the Alaveteli source at the 0.46.7.0 release tag. Please review with the usual scrutiny and flag anything that reads as unverified.

---

Have you updated the changelog? [skip changelog] - documentation-site-only change.
