### PR TITLE
Extract `OutgoingMessage::Subject`

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -252,7 +252,7 @@ class RequestController < ApplicationController
 
     @info_request.user = request_user
 
-    if spam_subject?(@outgoing_message.subject, @user)
+    if spam_subject?(@outgoing_message.subject(html: false), @user)
       handle_spam_subject(@info_request.user) && return
     end
 

--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -72,16 +72,6 @@ class OutgoingMailer < ApplicationMailer
     end
   end
 
-  # Subject to use for followup
-  def self.subject_for_followup(info_request, outgoing_message, options = {})
-    if outgoing_message.what_doing == 'internal_review'
-      _("Internal review of {{email_subject}}", email_subject: info_request.email_subject_request(html: options[:html]))
-    else
-      info_request.email_subject_followup(incoming_message: outgoing_message.incoming_message_followup,
-                                                 html: options[:html])
-    end
-  end
-
   # Whether we have a valid email address for a followup
   def self.is_followupable?(info_request, incoming_message_followup)
     if incoming_message_followup.nil? || !incoming_message_followup.valid_to_reply_to?

--- a/app/mailers/outgoing_mailer.rb
+++ b/app/mailers/outgoing_mailer.rb
@@ -22,7 +22,7 @@ class OutgoingMailer < ApplicationMailer
 
     mail(from: @outgoing_message.from,
          to: @outgoing_message.to,
-         subject: @outgoing_message.subject)
+         subject: @outgoing_message.subject(html: false))
   end
 
   # Later message to public body regarding existing request
@@ -35,7 +35,7 @@ class OutgoingMailer < ApplicationMailer
 
     mail(from: @outgoing_message.from,
          to: @outgoing_message.to,
-         subject: @outgoing_message.subject)
+         subject: @outgoing_message.subject(html: false))
   end
 
   # TODO: the condition checking valid_to_reply_to? also appears in views/request/_followup.html.erb,

--- a/app/mailers/request_mailer.rb
+++ b/app/mailers/request_mailer.rb
@@ -30,7 +30,9 @@ class RequestMailer < ApplicationMailer
 
     mail(from: from_user.name_and_email,
          to: info_request.incoming_name_and_email,
-         subject: info_request.email_subject_followup(html: false))
+         subject: OutgoingMessage::Subject.new(
+           info_request: info_request, html: false
+         ).followup)
   end
 
   # Used when a response is uploaded using the API

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -323,7 +323,9 @@ class InfoRequest < ApplicationRecord
     return [] unless subject_line
 
     # try to find a match on InfoRequest#title
