### PR TITLE
Allow admins to download batch requests

### DIFF
--- a/app/controllers/alaveteli_pro/batch_downloads_controller.rb
+++ b/app/controllers/alaveteli_pro/batch_downloads_controller.rb
@@ -6,6 +6,8 @@ class AlaveteliPro::BatchDownloadsController < AlaveteliPro::BaseController
   include ActionController::Live
 
   skip_before_action :html_response
+  skip_before_action :pro_user_authenticated?
+  before_action :user_authenticated?
 
   def show
     authorize! :download, info_request_batch
@@ -21,8 +23,17 @@ class AlaveteliPro::BatchDownloadsController < AlaveteliPro::BaseController
 
   private
 
+  def user_authenticated?
+    return if authenticated?
+
+    ask_to_login(
+      web: _('To download batch requests'),
+      email: _('Then you can download batch requests')
+    )
+  end
+
   def info_request_batch
-    @info_request_batch ||= current_user.info_request_batches.
+    @info_request_batch ||= InfoRequestBatch.
       find(params[:info_request_batch_id])
   end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -125,7 +125,8 @@ class Ability
 
     # Downloading batch requests
     can :download, InfoRequestBatch do |batch_request|
-      user && user == batch_request.user && user.is_pro?
+      (user && user == batch_request.user && user.is_pro?) ||
+        can?(:admin, batch_request)
     end
 
     # Updating batch requests

--- a/app/views/info_request_batch/show.html.erb
+++ b/app/views/info_request_batch/show.html.erb
@@ -60,7 +60,7 @@
                locals: { info_request_batch: @info_request_batch } %>
   <% end %>
 
-  <% if @info_request_batch.is_owning_user?(current_user) %>
+  <% if can? :download, @info_request_batch %>
     <%= render partial: 'downloads',
                locals: { info_request_batch: @info_request_batch } %>
   <% end %>

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Allow admins to download zips of batch requests, and only show batch download
+  links to users who can use them (Ben Fairless)
 * Allow admins to hide a request without notifying the user (Laurent Savaete)
 * Show public body change history while editing it (Laurent Savaete)
 * Cache recent request events on the front page for 10 minutes (Chris Mytton)

--- a/spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb
+++ b/spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb
@@ -17,17 +17,22 @@ RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
 
     context 'with a signed-in non-pro user' do
       let(:user) { FactoryBot.create(:user) }
-      before { sign_in user }
+      let(:batch) { FactoryBot.create(:info_request_batch, user: user) }
 
-      it 'redirects to site root' do
-        show
-        expect(response).to redirect_to(root_path)
+      before do
+        sign_in user
+        allow(controller).to receive(:current_user).and_return(user)
+      end
+
+      it { is_expected.to_not be_able_to(:download, batch) }
+
+      it 'denies access to their own batch' do
+        expect { show(id: batch.id) }.to raise_error(CanCan::AccessDenied)
       end
     end
 
     context 'with a signed-in pro user' do
       let(:pro_user) { FactoryBot.create(:pro_user) }
-      let(:ability) { Ability.new(pro_user) }
 
       before do
         sign_in pro_user
@@ -48,10 +53,8 @@ RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
 
         it { is_expected.to_not be_able_to(:download, batch) }
 
-        it 'raise 404' do
-          expect { show(id: batch.id) }.to raise_error(
-            ActiveRecord::RecordNotFound
-          )
+        it 'denies access' do
+          expect { show(id: batch.id) }.to raise_error(CanCan::AccessDenied)
         end
       end
 
@@ -60,10 +63,7 @@ RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
 
         before do
           # stub database calls
-          allow(pro_user).to(
-            receive_message_chain(:info_request_batches, :find).
-              and_return(batch)
-          )
+          allow(InfoRequestBatch).to receive(:find).and_return(batch)
         end
 
         it { is_expected.to be_able_to(:download, batch) }
@@ -133,6 +133,80 @@ RSpec.describe AlaveteliPro::BatchDownloadsController, type: :controller do
             expect(response.header['Content-Type']).to include 'text/csv'
           end
         end
