### PR TITLE
Detect disposable and relay email domains in UserSpamScorer

### DIFF
--- a/config/general.yml-example
+++ b/config/general.yml-example
@@ -1023,6 +1023,30 @@ BLOCK_SPAM_SIGNINS: false
 # ---
 BLOCK_SPAM_REQUESTS: false
 
+# API key for UserCheck (https://www.usercheck.com), used to detect email
+# domains that are disposable, are relay/forwarding services, or have invalid
+# MX records. When set, the user spam scorer gains three extra checks with
+# live lookups against the UserCheck API; when blank, the checks are disabled
+# and only the static domain lists apply.
+#
+# Only the email domain is ever sent to the API, never the full address.
+# Results are cached for 28 days per domain, so a domain that has already
+# been checked generates no further requests. API failures are logged and
+# score nothing, so an outage degrades to the static list behaviour.
+#
+# The default scores (email_domain_is_disposable: 20, email_domain_is_relay:
+# 10, email_domain_invalid_mx: 5) can be tuned via score_mappings in
+# config/user_spam_scorer.yml.
+#
+# USERCHECK_API_KEY - String (default: '')
+#
+# Example:
+#
+#   USERCHECK_API_KEY: 'xxxxxxxxxxxxxxxxxxxxxxxx'
+#
+# ---
+USERCHECK_API_KEY: ''
+
 # Restrict IP addresses from some countries from performing some actions.
 # If set, requests from IP addresses in the countries specified will be
 # prevented from making new requests on the site.

--- a/config/initializers/user_spam_scorer.rb
+++ b/config/initializers/user_spam_scorer.rb
@@ -1,4 +1,5 @@
 require 'ipaddr'
+require 'user_check'
 require 'user_spam_scorer'
 
 path = Rails.root.join('config/user_spam_scorer.yml')
@@ -12,3 +13,5 @@ if File.exist?(path)
     UserSpamScorer.public_send("#{key}=", value)
   end
 end
+
+UserCheck.register_scoring_methods!

--- a/config/user_spam_scorer.yml-example
+++ b/config/user_spam_scorer.yml-example
@@ -3,6 +3,19 @@
 #
 # Unfortunately at this time you can't override the regular expressions defined
 # for DEFAULT_SPAM_NAME_FORMAT or DEFAULT_SPAM_ABOUT_ME_FORMAT.
+#
+# score_mappings replaces the default set of checks and weights entirely, so
+# list every check you want to run. Scores registered by custom scoring
+# methods (for example the UserCheck email domain checks, enabled by setting
+# USERCHECK_API_KEY in general.yml) act as defaults which a score_mappings
+# entry here overrides:
+#
+#   score_mappings:
+#     name_is_all_lowercase?: 1
+#     name_is_one_word?: 1
+#     email_domain_is_disposable: 20
+#     email_domain_is_relay: 10
+#     email_domain_invalid_mx: 5
 
 user_spam_scorer:
   currency_symbols:

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Highlighted Features
 
+* Detect disposable and relay email domains at sign-up with an optional
+  UserCheck.com integration in the user spam scorer, enabled by setting
+  `USERCHECK_API_KEY` (Ben Fairless)
 * Allow admins to hide a request without notifying the user (Laurent Savaete)
 * Show public body change history while editing it (Laurent Savaete)
 * Cache recent request events on the front page for 10 minutes (Chris Mytton)

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -19,7 +19,7 @@ module AlaveteliConfiguration
   # Ensure any sensitive values match this pattern, or add to the pattern if
   # adding a new value that doesn't fit.
   mattr_accessor :sensitive_key_patterns,
-                 default: /SECRET|PASSWORD|LICENSE_KEY/
+                 default: /SECRET|PASSWORD|LICENSE_KEY|API_KEY/
 
   unless const_defined?(:DEFAULTS)
 
