### PR TITLE
Allow admins to hide a request without notifying the user

### DIFF
--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -190,16 +190,21 @@ class AdminRequestController < AdminController
       @info_request.save!
 
       if ! @info_request.is_external?
-        ContactMailer.from_admin_message(
-          @info_request.user.name,
-          @info_request.user.email,
-          subject,
-          params[:explanation].strip.html_safe
-        ).deliver_now
-        flash[:notice] = _("Your message to {{recipient_user_name}} has " \
-                           "been sent",
-                           recipient_user_name: @info_request.user.
-                                                     name.html_safe)
+        if params[:commit] == 'Hide request and notify user'
+          ContactMailer.from_admin_message(
+            @info_request.user.name,
+            @info_request.user.email,
+            subject,
+            params[:explanation].strip.html_safe
+          ).deliver_now
+          flash[:notice] = _("Your message to {{recipient_user_name}} has " \
+                             "been sent",
+                             recipient_user_name: @info_request.user.
+                                                       name.html_safe)
+        else
+          flash[notice] = _("The request has been hidden without messaging " \
+                            "the user")
+        end
       else
         flash[:notice] = _("This external request has been hidden")
       end

--- a/app/views/admin_request/show.html.erb
+++ b/app/views/admin_request/show.html.erb
@@ -217,6 +217,7 @@
       <% end %>
       <div class="form-actions" id="request_hide_button">
         <%= submit_tag 'Hide request', class: 'btn' %>
+        <%= submit_tag 'Hide request and notify user', class: 'btn btn-warning' %>
       </div>
     <% end %>
   <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Allow admins to hide a request without notifying the user (Laurent Savaete)
 * Cache recent request events on the front page for 10 minutes (Chris Mytton)
 * Cache total requests count on the front page for 1 hour (Chris Mytton)
 * Accept a two factor code briefly after it expires (Graeme Porteous)
@@ -205,7 +206,7 @@
 The following templates have been changed. Please use `script/reconcile-theme`
 to update overrides in your theme to match the new templates.
 
-    None yet
+    app/views/admin_request/show.html.erb
 
 # 0.46.5.0
 

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -297,7 +297,8 @@ RSpec.describe AdminRequestController, "when administering requests" do
       post :hide, params: {
                     id: info_request.id,
                     explanation: "Foo",
-                    reason: "vexatious"
+                    reason: "vexatious",
+                    commit: "Hide request and notify user"
                   }
       info_request.reload
       expect(info_request.prominence).to eq("requester_only")
@@ -306,6 +307,20 @@ RSpec.describe AdminRequestController, "when administering requests" do
       expect(deliveries.size).to eq(1)
       mail = deliveries[0]
       expect(mail.body).to match(/Foo/)
+    end
+
+    it "hides requests without a notification email" do
+      post :hide, params: {
+                    id: info_request.id,
+                    explanation: "Foo",
+                    reason: "vexatious",
+                    commit: "Hide request"
+                  }
+      info_request.reload
+      expect(info_request.prominence).to eq("requester_only")
+      expect(info_request.described_state).to eq("vexatious")
+      deliveries = ActionMailer::Base.deliveries
+      expect(deliveries.size).to eq(0)
     end
 
     it 'expires the file cache for the request' do

--- a/spec/integration/admin_spec.rb
+++ b/spec/integration/admin_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "When administering the site" do
       using_session(@admin) do
         visit admin_request_path id: request.id
         choose('reason_not_foi_not_foi')
-        find_button('Hide request').click
+        find_button('Hide request and notify user').click
         expect(page).
           to have_content('Your message to Awkward > Name has been sent')
       end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #8092 

## What does this do?

This adds an extra button on the /admin/requests/<nnnn> page that allows hiding a request with or without notifying the user by email.

## Why was this needed?

See issue above.

## Implementation notes

## Screenshots
<img width="1277" height="335" alt="image" src="https://github.com/user-attachments/assets/299b53ad-18cf-42ed-ac52-e106cf92227f" />

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
