### PR TITLE
Document USERCHECK_API_KEY and spammy sign-up scoring

### DIFF
--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -113,6 +113,7 @@ indentation correct. If in doubt, look at the examples already in the file, and 
 <code><a href="#cookie_store_session_secret">COOKIE_STORE_SESSION_SECRET</a></code>
 <br> <code><a href="#recaptcha_site_key">RECAPTCHA_SITE_KEY</a></code>
 <br> <code><a href="#recaptcha_secret_key">RECAPTCHA_SECRET_KEY</a></code>
+<br> <code><a href="#usercheck_api_key">USERCHECK_API_KEY</a></code>
 <br> <code><a href="#geoip_database">GEOIP_DATABASE</a></code>
 <br> <code><a href="#gaze_url">GAZE_URL</a></code>
 <br> <code><a href="#ga_code">GA_CODE</a></code> (GA=Google Analytics)
@@ -1198,6 +1199,33 @@ href="#smtp_mailer_enable_starttls_auto">SMTP_MAILER_ENABLE_STARTTLS_AUTO</a>.
   </dd>
 
   <dt>
+    <a name="usercheck_api_key"><code>USERCHECK_API_KEY</code></a>
+  </dt>
+  <dd>
+      API key for <a href="https://www.usercheck.com">UserCheck.com</a>, used to
+      detect spammy sign-ups. If set, Alaveteli checks the email domain of each
+      new user account against the UserCheck API and adds to the account's spam
+      score if the domain is a disposable email domain (default score 20), a
+      relay or forwarding domain (10), or has invalid MX records (5). If the key
+      is not set, the checks don't run at all. Only the email
+      <strong>domain</strong> is sent to the API &mdash; never the full email
+      address &mdash; and results are cached for 28 days per domain, so a domain
+      that has already been seen generates no further requests. If the API is
+      unavailable, the checks silently score nothing and Alaveteli falls back to
+      its existing behaviour. The default scores can be changed via
+      <code>score_mappings</code> in
+      <a href="#other-config"><code>config/user_spam_scorer.yml</code></a>.
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li>
+            <code>USERCHECK_API_KEY: 'xxxxxxxxxxxxxxxxxxxxxxxx'</code>
+        </li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
     <a name="geoip_database"><code>GEOIP_DATABASE</code></a>
   </dt>
   <dd>
@@ -1716,5 +1744,18 @@ which you can copy into place.
   </dt>
   <dd>
     Apache and Nginx configuration suggestions
+  </dd>
+  <dt>
+    <strong>user_spam_scorer.yml</strong>
+  </dt>
+  <dd>
+    optional per-site tuning of the user spam scorer, which scores new user
+    accounts for spam signals. You can adjust the weight given to each check
+    via <code>score_mappings</code> &mdash; including the three
+    <a href="https://www.usercheck.com">UserCheck.com</a> email-domain checks
+    enabled by
+    <code><a href="#usercheck_api_key">USERCHECK_API_KEY</a></code> &mdash;
+    and override the lists of suspicious and spam email domains. Copy
+    <code>config/user_spam_scorer.yml-example</code> into place to use it
   </dd>
 </dl>

--- a/docs/running/handling_spam.md
+++ b/docs/running/handling_spam.md
@@ -12,6 +12,7 @@ title: Handling spam
 There are several ways in which spammers can cause problems on an Alaveteli site:
 
 * [Spam emails sent to request addresses](#spam-emails-sent-to-request-addresses)
+* [Spammy sign-ups](#spammy-sign-ups)
 * [Spammy user profiles](#spammy-user-profiles)
 * [Spammy annotations](#spammy-annotations)
 
@@ -165,6 +166,23 @@ You can unset the rejection of incoming messages at the MTA for a given request 
     bundle exec rake config_files:unset_reject_incoming_at_mta REQUEST_ID=4
 
 This will unset the flag that shows that mail is being rejected at the MTA, and set **allow new responses from...** to `authority_only` for the request.
+
+## Spammy sign-ups
+
+Alaveteli scores new user accounts for spam signals as they sign up, using its `UserSpamScorer`. By default this uses static heuristics — checks on the user's name and email address, and hand-maintained lists of suspicious and spam email domains — and accounts that score highly can be prevented from signing up or flagged for admin attention.
+
+Setting the <code><a href="{{ page.baseurl }}/docs/customising/config/#usercheck_api_key">
+USERCHECK_API_KEY</a></code> setting in the config additionally enables live lookups against
+<a href="https://www.usercheck.com">UserCheck.com</a>, a service that tracks problematic email
+domains. When the key is set, the email domain of each new account is checked against the
+UserCheck API, and the account's spam score is increased if the domain is a disposable email
+domain (default score 20), a relay or forwarding domain (10), or has invalid MX records (5).
+These live lookups catch disposable-email providers that cycle through new domains faster than
+a hand-maintained list can track them.
+
+The default weights can be tuned — along with those of the other checks — via `score_mappings` in `config/user_spam_scorer.yml`, so you can adjust how heavily each signal counts for your site.
+
+Only the email **domain** is disclosed to UserCheck — never the full email address — and results are cached for 28 days per domain, so a domain that has already been seen generates no further requests. If the UserCheck API is unavailable or returns an error, the checks silently score nothing and spam scoring degrades to the static-list behaviour described above.
 
 ## Spammy user profiles
 


### PR DESCRIPTION
## Relevant issue(s)

Relates to mysociety/alaveteli#9467. Documents behaviour introduced by mysociety/alaveteli#9468.

## What does this do?

Documents the new `USERCHECK_API_KEY` setting and user spam scoring on alaveteli.org:

- `docs/customising/config.md`: adds `USERCHECK_API_KEY` to the general admin topic index and the general settings reference, and lists `user_spam_scorer.yml` under other configuration files.
- `docs/running/handling_spam.md`: adds a "Spammy sign-ups" section explaining `UserSpamScorer`'s static heuristics, the live UserCheck.com email-domain checks and their default scores, tuning via `config/user_spam_scorer.yml`, the privacy properties (only the domain is disclosed, cached 28 days) and silent degradation on API failure.

## Why was this needed?

mysociety/alaveteli#9468 adds optional UserCheck.com email-domain checks to the user spam scorer, enabled by setting `USERCHECK_API_KEY`. The site documentation needs to cover the new setting and the sign-up spam scoring it feeds into.

## Implementation notes

English docs only; nothing under `es/` was touched.

## Screenshots

## Notes to reviewer

Do not merge until mysociety/alaveteli#9468 lands — this documents behaviour introduced there.

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]