### PR TITLE
Disable various postgresql durability options to speed up specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,17 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        command: >-
+          postgres
+          -c fsync=off
+          -c synchronous_commit=off
+          -c wal_level=minimal
+          -c full_page_writes=off
+          -c autovacuum=off
+          -c max_wal_size=1GB
+          -c archive_mode=off
+          -c max_wal_senders=0
+          -c shared_buffers=256MB
 
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/alaveteli_test


### PR DESCRIPTION
## Relevant issue(s)

N/A

## What does this do?

This tries to speed up CI runs.

This is taken from
https://www.postgresql.org/docs/13/non-durability.html. This config is
only acceptable for tests, as it removes the durability guarantees that
postgres provides, in exchange for much faster operation. Various blog
posts report 15-20% faster CI runs with this kind of changes.

## Why was this needed?

It won't change our lives, but I've waited for CI runs to finish a little bit too much for my taste.
A quick `rbspy` on rspec shows that about 27-28% of the run time is spent on database calls. 
~~So this might drop CI run time by more than 5 minutes with no adverse effects.~~
Comparing 3 runs of "run core tests", this PR finished in 22m58, vs [26m43](https://github.com/mysociety/alaveteli/actions/runs/31687797710/job/94407960645?pr=9465) and [29m21](https://github.com/mysociety/alaveteli/actions/runs/31612259435/job/94166311913?pr=9439). So between 4 and 6-7min faster? Plenty of variability to be expected though :)

## Implementation notes

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