@@ -136,6 +136,7 @@ module AlaveteliConfiguration
       TWITTER_USERNAME: '',
       TWITTER_WIDGET_ID: false,
       USER_CONTACT_FORM_RECAPTCHA: false,
+      USERCHECK_API_KEY: '',
       USE_BULLET_IN_DEVELOPMENT: false,
       USE_DEFAULT_BROWSER_LANGUAGE: true,
       USE_GHOSTSCRIPT_COMPRESSION: false,

--- a/lib/user_check.rb
+++ b/lib/user_check.rb
@@ -1,0 +1,133 @@
+require 'json'
+require 'net/http'
+
+##
+# UserCheck.com integration for UserSpamScorer.
+#
+# Looks up email domains against the UserCheck API
+# (https://www.usercheck.com) to detect disposable domains, relay domains
+# and domains with invalid MX records, and registers a scoring method for
+# each with UserSpamScorer.
+#
+# The integration is opt-in: scoring methods are only registered when
+# USERCHECK_API_KEY is set in config/general.yml.
+#
+# Privacy contract: only the email *domain* is ever sent to the API, never
+# the local part of the address. Results are cached per domain for
+# CACHE_DURATION, so a domain that has already been checked generates no
+# further requests. API failures are logged and score nothing, so an outage
+# degrades to the static domain list checks.
+module UserCheck
+  API_BASE_URL = 'https://api.usercheck.com'
+  REQUEST_TIMEOUT = 5.seconds
+  CACHE_DURATION = 28.days
+  SAFE_RESULT = { disposable: false, relay_domain: false }.freeze
+
+  class << self
+    attr_writer :api_key
+
+    def api_key
+      @api_key ||= AlaveteliConfiguration.usercheck_api_key
+    end
+
+    def enabled?
+      api_key.present?
+    end
+
+    def check_domain(domain)
+      return SAFE_RESULT unless enabled?
+      return SAFE_RESULT if domain.blank?
+
+      cache_key = "usercheck_domain_#{domain}"
+      cached_result = Rails.cache.read(cache_key)
+      return cached_result if cached_result
+
+      result = make_api_request(domain)
+
+      if result[:success]
+        Rails.cache.write(cache_key, result, expires_in: CACHE_DURATION)
+      end
+
+      result
+    end
+
+    def register_scoring_methods!
+      return unless enabled?
+
+      UserSpamScorer.register_custom_scoring_method(
+        :email_domain_is_disposable,
+        20,
+        proc do |user|
+          result = UserCheck.check_domain(user.email_domain)
+          result[:success] && result[:disposable]
+        end
+      )
+
+      UserSpamScorer.register_custom_scoring_method(
+        :email_domain_is_relay,
+        10,
+        proc do |user|
+          result = UserCheck.check_domain(user.email_domain)
+          result[:success] && result[:relay_domain]
+        end
+      )
+
+      UserSpamScorer.register_custom_scoring_method(
+        :email_domain_invalid_mx,
+        5,
+        proc do |user|
+          result = UserCheck.check_domain(user.email_domain)
+          result[:success] && result[:mx_valid] == false
+        end
+      )
+    end
+
+    private
+
+    def make_api_request(domain)
+      uri = URI("#{API_BASE_URL}/domain/#{domain}")
+
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.open_timeout = REQUEST_TIMEOUT
+      http.read_timeout = REQUEST_TIMEOUT
+
+      request = Net::HTTP::Get.new(uri)
+      request['Authorization'] = "Bearer #{api_key}"
+
+      response = http.request(request)
+
+      case response.code
+      when '200'
+        data = JSON.parse(response.body)
+        {
+          success: true,
+          disposable: data['disposable'] == true,
+          relay_domain: data['relay_domain'] == true,
+          mx_valid: data['mx'] == true,
+          raw_data: data
+        }
+      when '401'
+        Rails.logger.error('UserCheck API: Invalid API key')
+        { success: false, error: 'Invalid API key' }
+      when '429'
+        Rails.logger.warn('UserCheck API: Rate limit exceeded')
+        { success: false, error: 'Rate limit exceeded' }
+      else
+        Rails.logger.warn(
+          "UserCheck API: Unexpected response #{response.code}"
+        )
+        { success: false, error: "HTTP #{response.code}" }
+      end
+    rescue Net::OpenTimeout, Net::ReadTimeout => e
+      Rails.logger.warn("UserCheck API: Timeout: #{e.message}")
+      { success: false, error: 'Timeout' }
+    rescue JSON::ParserError => e
+      Rails.logger.error("UserCheck API: Invalid JSON response: #{e.message}")
+      { success: false, error: 'Invalid JSON response' }
+    rescue StandardError => e
+      Rails.logger.error("UserCheck API: Unexpected error: #{e.message}")
+      { success: false, error: e.message }
+    end
+  end
+end

