### PR TITLE
Warn users that their latest request might not be listed

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -43,6 +43,7 @@ class UserController < ApplicationController
     set_show_requests if @show_requests
 
     @private_requests = []
+    @has_recent_requests = false
 
     if @is_you
       private_requests =
@@ -71,6 +72,15 @@ class UserController < ApplicationController
       @track_things_grouped = @track_things.group_by(&:track_type)
       # Requests you need to describe
       @undescribed_requests = @display_user.get_undescribed_requests
+
+      # very recent requests might not show up immediately on a user's page
+      # leading to unneeded actions like resends, or support emails. Warn them.
+      @has_recent_requests = 
+        @display_user.
+          info_requests.
+          visible_to_requester.
+          where(created_at: ..1.hour.ago).
+          exists?
     end
 
     respond_to do |format|

--- a/app/views/user/show/_show_requests.html.erb
+++ b/app/views/user/show/_show_requests.html.erb
@@ -40,6 +40,13 @@
           <% if @is_you %>
             <%= _('You have made no Freedom of Information requests using ' \
                   'this site.') %>
+          </p>
+          <% if @has_recent_requests %>
+            <p>
+              <%= _('(If you sent a request in the last few minutes, it might ' \
+                      'not appear here yet. Please check again in a few minutes.)') %>
+            </p>
+          <% end %>
           <% else %>
             <%= _('This person has made no Freedom of Information requests ' \
                   'using this site.') %>
@@ -68,6 +75,13 @@
         <%= @match_phrase %>
         <%= @page_desc %>
       </h2>
+
+      <% if @has_recent_requests %>
+        <p>
+          <%= _('(If you sent a request in the last few minutes, it might ' \
+                  'not appear here yet. Please check again in a few minutes.)') %>
+        </p>
+      <% end %>
 
       <% @request_results.results.each do |result| %>
         <%= render partial: 'request/request_listing_via_event',

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Allow admins to hide a request without notifying the user (Laurent Savaete)
 * Show public body change history while editing it (Laurent Savaete)
+* Warn users that their latest request may not be listed yet (Laurent Savaete)
 * Cache recent request events on the front page for 10 minutes (Chris Mytton)
 * Cache total requests count on the front page for 1 hour (Chris Mytton)
 * Accept a two factor code briefly after it expires (Graeme Porteous)


### PR DESCRIPTION
## Relevant issue(s)

N/A

## What does this do?

This PR adds a note on a user's page to warn them that recent requests may not yet be listed.

This is only shown to the user themselves, not others, and only if they created a request within the last hour.

## Why was this needed?

Various support emails show that users get confused when they post a request, and try to see it on `/user/<myself>`. As xapian might take a few minutes to update, they think it wasn't saved, leading to actions like resending the request (which bothers public bodies) or emailing support. Hopefully this note helps reduce these occurrences.

## Implementation notes

This will not be needed anymore once we switch over to the new search engine.

## Screenshots

<img width="1069" height="327" alt="image" src="https://github.com/user-attachments/assets/eb9ef24e-8985-4929-aa5a-6587721df433" />

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
