### PR TITLE
Drop support for PostgreSQL 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,20 +55,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { ruby: '3.4', postgres: 13.5 }
-
-    services:
-      postgres:
-        image: fixmystreet/postgres:${{ matrix.postgres }}
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports:
-        - '5432:5432'
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+        - { ruby: '3.4', postgres: 15.19 }
 
     env:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/alaveteli_test
@@ -79,6 +66,24 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+
+    - name: Start PostgreSQL
+      run: |
+        docker build \
+          --build-arg POSTGRES_VERSION=${{ matrix.postgres }} \
+          --file docker/Dockerfile-postgres --tag alaveteli-postgres .
+        docker run --detach --name postgres \
+          --env POSTGRES_PASSWORD=postgres --publish 5432:5432 \
+          alaveteli-postgres
+        for _ in $(seq 60); do
+          if docker exec postgres \
+               pg_isready -q -h 127.0.0.1 -U postgres -d alaveteli_test; then
+            exit 0
+          fi
+          sleep 2
+        done
+        docker logs postgres
+        exit 1
 
     - name: Cache apt packages
       uses: actions/cache@v4
@@ -100,14 +105,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-
-    - name: Setup database
-      run: |
-        psql postgres://postgres:postgres@localhost:5432 <<-EOSQL
-          CREATE DATABASE template_utf8 TEMPLATE template0 ENCODING "UTF-8";
-          UPDATE pg_database SET datistemplate=true WHERE datname='template_utf8';
-          CREATE DATABASE alaveteli_test TEMPLATE template_utf8;
-        EOSQL
 
     - name: Configure application and storage
       run: |

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Drop support for PostgreSQL 13 (Graeme Porteous)
 * Allow admins to hide a request without notifying the user (Laurent Savaete)
 * Show public body change history while editing it (Laurent Savaete)
 * Warn users that their latest request may not be listed yet (Laurent Savaete)
@@ -89,6 +90,16 @@
 * Block various action links via robots.txt (Laurent Savaete)
 
 ## Upgrade Notes
+
+* **IMPORTANT! We no longer support PostgreSQL 13**. Please upgrade to at least
+  version 15 before upgrading Alaveteli. This is the version shipped with Debian
+  Bookworm, and PostgreSQL 13 is now out of support upstream.
+
+  A major version upgrade needs the data moving over, either with `pg_upgrade`
+  or by dumping and restoring. Take a backup first and check your site works
+  before upgrading Alaveteli.
+
+  See: https://www.postgresql.org/docs/15/upgrading.html
 
 * _Required:_ This release now allows responses to be received from any source,
   1. Postfix/Exim `./script/mailin` pipe,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
 ARG RUBY_VERSION=3.4
 FROM ruby:${RUBY_VERSION}-trixie
 
-ENV DOCKER 1
-ENV DEBIAN_FRONTEND noninteractive
+ENV DOCKER=1
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
     apt-get install -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,10 @@ ENV DOCKER=1
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
+    apt-get install -y postgresql-common && \
+    /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y
+
+RUN apt-get update -y && \
     apt-get install -y \
     elinks \
     ghostscript \
@@ -14,7 +18,7 @@ RUN apt-get update -y && \
     libreoffice-writer-nogui \
     pdftk \
     poppler-utils \
-    postgresql-client \
+    postgresql-client-15 \
     sendmail \
     tnef \
     unrtf \

--- a/docker/Dockerfile-postgres
+++ b/docker/Dockerfile-postgres
@@ -1,5 +1,5 @@
 ARG POSTGRES_VERSION=15.19
 FROM postgres:${POSTGRES_VERSION}
 RUN localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
-ENV LANG en_GB.utf8
+ENV LANG=en_GB.utf8
 ADD ./docker/createdb.sh /docker-entrypoint-initdb.d/

--- a/docker/Dockerfile-postgres
+++ b/docker/Dockerfile-postgres
@@ -1,4 +1,5 @@
-FROM postgres:13.5
+ARG POSTGRES_VERSION=15.19
+FROM postgres:${POSTGRES_VERSION}
 RUN localedef -i en_GB -c -f UTF-8 -A /usr/share/locale/locale.alias en_GB.UTF-8
 ENV LANG en_GB.utf8
 ADD ./docker/createdb.sh /docker-entrypoint-initdb.d/

--- a/lib/database_collation.rb
+++ b/lib/database_collation.rb
@@ -3,8 +3,6 @@
 # a given language. Prefer the class method .supports? rather than creating a
 # new instance.
 class DatabaseCollation
-  MINIMUM_POSTGRESQL_VERSION = 90112 # rubocop:disable Style/NumericLiterals
-
   attr_reader :connection
 
   # Public: Does the connected database support collation in the given locale?
@@ -35,21 +33,13 @@ class DatabaseCollation
   #
   # Returns a Boolean
   def supports?(locale)
-    exist? && supported_collations.include?(locale)
+    postgresql? && supported_collations.include?(locale)
   end
 
   private
 
-  def exist?
-    postgresql? && postgresql_version >= MINIMUM_POSTGRESQL_VERSION
-  end
-
   def postgresql?
     adapter_name == 'PostgreSQL'
-  end
-
-  def postgresql_version
-    @postgresql_version ||= connection.send(:postgresql_version) if postgresql?
   end
 
   def supported_collations

--- a/spec/lib/database_collation_spec.rb
+++ b/spec/lib/database_collation_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe DatabaseCollation do
       expect(database.supports?('en_GB')).to be false
     end
 
-    it 'does not support collation if the postgresql version is too old' do
-      database = DatabaseCollation.
-                 new(mock_connection(postgresql_version: 90111)) # rubocop:disable Style/NumericLiterals
-      expect(database.supports?('en_GB')).to be false
-    end
-
     it 'does not support collation if the collation does not exist' do
       database = DatabaseCollation.new(mock_connection)
       expect(database.supports?('es')).to be false
@@ -56,9 +50,7 @@ RSpec.describe DatabaseCollation do
 end
 
 def mock_connection(connection_double_opts = {})
-  # Connection must be PostgreSQL 90112 or greater
-  default_double_opts = { adapter_name: 'PostgreSQL',
-                          postgresql_version: 90112 } # rubocop:disable Style/NumericLiterals
+  default_double_opts = { adapter_name: 'PostgreSQL' }
 
   connection_double_opts = default_double_opts.merge(connection_double_opts)
 


### PR DESCRIPTION
PostgreSQL 13 reached end of life in November 2025, so move to version 15, the release shipped with Debian Bookworm.

CI used to pull `fixmystreet/postgres`, which has no tag past 13.5. All that image adds to the official one is an en_GB locale, the same thing our own `docker/Dockerfile-postgres` does, so CI now builds and runs that instead. Its `createdb.sh` sets the databases up, replacing the psql step.