-    reply_format = InfoRequest.new(title: '').email_subject_followup
+    reply_format = OutgoingMessage::Subject.new(
+      info_request: InfoRequest.new(title: ''), html: false
+    ).followup
     requests_by_title = InfoRequest.left_joins(:incoming_messages).
       where(title: subject_line.gsub(/#{reply_format}/i, '').strip)
 
@@ -816,26 +818,6 @@ class InfoRequest < ApplicationRecord
 
   def incoming_name_and_email
     MailHandler.address_from_name_and_email(user_name, incoming_email)
-  end
-
-  # Subject lines for emails about the request
-  def email_subject_request(opts = {})
-    html = opts.fetch(:html, true)
-    _('{{law_used_full}} request - {{title}}',
-      law_used_full: legislation.to_s(:full),
-      title: (html ? title : title.html_safe))
-  end
-
-  def email_subject_followup(opts = {})
-    incoming_message = opts.fetch(:incoming_message, nil)
-    html = opts.fetch(:html, true)
-    if incoming_message.nil? || !incoming_message.valid_to_reply_to? || !incoming_message.subject
-      'Re: ' + email_subject_request(html: html)
-    elsif incoming_message.subject.match(/^Re:/i)
-      incoming_message.subject
-    else
-      'Re: ' + incoming_message.subject
-    end
   end
 
   def legislation

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -155,18 +155,21 @@ class OutgoingMessage < ApplicationRecord
   # message.
   #
   # Returns a String
-  def subject
+  def subject(html: true, incoming_message: incoming_message_followup)
+    subject = OutgoingMessage::Subject.new(
+      info_request: info_request,
+      incoming_message: incoming_message,
+      html: html
+    )
+
     if message_type == 'followup'
       if what_doing == 'internal_review'
-        _("Internal review of {{email_subject}}",
-          email_subject: info_request.email_subject_request(html: false))
+        subject.internal_review
       else
-        info_request.
-          email_subject_followup(incoming_message: incoming_message_followup,
-                                 html: false)
+        subject.followup
       end
     else
-      info_request.email_subject_request(html: false)
+      subject.initial_request
     end
   end
 

--- a/app/models/outgoing_message/subject.rb
+++ b/app/models/outgoing_message/subject.rb
@@ -1,0 +1,34 @@
+# Composes the subject line for an OutgoingMessage's email
+class OutgoingMessage::Subject
+  def initialize(info_request:, html:, incoming_message: nil)
+    @info_request = info_request
+    @incoming_message = incoming_message
+    @html = html
+  end
+
+  def initial_request
+    _('{{law_used_full}} request - {{title}}',
+      law_used_full: info_request.legislation.to_s(:full),
+      title: html ? info_request.title : info_request.title.html_safe)
+  end
+
+  def followup
+    if incoming_message.nil? ||
+       !incoming_message.valid_to_reply_to? ||
+       !incoming_message.subject
+      'Re: ' + initial_request
+    elsif incoming_message.subject.match(/^Re:/i)
+      incoming_message.subject
+    else
+      'Re: ' + incoming_message.subject
+    end
+  end
+
+  def internal_review
+    _("Internal review of {{email_subject}}", email_subject: initial_request)
+  end
+
+  protected
+
+  attr_reader :info_request, :incoming_message, :html
+end

--- a/app/views/followups/preview.html.erb
+++ b/app/views/followups/preview.html.erb
@@ -26,7 +26,7 @@
         <p class="preview_subject">
           <strong><%= _('To:') %></strong> <%=h OutgoingMailer.name_for_followup(@info_request, @incoming_message) %>
           <br>
-          <strong><%= _('Subject:') %></strong> <%= OutgoingMailer.subject_for_followup(@info_request, @outgoing_message, :html => true) %>
+          <strong><%= _('Subject:') %></strong> <%= @outgoing_message.subject %>
         </p>
 
         <div class="correspondence_text">

--- a/app/views/request/preview.html.erb
+++ b/app/views/request/preview.html.erb
@@ -43,7 +43,7 @@
           </p>
 
           <p class="preview_subject">
-            <strong><%= _('Subject') %></strong> <%= @info_request.email_subject_request %>
+            <strong><%= _('Subject') %></strong> <%= @outgoing_message.subject %>
           </p>
 
           <div class="correspondence_text">

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Consolidate outgoing message subject line generation to
+  `OutgoingMessage::Subject` (Gareth Rees)
 * Allow admins to hide a request without notifying the user (Laurent Savaete)
 * Show public body change history while editing it (Laurent Savaete)
 * Warn users that their latest request may not be listed yet (Laurent Savaete)

--- a/spec/mailers/outgoing_mailer_spec.rb
+++ b/spec/mailers/outgoing_mailer_spec.rb
@@ -50,84 +50,49 @@ RSpec.describe OutgoingMailer, " when working out follow up names and addresses"
   end
 end
 
-RSpec.describe OutgoingMailer, "when working out follow up subjects" do
-  it "should prefix the title with 'Freedom of Information request -' for initial requests" do
-    ir = info_requests(:fancy_dog_request)
-    im = ir.incoming_messages[0]
+RSpec.describe OutgoingMailer, "when sending mail" do
+  # String-composition rules (Re: prefixing, internal review, html
+  # escaping, etc) are covered by spec/models/outgoing_message/subject_spec.rb
+  # - these just check the real mailer actions deliver with the expected
+  # subject header.
+  describe '#initial_request' do
+    it "uses the request title with the law prefixed" do
+      ir = info_requests(:fancy_dog_request)
+      om = outgoing_messages(:useless_outgoing_message)
 
-    expect(ir.email_subject_request(html: false)).to eq("Freedom of Information request - Why do you have & such a fancy dog?")
+      mail = OutgoingMailer.initial_request(ir, om)
+      expect(mail.subject).
+        to eq("Freedom of Information request - " \
+              "Why do you have & such a fancy dog?")
+    end
   end
 
-  it "should use 'Re:' and initial request subject for followups which aren't replies to particular messages" do
-    ir = info_requests(:fancy_dog_request)
-    om = outgoing_messages(:useless_outgoing_message)
+  describe '#followup' do
+    it "prefixes with Re: the subject of the message being replied to" do
+      ir = info_requests(:fancy_dog_request)
+      im = ir.incoming_messages[0]
+      om = outgoing_messages(:useless_outgoing_message)
+      om.message_type = 'followup'
+      om.incoming_message_followup = im
 
-    expect(OutgoingMailer.subject_for_followup(ir, om, html: false)).to eq("Re: Freedom of Information request - Why do you have & such a fancy dog?")
-  end
-
-  it "should prefix with Re: the subject of the message being replied to" do
-    ir = info_requests(:fancy_dog_request)
-    im = ir.incoming_messages[0]
-    om = outgoing_messages(:useless_outgoing_message)
-    om.incoming_message_followup = im
-
-    expect(OutgoingMailer.subject_for_followup(ir, om, html: false)).to eq("Re: Geraldine FOI Code AZXB421")
-  end
-
-  it "should not add Re: prefix if there already is such a prefix" do
-    ir = info_requests(:fancy_dog_request)
-    im = ir.incoming_messages[0]
-    om = outgoing_messages(:useless_outgoing_message)
-    om.incoming_message_followup = im
-
-    im.raw_email.data = im.raw_email.data.sub("Subject: Geraldine FOI Code AZXB421", "Subject: Re: Geraldine FOI Code AZXB421")
-    expect(OutgoingMailer.subject_for_followup(ir, om, html: false)).to eq("Re: Geraldine FOI Code AZXB421")
-  end
-
-  it "should not add Re: prefix if there already is a lower case re: prefix" do
-    ir = info_requests(:fancy_dog_request)
-    im = ir.incoming_messages[0]
-    om = outgoing_messages(:useless_outgoing_message)
-    om.incoming_message_followup = im
-
-    im.raw_email.data = im.raw_email.data.sub("Subject: Geraldine FOI Code AZXB421", "Subject: re: Geraldine FOI Code AZXB421")
-    im.parse_raw_email!
-
-    expect(OutgoingMailer.subject_for_followup(ir, om, html: false)).to eq("re: Geraldine FOI Code AZXB421")
-  end
-
-  it "should use 'Re:' and initial request subject when replying to failed delivery notifications" do
-    ir = info_requests(:fancy_dog_request)
-    im = ir.incoming_messages[0]
-    om = outgoing_messages(:useless_outgoing_message)
-    om.incoming_message_followup = im
-
-    im.raw_email.data = im.raw_email.data.sub("foiperson@localhost", "postmaster@localhost")
-    im.raw_email.data = im.raw_email.data.sub("Subject: Geraldine FOI Code AZXB421", "Subject: Delivery Failed")
-    im.parse_raw_email!
-
-    expect(OutgoingMailer.subject_for_followup(ir, om, html: false)).to eq("Re: Freedom of Information request - Why do you have & such a fancy dog?")
-  end
-
-  context "dealing with an internal review" do
-    it "prefixes the subject of the message with 'Internal review of " \
-          "Freedom of Information request'" do
-      request = FactoryBot.create(:info_request_with_internal_review_request,
-                                  title: "Test")
-      expect(OutgoingMailer.subject_for_followup(
-        request,
-        request.outgoing_messages.last)).
-          to eq("Internal review of Freedom of Information request - Test")
+      mail = OutgoingMailer.followup(ir, om, im)
+      expect(mail.subject).to eq("Re: Geraldine FOI Code AZXB421")
     end
 
-    it "does not add HTMLEntities to the subject of the message" do
-      request = FactoryBot.create(:info_request_with_internal_review_request,
-                                  title: "Apostrophe's Test")
-      expect(OutgoingMailer.subject_for_followup(
-        request,
-        request.outgoing_messages.last)).
-          to eq("Internal review of Freedom of Information request - " \
-                "Apostrophe's Test")
+    context "dealing with an internal review" do
+      it "prefixes the subject of the message with 'Internal review of " \
+            "Freedom of Information request'" do
+        request = FactoryBot.create(
+          :info_request_with_internal_review_request, title: "Test"
+        )
+        om = request.outgoing_messages.last
+
+        mail = OutgoingMailer.followup(
+          request, om, om.incoming_message_followup
+        )
+        expect(mail.subject).
+          to eq("Internal review of Freedom of Information request - Test")
+      end
     end
   end
 end

--- a/spec/mailers/request_mailer_spec.rb
+++ b/spec/mailers/request_mailer_spec.rb
@@ -133,8 +133,10 @@ RSpec.describe RequestMailer do
       @request_user = mock_model(User)
       @public_body = mock_model(PublicBody, name: 'Test public body')
       @info_request = mock_model(InfoRequest, user: @request_user,
-                                 email_subject_followup: 'Re: Freedom of Information - Test request',
-                                 incoming_name_and_email: 'Someone <someone@example.org>')
+                                              title: 'Test request',
+                                              legislation: Legislation.default,
+                                              incoming_name_and_email:
+                                                'Someone <someone@example.org>')
     end
 
     it 'should should generate a "fake response" email with a reasonable subject line' do
@@ -143,7 +145,8 @@ RSpec.describe RequestMailer do
                                                "The body of the email...",
                                                "blah.txt",
                                                "The content of blah.txt")