--- a/lib/user_spam_scorer.rb
+++ b/lib/user_spam_scorer.rb
@@ -156,10 +156,12 @@ class UserSpamScorer
       instance_variable_set("@#{ key }", opts.fetch(key, self.class.send(key)))
     end
 
-    @score_mappings ||= []
-    self.class.custom_scoring_methods.each do |method_name, config|
-      @score_mappings = @score_mappings.merge(method_name => config[:score])
-    end
+    # Registered custom scoring methods provide default scores which a
+    # configured score_mappings (e.g. from config/user_spam_scorer.yml,
+    # where keys arrive as Strings) can override.
+    registered_scores =
+      self.class.custom_scoring_methods.transform_values { |c| c[:score] }
+    @score_mappings = registered_scores.merge(@score_mappings.symbolize_keys)
   end
 
   def spam?(user)
@@ -174,8 +176,14 @@ class UserSpamScorer
       result = if self.class.custom_scoring_methods.key?(method_name)
                  config = self.class.custom_scoring_methods[method_name]
                  config[:proc].call(user)
-               else
+               elsif respond_to?(method_name)
                  send(method_name, user)
+               else
+                 Rails.logger.warn(
+                   "UserSpamScorer: unknown score mapping " \
+                   "\"#{ method_name }\", skipping"
+                 )
+                 false
                end
 
       if result

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -6,5 +6,12 @@ RSpec.describe AlaveteliConfiguration do
   describe '#to_sanitized_hash' do
     subject { described_class.to_sanitized_hash }
     it { is_expected.to include(:INCOMING_EMAIL_SECRET => '[FILTERED]') }
+
+    context 'with a UserCheck API key configured' do
+      before { ENV['ALAVETELI_USERCHECK_API_KEY'] = 'real-api-key' }
+      after { ENV.delete('ALAVETELI_USERCHECK_API_KEY') }
+
+      it { is_expected.to include(USERCHECK_API_KEY: '[FILTERED]') }
+    end
   end
 end