+      end
+    end
+
+    context 'with a signed-in admin user' do
+      let(:admin_user) { FactoryBot.create(:admin_user) }
+
+      before do
+        sign_in admin_user
+        allow(controller).to receive(:current_user).and_return(admin_user)
+      end
+
+      context 'when info_request_batch owned by someone else' do
+        let(:batch) { FactoryBot.create(:info_request_batch) }
+
+        before do
+          # stub database calls
+          allow(InfoRequestBatch).to receive(:find).and_return(batch)
+        end
+
+        it { is_expected.to be_able_to(:download, batch) }
+
+        context 'when ZIP format' do
+          before do
+            # stub service calls - testing stream content is hard :(
+            allow(InfoRequestBatchZip).to receive(:new).
+              with(batch, ability: controller.current_ability).
+              and_return(double(:zip, name: 'NAME', stream: []))
+
+            show(format: 'zip')
+          end
+
+          it 'is a successful request' do
+            expect(response).to be_successful
+          end
+        end
+
+        context 'when CSV format' do
+          before do
+            # stub service calls
+            allow(InfoRequestBatchMetrics).to receive(:new).with(batch).
+              and_return(double(:metrics, to_csv: 'CSV_DATA', name: 'NAME'))
+
+            show(format: 'csv')
+          end
+
+          it 'is a successful request' do
+            expect(response).to be_successful
+          end
+        end
+      end
+
+      context 'when info_request_batch is embargoed' do
+        let(:batch) { FactoryBot.create(:info_request_batch, :embargoed) }
+
+        it { is_expected.to_not be_able_to(:download, batch) }
+
+        it 'denies access' do
+          expect { show(id: batch.id) }.to raise_error(CanCan::AccessDenied)
+        end
+      end
+    end
+
+    context 'with a signed-in pro admin user' do
+      let(:pro_admin_user) { FactoryBot.create(:pro_admin_user) }
+
+      before do
+        sign_in pro_admin_user
+        allow(controller).to receive(:current_user).and_return(pro_admin_user)
+      end
+
+      context 'when info_request_batch is embargoed' do
+        let(:batch) { FactoryBot.create(:info_request_batch, :embargoed) }
+
+        it { is_expected.to be_able_to(:download, batch) }
       end
     end
   end


### PR DESCRIPTION
Fixes #5955. Downstream report with full investigation: openaustralia/righttoknow#1043.

## What's the problem?

The Downloads box on a batch request page is shown to batch owners **and admins** (`InfoRequestBatch#is_owning_user?`), but the `:download` ability and `AlaveteliPro::BatchDownloadsController` only permit **pro batch owners**:

- An admin clicking ZIP gets `ERR_INVALID_RESPONSE` — the controller scopes the lookup to `current_user.info_request_batches`, raises `RecordNotFound`, and `render_exception` answers the `.zip` format with a zero-byte body still labelled `application/zip`.
- A non-pro batch owner is bounced to the homepage by `pro_user_authenticated?`.

## What's the fix?

Per the discussion in #5955, batch download becomes a pro and admin feature (individual requests within a batch remain downloadable by anyone):

- **Ability**: `:download` now also allows anyone who `can? :admin` the batch — admins for public batches, pro admins for embargoed ones. Pro batch owners are unchanged; non-pro owners still can't bulk-export correspondence.
- **Controller**: skip `pro_user_authenticated?` (same approach as `AlaveteliPro::EmbargoesController` for admin-usable actions), look the batch up directly rather than through `current_user`, and rely on `authorize! :download`. Unauthenticated users are still asked to log in.
- **View**: the Downloads box now renders only when `can? :download`, so non-pro owners and (for embargoed batches) non-pro admins stop seeing links that never worked.

One behaviour change worth noting: a signed-in user requesting someone else's batch download now gets `PermissionDenied` (403) rather than a 404. Batches themselves are public objects, so this doesn't leak anything.

Out of scope: `render_exception` still answers non-HTML formats with a bare `head @status`, which is what turned the original 404 into an opaque browser error — that's worth a separate fix (see the downstream issue for details).

## Testing

Updated `spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb`:

- admin (non-owner) can download ZIP/CSV of a public batch
- admin cannot download an embargoed batch; pro admin can
- non-pro owner is denied
- pro user requesting someone else's batch now expects `CanCan::AccessDenied` instead of `RecordNotFound`

`spec/controllers/alaveteli_pro/batch_downloads_controller_spec.rb` (23 examples), `spec/models/ability_spec.rb` (264) and `spec/controllers/info_request_batch_controller_spec.rb` (16) all pass.

---

Written with AI assistance (Claude Code, model `anthropic.claude-fable-5`). All changes reviewed and specs run locally.