-      expect(fake_email.subject).to eq("Re: Freedom of Information - Test request")
+      expect(fake_email.subject).
+        to eq("Re: Freedom of Information request - Test request")
     end
   end
 

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2315,7 +2315,10 @@ RSpec.describe InfoRequest do
     end
 
     context 'a direct reply to the original request email' do
-      let(:subject_line) { info_request.email_subject_followup }
+      let(:subject_line) do
+        OutgoingMessage::Subject.new(info_request: info_request, html: false).
+          followup
+      end
 
       let(:guess) { Guess.new(info_request, subject: subject_line) }
 
@@ -2324,7 +2327,8 @@ RSpec.describe InfoRequest do
 
     context '"Re" in the incoming subject has different capitalisation' do
       let(:subject_line) do
-        info_request.email_subject_followup.gsub('Re: ', 'RE: ')
+        OutgoingMessage::Subject.new(info_request: info_request, html: false).
+          followup.gsub('Re: ', 'RE: ')
       end
 
       let(:guess) { Guess.new(info_request, subject: subject_line) }
@@ -3357,25 +3361,6 @@ RSpec.describe InfoRequest do
                                                   name: 'Alaveteli User',
                                                   ban_text: '',
                                                   about_me: 'Hi' })
-    end
-  end
-
-  describe 'when working out a subject for request emails' do
-    it 'creates a standard request subject' do
-      info_request = FactoryBot.build(:info_request)
-      expected_text = "Freedom of Information request - #{info_request.title}"
-      expect(info_request.email_subject_request).to eq(expected_text)
-    end
-  end
-
-  describe 'when working out a subject for a followup emails' do
-    it "is not confused by an nil subject in the incoming message" do
-      ir = info_requests(:fancy_dog_request)
-      im = mock_model(IncomingMessage,
-                      subject: nil,
-                      valid_to_reply_to?: true)
-      subject = ir.email_subject_followup(incoming_message: im, html: false)
-      expect(subject).to match(/^Re: Freedom of Information request.*fancy dog/)
     end
 
     it "returns a hash with the user's name for an external request" do

