### PR TITLE
Update docs/running/ pages for Alaveteli 0.46.7.0

### DIFF
--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -409,12 +409,12 @@ its *url_title*.
 <div class="attention-box info">
   <p><strong>How to find a request's <em>id</em> or <em>url_title</em></strong></p>
   <p>
-    A request's <em>id</em> is the number after <code>/show/</code> in the
-    admin interface's URL when you are looking at that request.
-    For example, if the URL is <code>/admin/request/show/118</code>, then the
+    A request's <em>id</em> is the number after <code>/admin/requests/</code>
+    in the admin interface's URL when you are looking at that request.
+    For example, if the URL is <code>/admin/requests/118</code>, then the
     <em>id</em> is <code>118</code>. Similarly, if you know that you want to see the
     admin interface's page for the request with id <code>118</code>, you know it will
-    be <code>/admin/request/show/118</code>.
+    be <code>/admin/requests/118</code>.
   </p>
   <p>
     A request's <em>url_title</em> is the part after <code>/request/</code>

--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -377,14 +377,14 @@ your attention. Click on any one of them to see the details.
 
 <div class="attention-box helpful-hint">
   If the message does not belong to any request, you can delete it instead.
-  Simply click on the <strong>Destroy Message</strong> button instead of
+  Simply click on the <strong>Destroy message</strong> button instead of
   redelivering it.
 </div>
 
 When you inspect a message, you may see a guess made by Alaveteli as to which
 request the message belongs to. Check this request. If the guess is right
 &mdash; the incoming email really is a response to that request &mdash;
-the request's *title_url* will already be in the input box: click the
+the request's *url_title* will already be in the input box: click the
 **Redeliver to another request** button.
 
 If there is not a guess, or Alaveteli's guess is wrong, look at the  `To:`
@@ -464,7 +464,7 @@ effectively dead.
 To add an email address to the spam address list you need to copy it from an
 incoming message and paste it into the spam addresss list. The easiest way to
 do this is to click on **Summary** at the top of any admin page, and then click
-on **Put misdelivered responses with the right requests** to see the contents
+on **Put misdelivered responses with the right request** to see the contents
 of the holding pen.
 
 <div class="attention-box info">
@@ -497,7 +497,7 @@ running in your
 There are three ways to change public authority data on your site:
 
    * *Create* &mdash;
-     You can create a new public authority in the admin interface. Go to **Authorities**, and click the **New Public Authority** button.
+     You can create a new public authority in the admin interface. Go to **Authorities**, and click the **New public authority** button.
 
    * *Edit* &mdash;
      Once an authority is created, you can update its email address or other
@@ -508,7 +508,7 @@ There are three ways to change public authority data on your site:
      You can also create or edit more than one authority at the same time by
      uploading a file containing the data in comma-separated values (CSV)
      format. This works for new authorities as well as those that already exist
-     on your site. Go to **Authorities** and click the **Import from CSV** button. See the rest of this section for more about uploading.
+     on your site. Go to **Authorities** and click the **Import from CSV file** button. See the rest of this section for more about uploading.
 
 The upload feature is useful &mdash; especially when an Alaveteli site is first
 set up &mdash; because it's common to collect data such as the contact details
@@ -562,11 +562,6 @@ unrecognised column name, the import will fail.
     <td><code>short_name</code></td>
     <td><em>yes</em></td>
     <td>Some authorities are known by a shorter name</td>
-  </tr>
-  <tr>
-    <td><code>notes</code></td>
-    <td><em>yes</em></td>
-    <td>Notes, displayed publicly (may contain HTML)</td>
   </tr>
   <tr>
     <td><code>publication_scheme</code></td>
@@ -626,10 +621,10 @@ For example, here's data for three authorities in CSV format ready for upload.
 The first line defines the column names, then the next three lines contain the
 data (one line for each authority):
 
-    #name,short_name,short_name.es,request_email,notes
+    #name,short_name,short_name.es,request_email,home_page
     XYZ Library Inc.,XYZ Library,XYX Biblioteca,info@xyz.example.com,
-    Ejemplo Town Council,,Ayuntamiento de Ejemplo,etc@example.com,Lorem ipsum.
-    "Comma, Inc.",Comma,,comma@example.com,"e.g. <a href=""x"">link</a>"
+    Ejemplo Town Council,,Ayuntamiento de Ejemplo,etc@example.com,http://example.com
+    "Comma, Inc.",Comma,,comma@example.com,
 
 Note that, if Ejemplo Town Council already exists on the site, the blank entry
 for `short_name` will leave the existing value for that column unchanged.
