### PR TITLE
Show body version history

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -272,6 +272,9 @@ body.admin {
     width: 75px;
   }
 
+  .edit-history .row:nth-child(even) {
+    background-color: #f9f9f9;
+  }
 }
 
 /* Debug */

--- a/app/views/admin_public_body/_edit_history.html.erb
+++ b/app/views/admin_public_body/_edit_history.html.erb
@@ -1,0 +1,48 @@
+<div class="edit-history">
+  <% versions.each_with_index do |version, i| %>
+    <div class="row">
+      <div class="span2">
+        <b>
+          <%= "Version #{version.version}" %>
+        </b>
+      </div>
+
+      <div class="span4">
+        <%= version.updated_at.to_fs(:db) %>
+        (<%= time_ago_in_words(version.updated_at) %>
+        ago)
+      </div>
+
+      <div class="span6">
+        <p>
+          “<%= h(version.last_edit_comment) %>
+          <% if version.editor %>
+            –
+            <%= link_to version.editor.name, admin_user_path(version.editor) %>
+          <% else %>
+            –
+            <%= version.last_edit_editor %>
+          <% end %>
+        </p>
+
+        <% if i == versions.length - 1 %>
+          <ul>
+            <li>This is the first version.</li>
+          </ul>
+        <% else %>
+          <ul>
+            <% version.compare(versions[i+1]) do |change| %>
+              <li>
+                <%= change[:name] %>
+                was changed from
+                <code><%= change.fetch(:from, "-") %></code>
+                to
+                <code><%= change.fetch(:to, "-") %></code>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/admin_public_body/edit.html.erb
+++ b/app/views/admin_public_body/edit.html.erb
@@ -41,6 +41,9 @@
         (this is permanent!)
       <% end %>
     </div>
+    <hr>
+    <h2>History</h2>
+    <%= render partial: 'edit_history', locals: {versions: @public_body.versions.order(version: :desc)} %>
 
   </div>
   <div class="span4">

--- a/app/views/admin_public_body/show.html.erb
+++ b/app/views/admin_public_body/show.html.erb
@@ -69,48 +69,7 @@
 
 <h2>History</h2>
 
-<% @versions.each_with_index do |version, i| %>
-  <div class="row">
-    <div class="span2">
-      <b>
-        <%= "Version #{ version.version }" %>
-      </b>
-    </div>
-
-    <div class="span4">
-      <%= version.updated_at.to_fs(:db) %>
-      (<%= time_ago_in_words(version.updated_at) %> ago)
-    </div>
-
-    <div class="span6">
-      <p>
-        “<%= h(version.last_edit_comment) %>”
-
-        <% if version.editor %>
-          – <%= link_to version.editor.name, admin_user_path(version.editor) %>
-        <% else %>
-          – <%= version.last_edit_editor %>
-        <% end %>
-      </p>
-
-      <% if i == @versions.length - 1 %>
-        <ul>
-          <li>This is the first version.</li>
-        </ul>
-      <% else %>
-        <ul>
-          <% version.compare(@versions[i+1]) do |change| %>
-            <li>
-              <%= change[:name] %> was changed from
-              <code><%= change.fetch(:from, '-') %></code> to
-              <code><%= change.fetch(:to, '-') %></code>
-            </li>
-          <% end %>
-        </ul>
-      <% end %>
-    </div>
-  </div>
-<% end %>
+<%= render partial: 'edit_history', locals: {versions: @public_body.versions.order(version: :desc)} %>
 
 <hr>
 

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Show public body change history while editing it (Laurent Savaete)
 * Cache recent request events on the front page for 10 minutes (Chris Mytton)
 * Cache total requests count on the front page for 1 hour (Chris Mytton)
 * Accept a two factor code briefly after it expires (Graeme Porteous)


### PR DESCRIPTION
## Relevant issue(s)

Fixes #7997

## What does this do?

This is a simple refactor of the existing template for reuse in the edit view. The template itself is not modified.

## Why was this needed?

## Implementation notes

The history is a bit dense when shown on the edit page, as width is more limited. I added an alternating background colour to make it somewhat easier to read.

## Screenshots
<img width="890" height="845" alt="image" src="https://github.com/user-attachments/assets/494643af-e67f-4078-a267-f73bf9d6ae03" />

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