--- a/spec/models/outgoing_message/subject_spec.rb
+++ b/spec/models/outgoing_message/subject_spec.rb
@@ -1,0 +1,161 @@
+require 'spec_helper'
+
+RSpec.describe OutgoingMessage::Subject do
+  let(:msg_subject) do
+    described_class.new(
+      info_request: info_request,
+      incoming_message: incoming_message,
+      html: html
+    )
+  end
+
+  let!(:text_request) do
+    FactoryBot.create(:info_request, title: 'Just Text')
+  end
+
+  let!(:html_request) do
+    FactoryBot.create(:info_request, title: 'Fish & Chips')
+  end
+
+  # Defaults
+  let(:info_request) { text_request }
+  let(:incoming_message) { nil }
+  let(:html) { true }
+
+  describe '#initial_request' do
+    subject { msg_subject.initial_request }
+
+    it "prefixes the title with 'Freedom of Information request -'" do
+      is_expected.to eq('Freedom of Information request - Just Text')
+    end
+
+    context 'with html in the subject' do
+      let(:info_request) { html_request }
+
+      context 'when html is true' do
+        it 'escapes HTML in the title' do
+          is_expected.to eq('Freedom of Information request - Fish &amp; Chips')
+        end
+      end
+
+      context 'when html is false' do
+        let(:html) { false }
+
+        it 'does not escape HTML in the title' do
+          is_expected.to eq('Freedom of Information request - Fish & Chips')
+        end
+      end
+    end
+  end
+
+  describe '#followup' do
+    subject { msg_subject.followup }
+
+    context 'when there is no incoming message' do
+      it 'prefixes the initial request subject with Re:' do
+        is_expected.to eq('Re: Freedom of Information request - Just Text')
+      end
+    end
+
+    context 'when the incoming message is not valid to reply to' do
+      let(:incoming_message) do
+        mock_model(IncomingMessage, valid_to_reply_to?: false)
+      end
+
+      it 'prefixes the initial request subject with Re:' do
+        is_expected.to eq('Re: Freedom of Information request - Just Text')
+      end
+    end
+
+    context 'when the incoming message does not have a subject' do
+      let(:incoming_message) do
+        mock_model(IncomingMessage, subject: nil, valid_to_reply_to?: true)
+      end
+
+      it 'prefixes the initial request subject with Re:' do
+        is_expected.to eq('Re: Freedom of Information request - Just Text')
+      end
+    end
+
+    context 'when the incoming message subject is already prefixed with Re:' do
+      let(:incoming_message) do
+        mock_model(IncomingMessage, valid_to_reply_to?: true,
+                                    subject: 'Re: FOI REF#123456789')
+      end
+
+      it 'uses the incoming message subject verbatim' do
+        is_expected.to eq('Re: FOI REF#123456789')
+      end
+    end
+
+    context 'when the incoming message subject has a lower case re: prefix' do
+      let(:incoming_message) do
+        mock_model(IncomingMessage, valid_to_reply_to?: true,
+                                    subject: 're: FOI REF#123456789')
+      end
+
+      it 'does not add another Re: prefix' do
+        is_expected.to eq('re: FOI REF#123456789')
+      end
+    end
+
+    context 'when the incoming message subject is not prefixed with Re:' do
+      let(:incoming_message) do
+        mock_model(IncomingMessage, valid_to_reply_to?: true,
+                                    subject: 'FOI REF#123456789')
+      end
+
+      it 'prefixes the incoming message subject with Re:' do
+        is_expected.to eq('Re: FOI REF#123456789')
+      end
+    end
+
+    context 'with html in the subject' do
+      let(:info_request) { html_request }
+
+      context 'when html is true' do
+        it 'escapes HTML in the title' do
+          is_expected.
+            to eq('Re: Freedom of Information request - Fish &amp; Chips')
+        end
+      end
+
+      context 'when html is false' do
+        let(:html) { false }
+
+        it 'does not escape HTML in the title' do
+          is_expected.to eq('Re: Freedom of Information request - Fish & Chips')
+        end
+      end
+    end
+  end
+
+  describe '#internal_review' do
+    subject { msg_subject.internal_review }
+
+    it "prefixes the request subject with 'Internal review of'" do
+      is_expected.to eq('Internal review of Freedom of Information request - ' \
+                        'Just Text')
+    end
+
+    context 'with html in the subject' do
+      let(:info_request) { html_request }
+
+      context 'when html is true' do
+        it 'escapes HTML in the title' do
+          is_expected.to eq('Internal review of Freedom of Information ' \
+                            'request - Fish &amp; Chips')
+        end
+      end
+
+      context 'when html is false' do
+        let(:html) { false }
+
+        it 'does not escape HTML in the title' do
+          is_expected.to eq('Internal review of Freedom of Information ' \
+                            'request - Fish & Chips')
+        end
+      end
+    end
+  end
+end

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -251,92 +251,86 @@ RSpec.describe OutgoingMessage do
     end
   end
 