@@ -913,7 +908,7 @@ hanging the application altogether), so please:
 
 <strong>To attach a censor rule to a request</strong>, go to the admin page for the
 request, scroll to the bottom of the page, and click the "New censor
-rule (for this request only)" button. On the following page, enter the
+rule" button. On the following page, enter the
 text that you want to replace e.g. 'some private info', the text you
 wish to replace it with e.g. '[private info has been hidden]', and a
 comment letting other admins know why you have hidden the information.

--- a/docs/running/admin_manual.md
+++ b/docs/running/admin_manual.md
@@ -755,35 +755,29 @@ the checkbox **No rate limit**, and click the **Save** button.
 
 ### Batch requests
 
-Sometimes a user may want to send the same request to more than one authority, which we call a batch request. By default, Alaveteli does not allow users to make batch requests.
+Sometimes a user may want to send the same request to more than one authority, which we call a batch request. Batch requests are a feature of <a href="{{ page.baseurl }}/docs/pro/">Alaveteli Professional</a> &mdash; the older batch request interface for regular users was removed in Alaveteli 0.41.1.0.
 
 <div class="attention-box info">
 <p>We believe that batch requests can be abused &mdash; users can send poorly thought-out or vexatious requests, which will annoy authorities and damage the reputation of your site. However, well thought-out batch requests can be an extremely useful tool in collecting comparative data sets across types of authority, for example, all police forces.</p>
 <p>
-We recommend that you enable batch requesting for users who you notice making the same good request to multiple authorities.
-</p>
-<p>
-Users can choose which authorities to include in a batch requests. They  can even send a request to <em>every single authority</em> on your site. Only give this power to users that you trust.
+Users can choose which authorities to include in a batch request. Bear this in mind when deciding which users you give Pro accounts to.
 </p>
 </div>
 
-To enable batch requests on your site, first you must set
-<code><a href="{{ page.baseurl }}/docs/customising/config/#allow_batch_requests">ALLOW_BATCH_REQUESTS</a></code>
-to <code>true</code> in <code>general.yml</code>.
+Users with a Pro account can start a batch request from the make-request
+page in the Pro interface by clicking the "start a batch request" link.
+When the request is sent, Alaveteli will make a request page for this
+request for each authority, as if the user had made individual requests.
 
-This does not allow anyone to make batch requests yet. You must still
-enable this for each user on an individual basis. To do this, go to the
-<a href="{{ page.baseurl }}/docs/glossary/#admin_interface"
-class="glossary__link">admin interface</a>, click on **Users**, then
-click on the name of the user who wants to make batch requests. Click
-the **Edit** button. Tick the checkbox **Can make batch requests**, and
-click the **Save** button.
+The maximum number of authorities that can be included in a single batch
+request is controlled by the
+<code><a href="{{ page.baseurl }}/docs/pro/#pro_batch_authority_limit">PRO_BATCH_AUTHORITY_LIMIT</a></code>
+config setting (500 by default).
 
-If you've enabled batch requests for a user, when they start to make a
-request, in addition to the box where they can select an authority, they
-will see a link to "make a batch request". When the request is sent,
-Alaveteli will make a request page for this request for each authority,
-as if the user had made individual requests.
+The **Can make batch requests** checkbox on a user's edit page in the
+admin interface is a legacy of the old interface: it no longer enables
+batch requests, but users with it ticked are exempt from the daily
+request limit.
 
 ### Resending a request or sending it to a different authority
 

--- a/docs/running/holding_pen.md
+++ b/docs/running/holding_pen.md
@@ -94,7 +94,7 @@ For instructions, see
 
 If the `To:` address does not belong to a valid request and the message is
 clearly spam you can add that email address to Alaveteli's