--- a/spec/lib/user_check_spec.rb
+++ b/spec/lib/user_check_spec.rb
@@ -1,0 +1,355 @@
+require 'spec_helper'
+
+RSpec.describe UserCheck do
+  after { described_class.api_key = nil }
+
+  describe '.enabled?' do
+    it 'is true when a UserCheck API key is configured' do
+      allow(AlaveteliConfiguration).
+        to receive(:usercheck_api_key).and_return('api-key-123')
+      expect(described_class.enabled?).to eq(true)
+    end
+
+    it 'is false when the UserCheck API key is blank' do
+      allow(AlaveteliConfiguration).
+        to receive(:usercheck_api_key).and_return('')
+      expect(described_class.enabled?).to eq(false)
+    end
+
+    it 'allows the API key to be overridden for specs' do
+      described_class.api_key = 'override-key'
+      expect(described_class.enabled?).to eq(true)
+    end
+  end
+
+  describe '.check_domain' do
+    context 'when the integration is disabled' do
+      before { described_class.api_key = '' }
+
+      it 'returns a safe default result' do
+        expect(described_class.check_domain('example.com')).
+          to eq({ disposable: false, relay_domain: false })
+      end
+
+      it 'makes no HTTP requests' do
+        described_class.check_domain('example.com')
+        expect(WebMock).not_to have_requested(:get, /api\.usercheck\.com/)
+      end
+    end
+
+    context 'when the integration is enabled' do
+      let(:api_key) { 'api-key-123' }
+      let(:domain) { 'example.com' }
+      let(:api_url) { "https://api.usercheck.com/domain/#{domain}" }
+
+      before { described_class.api_key = api_key }
+
+      context 'with a blank domain' do
+        it 'returns a safe default result for nil' do
+          expect(described_class.check_domain(nil)).
+            to eq({ disposable: false, relay_domain: false })
+        end
+
+        it 'returns a safe default result for an empty string' do
+          expect(described_class.check_domain('')).
+            to eq({ disposable: false, relay_domain: false })
+        end
+
+        it 'makes no HTTP requests' do
+          described_class.check_domain(nil)
+          described_class.check_domain('')
+          expect(WebMock).not_to have_requested(:get, /api\.usercheck\.com/)
+        end
+      end
+
+      context 'caching' do
+        around do |example|
+          original_cache = Rails.cache
+          Rails.cache = ActiveSupport::Cache::MemoryStore.new
+          example.call
+          Rails.cache = original_cache
+        end
+
+        it 'caches successful results for 28 days keyed by domain' do
+          stub_request(:get, api_url).
+            to_return(status: 200, body: { 'disposable' => false }.to_json)
+
+          expect(Rails.cache).to receive(:write).
+            with("usercheck_domain_#{domain}",
+                 hash_including(success: true),
+                 expires_in: 28.days).
+            and_call_original
+
+          described_class.check_domain(domain)
+        end
+
+        it 'does not make a second HTTP request for a cached domain' do
+          stub_request(:get, api_url).
+            to_return(status: 200, body: { 'disposable' => false }.to_json)
+
+          first_result = described_class.check_domain(domain)
+          second_result = described_class.check_domain(domain)
+
+          expect(WebMock).to have_requested(:get, api_url).once
+          expect(second_result).to eq(first_result)
+        end
+
+        it 'does not cache failed results' do
+          stub_request(:get, api_url).
+            to_return(status: 500, body: '{"error": "server error"}')
+
+          described_class.check_domain(domain)
+          described_class.check_domain(domain)
+
+          expect(WebMock).to have_requested(:get, api_url).twice
+        end
+      end
+
+      context 'with a successful API response' do
+        let(:api_response) do
+          {
+            'disposable' => true,
+            'relay_domain' => false,
+            'mx' => true,
+            'status' => 200
+          }
+        end
+
+        before do
+          stub_request(:get, api_url).
+            with(headers: { 'Authorization' => "Bearer #{api_key}" }).
+            to_return(status: 200, body: api_response.to_json)
+        end
+
+        it 'returns the parsed API result' do
+          expect(described_class.check_domain(domain)).to eq(
+            success: true,
+            disposable: true,
+            relay_domain: false,
+            mx_valid: true,
+            raw_data: api_response
+          )
+        end
+      end
+      context 'with a 401 Unauthorized response' do
+        before do
+          stub_request(:get, api_url).
+            to_return(status: 401, body: '{"error": "unauthorized"}')
+        end
+
+        it 'returns a failure result' do
+          expect(described_class.check_domain(domain)).
+            to eq(success: false, error: 'Invalid API key')
+        end
+
+        it 'logs an error' do
+          expect(Rails.logger).to receive(:error).
+            with('UserCheck API: Invalid API key')
+          described_class.check_domain(domain)
+        end
+      end
+
+      context 'with a 429 Rate Limit response' do
+        before do
+          stub_request(:get, api_url).
+            to_return(status: 429, body: '{"error": "rate limited"}')
+        end
+
+        it 'returns a failure result' do
+          expect(described_class.check_domain(domain)).
+            to eq(success: false, error: 'Rate limit exceeded')
+        end
+
+        it 'logs a warning' do
+          expect(Rails.logger).to receive(:warn).
+            with('UserCheck API: Rate limit exceeded')
+          described_class.check_domain(domain)
+        end
+      end
+
+      context 'with another HTTP error response' do
+        before do
+          stub_request(:get, api_url).
+            to_return(status: 500, body: '{"error": "server error"}')
+        end
+
+        it 'returns a failure result with the HTTP code' do
+          expect(described_class.check_domain(domain)).
+            to eq(success: false, error: 'HTTP 500')
+        end
+
+        it 'logs a warning' do
+          expect(Rails.logger).to receive(:warn).
+            with('UserCheck API: Unexpected response 500')
+          described_class.check_domain(domain)
+        end
+      end
+
+      context 'with a timeout' do
+        before { stub_request(:get, api_url).to_timeout }
+
+        it 'returns a failure result' do
+          expect(described_class.check_domain(domain)).
+            to eq(success: false, error: 'Timeout')
+        end
+
+        it 'logs a warning' do
+          expect(Rails.logger).to receive(:warn).
+            with(/UserCheck API: Timeout:/)
+          described_class.check_domain(domain)
+        end
+      end
+
+      context 'with an invalid JSON response' do
+        before do
+          stub_request(:get, api_url).
+            to_return(status: 200, body: 'not json')
+        end
+
+        it 'returns a failure result' do
+          expect(described_class.check_domain(domain)).
+            to eq(success: false, error: 'Invalid JSON response')
+        end
+
+        it 'logs an error' do
+          expect(Rails.logger).to receive(:error).
+            with(/UserCheck API: Invalid JSON response:/)
+          described_class.check_domain(domain)
+        end
+      end
+
+      context 'with a network error' do
+        before do
+          stub_request(:get, api_url).
+            to_raise(SocketError.new('network unreachable'))
+        end
+
+        it 'returns a failure result with the error message' do
+          expect(described_class.check_domain(domain)).
+            to eq(success: false, error: 'network unreachable')
+        end
+
+        it 'logs an error' do
+          expect(Rails.logger).to receive(:error).
+            with(/UserCheck API: Unexpected error:/)
+          described_class.check_domain(domain)
+        end
+      end
+
+      context 'with an SSL error' do
+        before do
+          stub_request(:get, api_url).
+            to_raise(OpenSSL::SSL::SSLError.new('certificate verify failed'))
+        end
+
+        it 'returns a failure result with the error message' do
+          expect(described_class.check_domain(domain)).
+            to eq(success: false, error: 'certificate verify failed')
+        end
+      end
+    end
+  end
+
+  describe '.register_scoring_methods!' do
+    after { UserSpamScorer.reset }
+
+    context 'when the integration is disabled' do
+      before { described_class.api_key = '' }
+
+      it 'registers no scoring methods' do
+        described_class.register_scoring_methods!
+        expect(UserSpamScorer.custom_scoring_methods).to be_empty
+      end
+    end
+
+    context 'when the integration is enabled' do
+      let(:user) { double('User', email_domain: 'example.com') }
+
+      before do
+        described_class.api_key = 'api-key-123'
+        described_class.register_scoring_methods!
+      end
+
+      def registered_proc(method_name)
+        UserSpamScorer.custom_scoring_methods[method_name][:proc]
+      end
+
+      it 'registers email_domain_is_disposable with a default score of 20' do
+        expect(
+          UserSpamScorer.custom_scoring_methods[
+            :email_domain_is_disposable][:score]
+        ).to eq(20)
+      end
+
+      it 'registers email_domain_is_relay with a default score of 10' do
+        expect(
+          UserSpamScorer.custom_scoring_methods[:email_domain_is_relay][:score]
+        ).to eq(10)
+      end
+
+      it 'registers email_domain_invalid_mx with a default score of 5' do
+        expect(
+          UserSpamScorer.custom_scoring_methods[
+            :email_domain_invalid_mx][:score]
+        ).to eq(5)
+      end
+
+      it 'scores email_domain_is_disposable for a disposable domain' do
+        allow(described_class).to receive(:check_domain).
+          with('example.com').
+          and_return(success: true, disposable: true, relay_domain: false,
+                     mx_valid: true)
+
+        expect(registered_proc(:email_domain_is_disposable).call(user)).
+          to eq(true)
+        expect(registered_proc(:email_domain_is_relay).call(user)).
+          to eq(false)
+      end
+
+      it 'scores email_domain_is_relay for a relay domain' do
+        allow(described_class).to receive(:check_domain).
+          with('example.com').
+          and_return(success: true, disposable: false, relay_domain: true,
+                     mx_valid: true)
+
+        expect(registered_proc(:email_domain_is_relay).call(user)).
+          to eq(true)
+        expect(registered_proc(:email_domain_is_disposable).call(user)).
+          to eq(false)
+      end
+
+      it 'scores email_domain_invalid_mx for a domain with invalid MX' do
+        allow(described_class).to receive(:check_domain).
+          with('example.com').
+          and_return(success: true, disposable: false, relay_domain: false,
+                     mx_valid: false)
+
+        expect(registered_proc(:email_domain_invalid_mx).call(user)).
+          to eq(true)
+      end
+
+      it 'does not score email_domain_invalid_mx when MX is valid' do
+        allow(described_class).to receive(:check_domain).
+          with('example.com').
+          and_return(success: true, disposable: false, relay_domain: false,
+                     mx_valid: true)
+
+        expect(registered_proc(:email_domain_invalid_mx).call(user)).
+          to eq(false)
+      end
+
+      it 'scores nothing when the API request fails' do
+        allow(described_class).to receive(:check_domain).
+          with('example.com').
+          and_return(success: false, error: 'Timeout')
+
+        expect(registered_proc(:email_domain_is_disposable).call(user)).
+          to be_falsey
+        expect(registered_proc(:email_domain_is_relay).call(user)).
+          to be_falsey
+        expect(registered_proc(:email_domain_invalid_mx).call(user)).
+          to be_falsey
+      end
+    end
+  end
+end