+  # Advanced composition rules are covered by OutgoingMessage::Subject specs.
+  # These just check that we dispatch to the right OutgoingMessage::Subject
+  # method and pass through the options.
   describe '#subject' do
+    subject { message.subject(html: html, incoming_message: incoming_message) }
+
+    # Defaults
+    let(:html) { true }
+    let(:incoming_message) { nil }
+
+    let(:info_request) do
+      FactoryBot.create(:info_request, title: 'Example Request')
+    end
+
     context 'when sending an initial request' do
-      it 'uses the request title with the law prefixed' do
-        request = FactoryBot.create(:info_request, title: 'Example Request')
-        message = FactoryBot.build(:initial_request, info_request: request)
-        expected = 'Freedom of Information request - Example Request'
-        expect(message.subject).to eq(expected)
+      let(:message) do
+        FactoryBot.build(:initial_request, info_request: info_request)
+      end
+
+      it 'uses the request subject' do
+        is_expected.to eq('Freedom of Information request - Example Request')
       end
     end
 
-    context 'when sending a followup that is not a reply to an incoming message' do
-      it 'prefixes the initial request subject with Re:' do
-        request = FactoryBot.create(:info_request, title: 'Example Request')
-        message = FactoryBot.build(:new_information_followup,
-                                   info_request: request)
-        allow(message).to receive(:incoming_message_followup).and_return(nil)
-        expected = 'Re: Freedom of Information request - Example Request'
-        expect(message.subject).to eq(expected)
-      end
-    end
-
-    context 'when following up to an incoming message' do
-      it 'uses the request title prefixed with Re: if the incoming message does not have a valid reply address' do
-        request = FactoryBot.create(:info_request, title: 'Example Request')
-        message = FactoryBot.build(:new_information_followup,
-                                   info_request: request)
-
-        followup =
-          mock_model(IncomingMessage, valid_to_reply_to?: false)
-        allow(message).
-          to receive(:incoming_message_followup).and_return(followup)
-
-        expected = 'Re: Freedom of Information request - Example Request'
-        expect(message.subject).to eq(expected)
+    context 'when sending a followup' do
+      let(:message) do
+        FactoryBot.build(:new_information_followup, info_request: info_request)
       end
 