-<a href="{{ page.baseurl }}/#spam-address-list" class="glossary__link">spam address list</a>.
+<a href="{{ page.baseurl }}/docs/glossary/#spam-address-list" class="glossary__link">spam address list</a>.
 Subsequent messages to that address will be automatically rejected &mdash; for
 instructions see
 [rejecting spam that arrives in the holding pen]({{ page.baseurl }}/docs/running/admin_manual/#rejecting-spam-that-arrives-in-the-holding-pen).

--- a/docs/running/requests.md
+++ b/docs/running/requests.md
@@ -76,7 +76,7 @@ that the request has been closed because it is old, with a suggestion that the
 sender can email your site's administrators directly.
 
 You can can stop this behaviour by changing the **Allow new responses from...**
-setting back to `normal` at any time. Alternatively, you can change the way
+setting back to `anybody` at any time. Alternatively, you can change the way
 rejected messages are handled (for example, sending such responses to the
 holding pen instead of bouncing them) with the request's **Handle rejected
 responses** setting.

--- a/docs/running/server.md
+++ b/docs/running/server.md
@@ -58,9 +58,9 @@ these settings:
 * [`INCOMING_EMAIL_SECRET`]({{ page.baseurl }}/docs/customising/config/#incoming_email_secret)
 * [`ADMIN_USERNAME`]({{ page.baseurl }}/docs/customising/config/#admin_username)
 * [`ADMIN_PASSWORD`]({{ page.baseurl }}/docs/customising/config/#admin_password)
-* [`COOKIE_STORE_SESSION_SECRET`]({{ page.baseurl }}/docs/customising/config/#cookie_store_session_secret)
-* [`RECAPTCHA_PUBLIC_KEY`]({{ page.baseurl }}/docs/customising/config/#recaptcha_public_key)
-* [`RECAPTCHA_PRIVATE_KEY`]({{ page.baseurl }}/docs/customising/config/#recaptcha_private_key)
+* [`SECRET_KEY_BASE`]({{ page.baseurl }}/docs/customising/config/#secret_key_base)
+* [`RECAPTCHA_SITE_KEY`]({{ page.baseurl }}/docs/customising/config/#recaptcha_site_key)
+* [`RECAPTCHA_SECRET_KEY`]({{ page.baseurl }}/docs/customising/config/#recaptcha_secret_key)
 
 You should consider running the admin part of the site over HTTPS. This can be
 achieved with rewrite rules that redirect URLs beginning with `/admin`.
@@ -104,7 +104,7 @@ in the setting
 setting in `config/general.yml`.
 
 Refer to the [Postgres
-documentation](http://www.postgresql.org/docs/8.4/static/backup.html) for
+documentation](https://www.postgresql.org/docs/current/backup.html) for
 database backup strategies. The most common method is to use `pg_dump` to
 create a SQL dump of the database, and backup a zipped copy of this.
 

--- a/docs/running/server.md
+++ b/docs/running/server.md
@@ -134,6 +134,9 @@ something like:
 
 ## Deployments
 
-We strongly recommend you use a
-<a href="{{ page.baseurl }}/docs/installing/deploy/">deployment mechanism</a>
-to make changes to your production site.
+We strongly recommend you make changes to your production site with a
+repeatable, automated process rather than by editing it directly. Deploy
+from a specific release tag and run the post-deploy script after each
+deployment &mdash; see
+<a href="{{ page.baseurl }}/docs/running/upgrading/">upgrading</a>
+for details.

--- a/docs/running/server.md
+++ b/docs/running/server.md
@@ -31,7 +31,7 @@ Don't forget to set up the cron jobs as outlined in the
 
 We recommend running your site behind
 [Apache](https://httpd.apache.org) +
-[Passenger](https://www.phusionpassenger.com) or [Nginx](http://wiki.nginx.org/Main) + [Thin](http://code.macournoyer.com/thin/).
+[Passenger](https://www.phusionpassenger.com), or behind [Nginx](https://nginx.org) as a reverse proxy in front of [Puma](https://puma.io) (the application server Alaveteli bundles).
 
 If you're using Passenger, refer to the
 [installation instructions]({{ page.baseurl }}/docs/installing/manual_install/)

--- a/docs/running/upgrading.md
+++ b/docs/running/upgrading.md
@@ -41,11 +41,11 @@ Alaveteli uses a &ldquo;shifted&rdquo; version of [semver](http://semver.org)
 (just as [Rails version numbering](http://guides.rubyonrails.org/maintenance_policy.html)
 does). This means that version numbers are of the form: `SERIES.MAJOR.MINOR.PATCH`.
 
-At the time of writing, the current release is `0.46.5.0`:
+At the time of writing, the current release is `0.46.7.0`:
 
 - Series `0`
 - Major `46`
-- Minor `5`
+- Minor `7`
 - Patch `0`
 
 We'll use the [semver](http://semver.org) specification for Alaveteli's

--- a/docs/running/upgrading.md
+++ b/docs/running/upgrading.md
@@ -17,7 +17,7 @@ Upgrading Alaveteli
 
 * Set the repo and branch in `deploy.yml` to be the
   version you want. We recommend you set this to the explicit tag name (for example,
-  `0.18`, and not `master`) so there's no risk of you accidentally deploying
+  `0.46.5.0`, and not `master`) so there's no risk of you accidentally deploying
   a new version before you're aware it's been released. The code will be updated
   and any post-deploy procedures will automatically run.
 
@@ -49,12 +49,12 @@ Alaveteli uses a &ldquo;shifted&rdquo; version of [semver](http://semver.org)
 (just as [Rails version numbering](http://guides.rubyonrails.org/maintenance_policy.html)
 does). This means that version numbers are of the form: `SERIES.MAJOR.MINOR.PATCH`.
 
-At the time of writing, the current release is `0.19.0.6`:
+At the time of writing, the current release is `0.46.5.0`:
 
 - Series `0`
-- Major `19`
-- Minor `0`
-- Patch `6`
+- Major `46`
+- Minor `5`
+- Patch `0`
 
 We'll use the [semver](http://semver.org) specification for Alaveteli's
 version numbering when it reaches `1.0.0`.

--- a/docs/running/upgrading.md
+++ b/docs/running/upgrading.md
@@ -13,25 +13,17 @@ Upgrading Alaveteli
 </p>
 
 
-## Using Capistrano (recommended)
-
-* Set the repo and branch in `deploy.yml` to be the
-  version you want. We recommend you set this to the explicit tag name (for example,
-  `0.46.5.0`, and not `master`) so there's no risk of you accidentally deploying
-  a new version before you're aware it's been released. The code will be updated
-  and any post-deploy procedures will automatically run.
-
-
-## Manual upgrade
-
-If you are not able to use Capistrano to update your site, you will need to
-perform a manual upgrade.
+## How to upgrade
 
 ### Update the code
 
 * Navigate to your site directory (likely to be `/var/www/YOUR-SITE/alaveteli/`)
-* Run git pull as the alaveteli user to avoid access permission errors for site
-  files with the command `sudo -u alaveteli git pull`
+* Check out the version you want. We recommend you use the explicit tag name
+  (for example, `0.46.7.0`, and not `master`) so there's no risk of you
+  accidentally deploying a new version before you're aware it's been released.
+  Run git as the alaveteli user to avoid access permission errors for site
+  files, for example `sudo -u alaveteli git fetch --tags && sudo -u alaveteli
+  git checkout 0.46.7.0`
 
 ### Run the post-deploy script
 
@@ -39,7 +31,7 @@ perform a manual upgrade.
   post-deploy script as the alaveteli user by issuing
   `sudo -u alaveteli script/rails-post-deploy`
 
-Do this after each manual deployment as runs any database migrations for you,
+Do this after each deployment as it runs any database migrations for you,
 plus various other things that can be automated for deployment.
 
 


### PR DESCRIPTION
## Relevant issue(s)

N/A

## What does this do?

Fixes verifiably stale content in the English `docs/running/` pages of the documentation site (gh-pages branch):

- **admin_manual.md**
  - Removes the `notes` column from the public authority CSV import documentation and example CSV. Notes moved to a separate `Note` model and the field was removed from `PublicBody` CSV import in 0.42.0.0 (commit `2a2c1da84`, which fixed mysociety/alaveteli#7217); an unrecognised column now fails the import, so the docs were actively misleading.
  - Rewrites the "Batch requests" section: the legacy batch request interface for regular users was removed in 0.41.1.0 and the `ALLOW_BATCH_REQUESTS` config option no longer exists. Batch requests are now an Alaveteli Professional feature (capped by `PRO_BATCH_AUTHORITY_LIMIT`, default 500). The admin **Can make batch requests** checkbox remains but now only exempts a user from daily rate limits (`User#exceeded_limit?`).
  - Fixes the admin request URL example: `/admin/requests/118` rather than the old `/admin/request/show/118` (per `resources :requests` under the `/admin` scope in `config/routes.rb`).
  - Matches current admin UI text: "New public authority", "Import from CSV file", "Destroy message", "New censor rule" (the "(for this request only)" suffix no longer exists), and the singular "Put misdelivered responses with the right request" to-do label.
  - Fixes a `title_url` → `url_title` typo in the holding pen instructions.
- **server.md**
  - Replaces `COOKIE_STORE_SESSION_SECRET` with `SECRET_KEY_BASE`, and `RECAPTCHA_PUBLIC_KEY`/`RECAPTCHA_PRIVATE_KEY` with `RECAPTCHA_SITE_KEY`/`RECAPTCHA_SECRET_KEY`, matching `config/general.yml-example`.
  - Recommends Nginx + Puma rather than Nginx + Thin: Alaveteli bundles Puma (`puma ~> 7.1.0` in the 0.46.7.0 Gemfile) and Thin is no longer a dependency.
  - Rewords the "Deployments" section to recommend deploying from a specific release tag and running the post-deploy script (linking to the upgrading page) instead of linking to the Capistrano-based deploy docs, which are being retired.
  - Points the PostgreSQL backup docs link at `/docs/current/` instead of the long-EOL 8.4 docs.
- **upgrading.md**
  - Removes the "Using Capistrano (recommended)" section. The standard upgrade path is now checking out the release tag and running `script/rails-post-deploy`; the former "Manual upgrade" steps become the main "How to upgrade" section.
  - Updates the "current release" version example from `0.19.0.6` to `0.46.7.0` (and the old `0.18` tag example).
- **requests.md**
  - "Allow new responses from..." has no `normal` value; the value that re-opens a request to responses is `anybody` (per the `validates_inclusion_of :allow_new_responses_from` list in `app/models/info_request.rb`).
- **holding_pen.md**
  - Fixes a broken glossary link for the spam address list, which pointed at `{{ page.baseurl }}/#spam-address-list` instead of `{{ page.baseurl }}/docs/glossary/#spam-address-list`.

## Why was this needed?

These pages contain instructions that no longer match the current Alaveteli release (0.46.7.0). The CSV import `notes` column in particular would cause an import failure if followed, the batch requests section documented a config option that no longer exists, and several config option names no longer exist under their documented names. All corrections were verified against the 0.46.7.0 Alaveteli source (`config/general.yml-example`, `config/routes.rb`, `app/models/`, `app/views/admin*`, `app/views/alaveteli_pro/`, and `doc/CHANGES.md`).

## Implementation notes

- Changes are deliberately conservative: no prose restyling beyond the rewritten batch requests and upgrade sections, Jekyll front matter and Liquid tags untouched, English pages only.
- The `server.md` config anchors (`#secret_key_base`, `#recaptcha_site_key`, `#recaptcha_secret_key`) assume the customising/config page documents these settings under those names.
- The Capistrano upgrade recommendation was removed (rather than reworded) because Capistrano support was dropped on `develop` (commit `29e015934`, "This method of deploying Alaveteli won't work") and the installing-section deploy page is being reduced to a removal note in a parallel change, so nothing here links to Capistrano workflows any more.
- Not changed, flagged for maintainers:
  - `redaction.md` says basic censor rule text replacement is always case sensitive, which is correct for 0.46.7.0 (`CensorRule#apply_to_text` does a literal `gsub`). A `case_sensitive` toggle (and diacritic-insensitive matching) exists on `develop` but is unreleased, so the page will need updating at the next release.
  - `adwords.md` documents Google Ads/Grants, not Alaveteli; nothing there is verifiable against the source tree so it was left untouched (it still uses the retired "Adwords" branding throughout).
  - Historical/anecdotal WhatDoTheyKnow content (2010 support statistics, mail import error rates) left as-is since it is presented as historical example.

## Screenshots

N/A

## Notes to reviewer

The `notes` CSV column removal and the batch requests rewrite are the most substantive changes — see mysociety/alaveteli#7217 / commit `2a2c1da84` for the CSV change, and the 0.41.1.0 entry in `doc/CHANGES.md` ("Remove legacy batch request interface") for batch requests. Everything else is label/name/link corrections verified directly against the 0.46.7.0 source. The example CSV now uses `home_page` in place of `notes`; the double-quote escaping guidance remains as prose bullets above the example.

## AI disclosure

This change was prepared with the assistance of AI coding agents (opencode, coordinated via Orca orchestration), working under human direction. All edits were verified by the agents against the Alaveteli source at the 0.46.7.0 release tag. Please review with the usual scrutiny and flag anything that reads as unverified.

---

Have you updated the changelog? [skip changelog] - documentation-site-only change.