--- a/spec/lib/user_spam_scorer_spec.rb
+++ b/spec/lib/user_spam_scorer_spec.rb
@@ -282,6 +282,28 @@ RSpec.describe UserSpamScorer do
 
       described_class.reset
     end
+
+    it 'prefers a configured score over a registered default score' do
+      described_class.register_custom_scoring_method(
+        :custom_method, 5, proc { |_u| true }
+      )
+
+      scorer = described_class.new(score_mappings: { custom_method: 30 })
+      expect(scorer.score_mappings[:custom_method]).to eq(30)
+
+      described_class.reset
+    end
+
+    it 'symbolizes String score_mappings keys as loaded from YAML config' do
+      described_class.register_custom_scoring_method(
+        :custom_method, 5, proc { |_u| true }
+      )
+
+      scorer = described_class.new(score_mappings: { 'custom_method' => 1 })
+      expect(scorer.score_mappings).to eq({ custom_method: 1 })
+
+      described_class.reset
+    end
   end
 
   describe '#spam?' do
@@ -324,11 +346,22 @@ RSpec.describe UserSpamScorer do
       expect(scorer.score(user)).to eq(5)
     end
 
-    it 'raises an error if a mapping is invalid' do
+    it 'skips a mapping which is neither registered nor an instance method' do
+      user_attrs = { name: 'Bob Smith' }
+      user = mock_model(User, user_attrs)
+      scorer = described_class.new(
+        score_mappings: { name_is_one_word?: 1, invalid_method: 5 }
+      )
+      expect(scorer.score(user)).to eq(0)
+    end
+
+    it 'warns when skipping an unknown mapping' do
       user_attrs = { name: 'Bob Smith' }
       user = mock_model(User, user_attrs)
       scorer = described_class.new(score_mappings: { invalid_method: 1 })