-      it 'uses the request title prefixed with Re: if the incoming message does not have a subject' do
-        request = FactoryBot.create(:info_request, title: 'Example Request')
-        message = FactoryBot.build(:new_information_followup,
-                                   info_request: request)
-
-        followup = mock_model(IncomingMessage, subject: nil,
-                                               valid_to_reply_to?: true)
-        allow(message).
-          to receive(:incoming_message_followup).and_return(followup)
-
-        expected = 'Re: Freedom of Information request - Example Request'
-        expect(message.subject).to eq(expected)
-      end
-
-      it 'uses the incoming message subject if it is already prefixed with Re:' do
-        request = FactoryBot.create(:info_request, title: 'Example Request')
-        message = FactoryBot.build(:new_information_followup,
-                                   info_request: request)
-
-        followup =
-          mock_model(IncomingMessage, valid_to_reply_to?: true,
-                                      subject: 'Re: FOI REF#123456789')
-        allow(message).
-          to receive(:incoming_message_followup).and_return(followup)
-
-        expect(message.subject).to eq('Re: FOI REF#123456789')
-      end
-
-      it 'prefixes the incoming message subject if it is not prefixed with Re:' do
-        request = FactoryBot.create(:info_request, title: 'Example Request')
-        message = FactoryBot.build(:new_information_followup,
-                                   info_request: request)
-
-        followup =
-          mock_model(IncomingMessage, valid_to_reply_to?: true,
-                                      subject: 'FOI REF#123456789')
-        allow(message).
-          to receive(:incoming_message_followup).and_return(followup)
-
-        expect(message.subject).to eq('Re: FOI REF#123456789')
+      it 'uses the followup subject' do
+        is_expected.
+          to eq('Re: Freedom of Information request - Example Request')
       end
     end
 
     context 'when requesting an internal review' do
-      it 'prefixes the request title with the internal review message' do
-        request = FactoryBot.create(:info_request, title: 'Example Request')
-        message = FactoryBot.build(:internal_review_request, info_request: request)
-        expected = 'Internal review of Freedom of Information request - Example Request'
-        expect(message.subject).to eq(expected)
+      let(:message) do
+        FactoryBot.build(:internal_review_request, info_request: info_request)
       end
+
+      it 'uses the internal review subject' do
+        is_expected.
+          to eq('Internal review of Freedom of Information request - ' \
+                'Example Request')
+      end
+    end
+
+    context 'with non-ASCII characters' do
+      let(:info_request) do
+        FactoryBot.create(:info_request, title: 'Fish & Chips')
+      end
+
+      let(:message) do
+        FactoryBot.build(:initial_request, info_request: info_request)
+      end
+
+      it 'defaults to html-escaped output' do
+        is_expected.to match(/Fish &amp; Chips/)
+      end
+
+      context 'when explicitly setting html: false' do
+        let(:html) { false }
+        it { is_expected.to match(/Fish & Chips/) }
+      end
+    end
+
+    context 'when passing an incoming_message' do
+      let(:message) do
+        FactoryBot.build(:new_information_followup, info_request: info_request)
+      end
+
+      let(:incoming_message) do
+        mock_model(
+          IncomingMessage,
+          valid_to_reply_to?: true,
+          subject: 'Custom Subject'
+        )
+      end
+
+      it { is_expected.to eq('Re: Custom Subject') }
     end
   end
 