-      expect { scorer.score(user) }.to raise_error(NoMethodError)
+      expect(Rails.logger).to receive(:warn).
+        with(/UserSpamScorer: unknown score mapping "invalid_method"/)
+      scorer.score(user)
     end
 
     it 'executes custom scoring methods' do


### PR DESCRIPTION
## Relevant issue(s)

mysociety/alaveteli#9467

## What does this do?

Adds an opt-in integration with [UserCheck](https://www.usercheck.com) to `UserSpamScorer`. When `USERCHECK_API_KEY` is set in `config/general.yml`, three extra scoring methods register, each backed by a live lookup of the email **domain** of the user being scored:

| Check | Default score |
| --- | --- |
| `email_domain_is_disposable` | 20 |
| `email_domain_is_relay` | 10 |
| `email_domain_invalid_mx` | 5 |

When the key is blank nothing registers and behaviour is unchanged.

It also makes `score_mappings` genuinely configurable: scores passed to `register_custom_scoring_method` now act as defaults which `config/user_spam_scorer.yml` can override, and String keys from the YAML config are symbolised so they hit the custom method registry.

## Why was this needed?

Core's only email-domain defence is static lists (`DEFAULT_SUSPICIOUS_DOMAINS`, `DEFAULT_SPAM_DOMAINS`, `DEFAULT_SPAM_TLDS`), and disposable-mail providers add domains faster than a hand-maintained list can track. WhatDoTheyKnow solved this at theme level (mysociety/whatdotheyknow-theme#2020, mysociety/whatdotheyknow-theme#2023); this upstreams it so each site doesn't reimplement it, per @garethrees' suggestion on openaustralia/righttoknow#1049.

## Implementation notes

- **Privacy contract** (documented on the module): only the email domain is ever sent to the API, never the local part. Successful results are cached per domain for 28 days, so an already-seen domain generates no further requests. This keeps third-party disclosure down to "someone signed up with an address at this domain", which matters for deployments with cross-border transfer rules (APP 8, GDPR Chapter V).
- **Score mapping precedence**: `#initialize` previously merged registered custom scores in *after* configured mappings, so registration always won. Registered scores are now reverse-merged as defaults.
- **String keys from YAML**: previously a configured custom method score would miss the Symbol-keyed registry and fall through to `send`, raising `NoMethodError`. Keys are now symbolised.
- **Unknown mappings**: a mapping whose method is neither registered nor an instance method is now skipped with a `Rails.logger.warn` instead of raising, so a site that configures scores for the UserCheck checks doesn't crash scoring in environments where the key is unset.
- **Admin debug page**: `sensitive_key_patterns` extended with `API_KEY` so the key renders as `[FILTERED]`.
- Deliberately leaves out WDTK's `content_limit` override for accounts tagged `disposable_email`, which was a temporary rollout measure (per the issue).

## Screenshots

N/A

## Notes to reviewer

- **Silent failure trade-off**: API timeouts/errors are logged and score nothing, so an outage degrades to current behaviour — but a site can't easily tell the checks have stopped running. This mirrors the WDTK theme implementation; happy to add more visibility if you'd prefer.
- This implements the issue as filed; there's no maintainer sign-off on the shape yet, so treat the design choices above as proposals.
- A companion documentation PR against `gh-pages` is being opened and will be cross-linked here.
- Test evidence (run via docker compose): `bundle exec rspec spec/lib/user_check_spec.rb spec/lib/user_spam_scorer_spec.rb spec/lib/configuration_spec.rb` → 146 examples, 0 failures; `spec/controllers/user_controller_spec.rb`, `spec/controllers/users/sessions_controller_spec.rb`, `spec/controllers/user_profile/about_me_controller_spec.rb` → all green.

<hr>

Have you updated the changelog? Yes — see `doc/CHANGES.md` under `# develop`.