@@ -1071,7 +1065,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           load_mail_server_logs <<-EOF.strip_heredoc
@@ -1087,7 +1083,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           load_mail_server_logs <<-EOF.strip_heredoc
@@ -1103,7 +1101,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           load_mail_server_logs <<-EOF.strip_heredoc
@@ -1137,7 +1137,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           load_mail_server_logs <<-EOF.strip_heredoc
@@ -1199,7 +1201,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           load_mail_server_logs <<-EOF.strip_heredoc
@@ -1259,7 +1263,9 @@ RSpec.describe OutgoingMessage do
             message = FactoryBot.create(:initial_request)
             body_email = message.info_request.public_body.request_email
             request_email = message.info_request.incoming_email
-            request_subject = message.info_request.email_subject_request(html: false)
+            request_subject = OutgoingMessage::Subject.new(
+              info_request: message.info_request, html: false
+            ).initial_request
             smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
             load_mail_server_logs <<-EOF.strip_heredoc
@@ -1297,7 +1303,9 @@ RSpec.describe OutgoingMessage do
             message = FactoryBot.create(:initial_request)
             body_email = message.info_request.public_body.request_email
             request_email = message.info_request.incoming_email
-            request_subject = message.info_request.email_subject_request(html: false)
+            request_subject = OutgoingMessage::Subject.new(
+              info_request: message.info_request, html: false
+            ).initial_request
             smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
             load_mail_server_logs <<-EOF.strip_heredoc
@@ -1365,7 +1373,9 @@ RSpec.describe OutgoingMessage do
             message = FactoryBot.create(:initial_request)
             body_email = message.info_request.public_body.request_email
             request_email = message.info_request.incoming_email
-            request_subject = message.info_request.email_subject_request(html: false)
+            request_subject = OutgoingMessage::Subject.new(
+              info_request: message.info_request, html: false
+            ).initial_request
             smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
             load_mail_server_logs <<-EOF.strip_heredoc
@@ -1432,7 +1442,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           load_mail_server_logs <<-EOF.strip_heredoc
@@ -1471,7 +1483,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:internal_review_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           message.prepare_message_for_resend
@@ -1528,7 +1542,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           load_mail_server_logs <<-EOF.strip_heredoc
@@ -1557,7 +1573,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           load_mail_server_logs <<-EOF.strip_heredoc
@@ -1589,7 +1607,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:initial_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           load_mail_server_logs <<-EOF.strip_heredoc
@@ -1631,7 +1651,9 @@ RSpec.describe OutgoingMessage do
           message = FactoryBot.create(:internal_review_request)
           body_email = message.info_request.public_body.request_email
           request_email = message.info_request.incoming_email
-          request_subject = message.info_request.email_subject_request(html: false)
+          request_subject = OutgoingMessage::Subject.new(
+            info_request: message.info_request, html: false
+          ).initial_request
           smtp_message_id = 'ogm-14+537f69734b97c-1ebd@localhost'
 
           message.prepare_message_for_resend


### PR DESCRIPTION
## Relevant issue(s)

In service of #9347, #8823, #8824

## What does this do?

Extract `OutgoingMessage::Subject`

## Why was this needed?

* Reduce complexity of generating a subject line
* Will make it easier to then apply redactions to the output of this

## Implementation notes

~`OutgoingMessage#subject` now requires an explicit `html` kwarg as previously we relied on different methods to generate the subject in the different contexts. As these have now been consolidated, making an explicit choice felt like the right design decision:~
*~ If we defaulted to true, we could accidentally include escaped characters in subject lines (cosmetic, but annoying and hard to spot)~
* ~If we defaulted to false, we could accidentally open the door to XSS bugs~

`OutgoingMessage#subject`'s `html` kwarg defaults to `true`, since `subject` is called dynamically via `admin_columns` with no arguments. This is the safer approach since the worst case is that we include escaped characters in subject lines, rather than the other way round where we could accidentally include an XSS vector. Left the above comment for reference as that was the initial intention.

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
