### PR TITLE
Prepare alert generation to move off Xapian

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -407,6 +407,14 @@ class ApplicationController < ActionController::Base
       results(page: @page, per_page: @per_page)
   end
 
+  def perform_track_search(track_thing)
+    per_page = 25
+    order, = order_to_sort_by(track_thing.params[:feed_sortby])
+    offset = (get_search_page_from_params - 1) * per_page
+    track_thing.matches(sort_by: order, limit: per_page,
+                        offset: offset)
+  end
+
   def get_search_page_from_params
     page = (params[:page] || "1").to_i
     page = 1 if page < 1

--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -170,10 +170,7 @@ class TrackController < ApplicationController
   end
 
   def atom_feed_internal
-    @search_results = perform_search(
-      [InfoRequestEvent], @track_thing.track_query,
-      @track_thing.params[:feed_sortby], nil, 25
-    )
+    @search_results = perform_track_search(@track_thing)
     # We're assuming that a request to a feed url with no format suffix wants atom/xml
     # so set that as the default, regardless of content negotiation
     request.format = params[:format] || 'xml'

--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -170,7 +170,8 @@ class TrackController < ApplicationController
   end
 
   def atom_feed_internal
-    @search_results = perform_track_search(@track_thing)
+    search_results = perform_track_search(@track_thing)
+    @events = search_results.results.map { |result| result[:model] }
     # We're assuming that a request to a feed url with no format suffix wants atom/xml
     # so set that as the default, regardless of content negotiation
     request.format = params[:format] || 'xml'
@@ -179,16 +180,13 @@ class TrackController < ApplicationController
         highlight = ->(t) do
           view_context.highlight_and_excerpt(
             t,
-            @search_results.words_to_highlight(
+            search_results.words_to_highlight(
               regex: true, include_original: true
             ),
             150
           )
         end
-        json = @search_results.results.map do |r|
-          r[:model].json_for_api(true, highlight)
-        end
-        render json: json
+        render json: @events.map { |event| event.json_for_api(true, highlight) }
       end
       format.any { render template: 'track/atom_feed',
                    formats: [:atom],

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -317,7 +317,7 @@ class UserController < ApplicationController
     else
       @user.
         track_things.
-        collect { |thing| perform_search([InfoRequestEvent], thing.track_query, thing.params[:feed_sortby], nil).results }.
+        collect { |thing| perform_track_search(thing).results }.
         flatten.
         sort { |a,b| b[:model].created_at <=> a[:model].created_at }.
         first(20)

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -127,13 +127,8 @@ class UserController < ApplicationController
               track_medium: 'email_daily').
           order(created_at: :desc)
       @track_things.each do |track_thing|
-        # TODO: factor out of track_mailer.rb
-        results = Search.search(
-          track_thing.track_query,
-          models: [InfoRequestEvent],
-          sort_by: 'described_at',
-          sort_ascending: true
-        ).results(page: 1, per_page: 20)
+        results = track_thing.matches(sort_by: 'described_at',
+                                      limit: 20)
         feed_results += results.results.map { |x| x[:model] }
       end
     end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -317,9 +317,9 @@ class UserController < ApplicationController
     else
       @user.
         track_things.
-        collect { |thing| perform_track_search(thing).results }.
-        flatten.
-        sort { |a,b| b[:model].created_at <=> a[:model].created_at }.
+        flat_map { |thing| perform_track_search(thing).results }.
+        map { |result| result[:model] }.
+        sort { |a, b| b.created_at <=> a.created_at }.
         first(20)
     end
   end

--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -76,28 +76,26 @@ class TrackMailer < ApplicationMailer
         search_results = track_thing.matches(sort_by: 'described_at',
                                              limit: 100)
         # Go through looking for unalerted things
-        alert_results = []
+        alert_events = []
         search_results.results.each do |result|
-          if result[:model].class.to_s != "InfoRequestEvent"
-            raise "need to add other types to TrackMailer.alert_tracks (unalerted)"
-          end
+          event = result[:model]
 
-          if track_thing.created_at >= result[:model].described_at  # made before the track was created
-            next
-          end
-          if result[:model].described_at < one_week_ago  # older than 1 week (see 14 days / 7 days in comment above)
-            next
-          end
-          if done_info_request_events.include?(result[:model].id)  # definitely already done
-            next
-          end
+          # made before the track was created
+          next if track_thing.created_at >= event.described_at
+
+          # older than 1 week (see 14 days / 7 days in comment above)
+          next if event.described_at < one_week_ago
+
+          # definitely already done
+          next if done_info_request_events.include?(event.id)
 
           # OK alert this one
-          alert_results.push(result)
+          alert_events.push(event)
         end
         # If there were more alerts for this track, then store them
-        unless alert_results.empty?
-          email_about_things.push([track_thing, alert_results, search_results])
+        unless alert_events.empty?
+          highlight_words = search_results.words_to_highlight(regex: true)
+          email_about_things.push([track_thing, alert_events, highlight_words])
         end
       end
 
@@ -111,15 +109,11 @@ class TrackMailer < ApplicationMailer
       end
 
       # Record that we've now sent those alerts to that user
-      email_about_things.each do |track_thing, alert_results|
-        alert_results.each do |result|
+      email_about_things.each do |track_thing, alert_events, _highlight_words|
+        alert_events.each do |event|
           track_things_sent_email = TrackThingsSentEmail.new
           track_things_sent_email.track_thing_id = track_thing.id
-          if result[:model].class.to_s == "InfoRequestEvent"
-            track_things_sent_email.info_request_event_id = result[:model].id
-          else
-            raise "need to add other types to TrackMailer.alert_tracks (mark alerted)"
-          end
+          track_things_sent_email.info_request_event_id = event.id
           track_things_sent_email.save!
         end
       end

--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -73,11 +73,8 @@ class TrackMailer < ApplicationMailer
         # Query for things in this track. We use described_at for the
         # ordering, so we catch anything new (before described), or
         # anything whose new status has been described.
-        search_results = Search.search(track_thing.track_query,
-                                       models: [InfoRequestEvent],
-                                       sort_by: 'described_at',
-                                       sort_ascending: true).
-                           results(page: 1, per_page: 100)
+        search_results = track_thing.matches(sort_by: 'described_at',
+                                             limit: 100)
         # Go through looking for unalerted things
         alert_results = []
         search_results.results.each do |result|

--- a/app/models/incoming_message.rb
+++ b/app/models/incoming_message.rb
@@ -73,6 +73,7 @@ class IncomingMessage < ApplicationRecord
 
   scope :pro, -> { joins(:info_request).merge(InfoRequest.pro) }
   scope :unparsed, -> { where(last_parsed: nil) }
+  scope :is_searchable, -> { where(prominence: 'normal') }
 
   cache_from_raw_email :subject, :sent_at,
                        :from_name, :from_email, :from_email_domain,

--- a/app/models/info_request_event.rb
+++ b/app/models/info_request_event.rb
@@ -89,6 +89,19 @@ class InfoRequestEvent < ApplicationRecord
 
   validates_presence_of :event_type
 
+  scope :is_searchable, -> {
+    searchable_requests = joins(:info_request).merge(InfoRequest.is_searchable)
+
+    searchable_requests.
+      where(event_type: 'response',
+            incoming_message: IncomingMessage.is_searchable).
+      or(searchable_requests.
+           where(event_type: %w[sent followup_sent],
+                 outgoing_message: OutgoingMessage.is_searchable)).
+      or(searchable_requests.
+           where(event_type: 'comment', comment: Comment.where(visible: true)))
+  }
+
   before_save(if: :only_editing_prominence_to_hide?) do
     self.event_type = "hide"
   end

--- a/app/models/track_thing.rb
+++ b/app/models/track_thing.rb
@@ -25,6 +25,8 @@ require 'set'
 # TODO: TrackThing looks like a good candidate for single table inheritance
 
 class TrackThing < ApplicationRecord
+  include Search::EventSearch
+
   TRACK_MEDIUMS = %w(email_daily feed)
 
   belongs_to :info_request,
@@ -123,6 +125,13 @@ class TrackThing < ApplicationRecord
 
   def track_type_description
     TrackThing.track_type_description(track_type)
+  end
+
+  # Newest first, from the sort_ascending default in search_events, which
+  # the backend reads as a reverse flag rather than as an ascending one.
+  def matches(sort_by:, limit:, offset: 0)
+    search_events(track_query,
+                  sort_by: sort_by, limit: limit, offset: offset)
   end
 
   def track_query_description

--- a/app/views/track/atom_feed.atom.erb
+++ b/app/views/track/atom_feed.atom.erb
@@ -4,15 +4,10 @@
   <link type="text/html" rel="alternate" href="<%= request.protocol + request.host_with_port %>"/>
   <link type="application/atom+xml" rel="self" href="<%= request.url %>"/>
   <title><%= @track_thing.params[:title_in_rss] %></title>
-  <% @search_results.results.each do |result| %>
+  <% @events.each do |event| %>
     <%
       # Get the HTML content from the same partial template as website search does
-      content = ''
-      if result[:model].class.to_s == 'InfoRequestEvent'
-        content += render :partial => 'request/request_listing_via_event', :formats => [:html], :locals => { :event => result[:model] }
-      else
-        content = "<p><strong>Unknown search result type " + result[:model].class.to_s + "</strong></p>"
-      end
+      content = render :partial => 'request/request_listing_via_event', :formats => [:html], :locals => { :event => event }
       # Pull out the heading as separate item, from the partial template
       content.match(/(<span class="head">\s+<a href="[^>]*">(.*)<\/a>\s+<\/span>)/)
       heading = $1
@@ -20,9 +15,9 @@
       content.sub!(heading, "")
     %>
     <entry>
-      <id>tag:<%= request.host %>,2005:<%= result[:model].class %>/<%= result[:model].id %></id>
-      <published><%= result[:model].created_at.xmlschema %></published>
-      <link type="text/html" rel="alternate" href="<%= polymorphic_url(result[:model]) %>"/>
+      <id>tag:<%= request.host %>,2005:<%= event.class %>/<%= event.id %></id>
+      <published><%= event.created_at.xmlschema %></published>
+      <link type="text/html" rel="alternate" href="<%= polymorphic_url(event) %>"/>
       <title type="html"><%= heading_text %></title>
       <content type="html"><%= content %></content>
     </entry>

--- a/app/views/track_mailer/event_digest.text.erb
+++ b/app/views/track_mailer/event_digest.text.erb
@@ -6,64 +6,62 @@
     main_text += ("=" * track_thing.params[:title_in_email].size) + "\n\n"
     @highlight_words = words
     for event in alert_events.reverse
-      begin
-        # Request title - only add title if we're not tracking a request.
-        # e.g. -- Address and opening times of Post Office branches --
-        if track_thing.info_request.nil?
-          main_text += "-- " + highlight_words(event.info_request.title, @highlight_words, false) + " --\n"
-        end
-
-        # e.g. Julian Burgess sent a request to Royal Mail Group (15 May 2008)
-        if event.event_type == 'response'
-          if event.info_request.is_external?
-            user_name = _('An anonymous user')
-          else
-            user_name = event.info_request.user_name
-          end
-          url = incoming_message_url(event.incoming_message, :cachebust => true)
-          main_text += _("{{public_body}} sent a response to {{user_name}}",
-            :public_body => event.info_request.public_body.name.html_safe,
-            :user_name => user_name.html_safe)
-        elsif event.event_type == 'followup_sent'
-          url = outgoing_message_url(event.outgoing_message, :cachebust => true)
-          main_text += _("{{user_name}} sent a follow up message to " \
-                         "{{public_body}}",
-                         :user_name => event.info_request.user_name.html_safe,
-                         :public_body => event.info_request.public_body.name.
-                                           html_safe)
-        elsif event.event_type == 'sent'
-          # this is unlikely to happen in real life, but happens in the test code
-          url = outgoing_message_url(event.outgoing_message, :cachebust => true)
-          main_text += _("{{user_name}} sent a request to {{public_body}}",
-                         :user_name => event.info_request.user_name.html_safe,
-                         :public_body => event.info_request.public_body.name.
-                                           html_safe)
-        elsif event.event_type == 'comment'
-          url = comment_url(event.comment)
-          main_text += _("{{user_name}} added an annotation",
-                         :user_name => event.comment.user.name.html_safe)
-        else
-          raise "unknown type in event_digest " + event.event_type
-        end
-        main_text += " (" + simple_date(event.created_at, :format => :text) + ")\n"
-
-        # Main text, wrapped, words highlighted with * and indented.
-        if event.is_outgoing_message?
-          extract = highlight_and_excerpt(event.outgoing_message.get_text_for_indexing, @highlight_words, 150, false)
-        elsif event.is_incoming_message?
-          extract = highlight_and_excerpt(event.incoming_message.get_text_for_indexing_clipped, @highlight_words, 150, false)
-        elsif event.is_comment?
-          extract = highlight_and_excerpt(event.comment.body, @highlight_words, 150, false)
-        else
-          extract = highlight_and_excerpt(info_request.initial_request_text, @highlight_words, 150, false)
-        end
-        extract = extract.gsub(/\s+/, ' ')
-        main_text += ('"' + extract + '"').gsub(/\n+$/, "") + "\n"
-
-        # Link to the request/response
-        main_text += url + "\n"
-        main_text += "\n"
+      # Request title - only add title if we're not tracking a request.
+      # e.g. -- Address and opening times of Post Office branches --
+      if track_thing.info_request.nil?
+        main_text += "-- " + highlight_words(event.info_request.title, @highlight_words, false) + " --\n"
       end
+
+      # e.g. Julian Burgess sent a request to Royal Mail Group (15 May 2008)
+      if event.event_type == 'response'
+        if event.info_request.is_external?
+          user_name = _('An anonymous user')
+        else
+          user_name = event.info_request.user_name
+        end
+        url = incoming_message_url(event.incoming_message, :cachebust => true)
+        main_text += _("{{public_body}} sent a response to {{user_name}}",
+          :public_body => event.info_request.public_body.name.html_safe,
+          :user_name => user_name.html_safe)
+      elsif event.event_type == 'followup_sent'
+        url = outgoing_message_url(event.outgoing_message, :cachebust => true)
+        main_text += _("{{user_name}} sent a follow up message to " \
+                       "{{public_body}}",
+                       :user_name => event.info_request.user_name.html_safe,
+                       :public_body => event.info_request.public_body.name.
+                                         html_safe)
+      elsif event.event_type == 'sent'
+        # this is unlikely to happen in real life, but happens in the test code
+        url = outgoing_message_url(event.outgoing_message, :cachebust => true)
+        main_text += _("{{user_name}} sent a request to {{public_body}}",
+                       :user_name => event.info_request.user_name.html_safe,
+                       :public_body => event.info_request.public_body.name.
+                                         html_safe)
+      elsif event.event_type == 'comment'
+        url = comment_url(event.comment)
+        main_text += _("{{user_name}} added an annotation",
+                       :user_name => event.comment.user.name.html_safe)
+      else
+        raise "unknown type in event_digest " + event.event_type
+      end
+      main_text += " (" + simple_date(event.created_at, :format => :text) + ")\n"
+
+      # Main text, wrapped, words highlighted with * and indented.
+      if event.is_outgoing_message?
+        extract = highlight_and_excerpt(event.outgoing_message.get_text_for_indexing, @highlight_words, 150, false)
+      elsif event.is_incoming_message?
+        extract = highlight_and_excerpt(event.incoming_message.get_text_for_indexing_clipped, @highlight_words, 150, false)
+      elsif event.is_comment?
+        extract = highlight_and_excerpt(event.comment.body, @highlight_words, 150, false)
+      else
+        extract = highlight_and_excerpt(info_request.initial_request_text, @highlight_words, 150, false)
+      end
+      extract = extract.gsub(/\s+/, ' ')
+      main_text += ('"' + extract + '"').gsub(/\n+$/, "") + "\n"
+
+      # Link to the request/response
+      main_text += url + "\n"
+      main_text += "\n"
     end
     main_text
   end

--- a/app/views/track_mailer/event_digest.text.erb
+++ b/app/views/track_mailer/event_digest.text.erb
@@ -1,14 +1,12 @@
 <%
   # Construct the main text of the mail
   main_text = ''
-  for track_thing, alert_results, search_results in @email_about_things
+  for track_thing, alert_events, words in @email_about_things
     main_text += track_thing.params[:title_in_email] + "\n"
     main_text += ("=" * track_thing.params[:title_in_email].size) + "\n\n"
-    @highlight_words = search_results.words_to_highlight(:regex => true)
-    for result in alert_results.reverse
-      if result[:model].class.to_s == "InfoRequestEvent"
-        event = result[:model]
-
+    @highlight_words = words
+    for event in alert_events.reverse
+      begin
         # Request title - only add title if we're not tracking a request.
         # e.g. -- Address and opening times of Post Office branches --
         if track_thing.info_request.nil?
@@ -65,8 +63,6 @@
         # Link to the request/response
         main_text += url + "\n"
         main_text += "\n"
-      else
-        raise "need to add other types to TrackMailer.event_digest"
       end
     end
     main_text

--- a/app/views/user/river.html.erb
+++ b/app/views/user/river.html.erb
@@ -3,7 +3,7 @@
 <div class="single_user">
   <h1><%=@title%></h1>
 
-  <% for result in @results %>
-    <%= render :partial => 'request/request_listing_via_event', :locals => { :event => result[:model] } %>
+  <% for event in @results %>
+    <%= render :partial => 'request/request_listing_via_event', :locals => { :event => event } %>
   <% end %>
 </div>

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -142,10 +142,11 @@ namespace :translation do
 
     # track mailer
     search_results = track_thing.matches(sort_by: 'described_at', limit: 100)
-    event_digest_email = TrackMailer.event_digest(info_request.user,
-                                                  [[track_thing,
-                                                    search_results.results,
-                                                    search_results]])
+    highlight_words = search_results.words_to_highlight(regex: true)
+    alert_events = search_results.results.map { |result| result[:model] }
+    event_digest_email = TrackMailer.event_digest(
+      info_request.user, [[track_thing, alert_events, highlight_words]]
+    )
     write_email(event_digest_email, 'Alerts on things the user is tracking', output_file)
 
     # user mailer

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -141,15 +141,11 @@ namespace :translation do
                 output_file)
 
     # track mailer
-    xapian_object = ActsAsXapian::Search.new([InfoRequestEvent], track_thing.track_query,
-                                             sort_by_prefix: 'described_at',
-                                             sort_by_ascending: true,
-                                             collapse_by_prefix: nil,
-                                             limit: 100)
+    search_results = track_thing.matches(sort_by: 'described_at', limit: 100)
     event_digest_email = TrackMailer.event_digest(info_request.user,
                                                   [[track_thing,
-                                                    xapian_object.results,
-                                                    xapian_object]])
+                                                    search_results.results,
+                                                    search_results]])
     write_email(event_digest_email, 'Alerts on things the user is tracking', output_file)
 
     # user mailer

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe TrackController do
                               feed: 'feed',
                               url_title: track_thing.info_request.url_title
                             }
-        expect(assigns[:search_results]).to be_present
+        expect(assigns[:events]).to eq([event])
       end
 
       it 'sorts by the order the track asks for' do

--- a/spec/controllers/track_controller_spec.rb
+++ b/spec/controllers/track_controller_spec.rb
@@ -96,6 +96,36 @@ RSpec.describe TrackController do
         expect(assigns[:search_results]).to be_present
       end
 
+      it 'sorts by the order the track asks for' do
+        track_thing = FactoryBot.create(:request_update_track)
+        stub_search_results(items: [])
+
+        expect(Search).to receive(:search).
+          with(track_thing.track_query, hash_including(sort_by: 'created_at')).
+          and_return(double(results: build_search_results(items: [])))
+
+        get :track_request, params: {
+          feed: 'feed',
+          url_title: track_thing.info_request.url_title
+        }
+      end
+
+      it 'pages through the events' do
+        track_thing = FactoryBot.create(:request_update_track)
+        searcher = double
+        allow(Search).to receive(:search).and_return(searcher)
+
+        expect(searcher).to receive(:results).
+          with(page: 2, per_page: 25).
+          and_return(build_search_results(items: []))
+
+        get :track_request, params: {
+          feed: 'feed',
+          page: 2,
+          url_title: track_thing.info_request.url_title
+        }
+      end
+
       it 'should return atom/xml for a feed url without format specified, even if the requester prefers json' do
         request.env['HTTP_ACCEPT'] = 'application/json,text/xml'
         track_thing = FactoryBot.create(:request_update_track)

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -1410,16 +1410,20 @@ RSpec.describe UserController, "when viewing the river" do
     request_track = FactoryBot.create(:request_update_track,
                                       tracking_user: user)
     search_track = FactoryBot.create(:search_track, tracking_user: user)
-    older = { model: mock_model(InfoRequestEvent, created_at: 2.hours.ago) }
-    newer = { model: mock_model(InfoRequestEvent, created_at: 1.hour.ago) }
+    older = mock_model(InfoRequestEvent, created_at: 2.hours.ago)
+    newer = mock_model(InfoRequestEvent, created_at: 1.hour.ago)
 
     stub_search_results(items: [])
     allow(Search).to receive(:search).
       with(request_track.track_query, any_args).
-      and_return(double(results: build_search_results(items: [older])))
+      and_return(double(results: build_search_results(
+        items: [{ model: older }]
+      )))
     allow(Search).to receive(:search).
       with(search_track.track_query, any_args).
-      and_return(double(results: build_search_results(items: [newer])))
+      and_return(double(results: build_search_results(
+        items: [{ model: newer }]
+      )))
 
     sign_in user
     get :river

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -1403,6 +1403,37 @@ RSpec.describe UserController, "when showing JSON version for API" do
   end
 end
 
+RSpec.describe UserController, "when viewing the river" do
+  let(:user) { FactoryBot.create(:user) }
+
+  it 'gathers the events matching every track the user has' do
+    request_track = FactoryBot.create(:request_update_track,
+                                      tracking_user: user)
+    search_track = FactoryBot.create(:search_track, tracking_user: user)
+    older = { model: mock_model(InfoRequestEvent, created_at: 2.hours.ago) }
+    newer = { model: mock_model(InfoRequestEvent, created_at: 1.hour.ago) }
+
+    stub_search_results(items: [])
+    allow(Search).to receive(:search).
+      with(request_track.track_query, any_args).
+      and_return(double(results: build_search_results(items: [older])))
+    allow(Search).to receive(:search).
+      with(search_track.track_query, any_args).
+      and_return(double(results: build_search_results(items: [newer])))
+
+    sign_in user
+    get :river
+
+    expect(assigns[:results]).to eq([newer, older])
+  end
+
+  it 'has no results for a visitor who is not logged in' do
+    get :river
+
+    expect(assigns[:results]).to be_empty
+  end
+end
+
 RSpec.describe UserController, "when viewing the wall" do
   it 'orders feed results by created_at descending' do
     user = FactoryBot.create(:user)

--- a/spec/controllers/user_controller_spec.rb
+++ b/spec/controllers/user_controller_spec.rb
@@ -1416,6 +1416,26 @@ RSpec.describe UserController, "when viewing the wall" do
     expect(assigns[:feed_results]).to eq([new_event, old_event])
   end
 
+  it 'includes events matching the tracks the user owns' do
+    user = FactoryBot.create(:user)
+    track_thing = FactoryBot.create(:search_track, tracking_user: user)
+    tracked_event = mock_model(InfoRequestEvent, created_at: 1.hour.ago)
+
+    searcher = double
+    stub_search_results(items: [])
+    allow(Search).to receive(:search).
+      with(track_thing.track_query, hash_including(sort_by: 'described_at')).
+      and_return(searcher)
+    expect(searcher).to receive(:results).
+      with(page: 1, per_page: 20).
+      and_return(build_search_results(items: [tracked_event]))
+
+    sign_in user
+    get :wall, params: { url_name: user.url_name }
+
+    expect(assigns[:feed_results]).to eq([tracked_event])
+  end
+
   it 'does not return feed results for closed users' do
     user = FactoryBot.create(:user, :closed)
 

--- a/spec/mailers/previews/track_mailer_preview.rb
+++ b/spec/mailers/previews/track_mailer_preview.rb
@@ -13,13 +13,8 @@ class TrackMailerPreview < ActionMailer::Preview
     [
       [
         track_thing,
-        [
-          OpenStruct.new(model: comment_event),
-          OpenStruct.new(model: response_event),
-          OpenStruct.new(model: followup_sent),
-          OpenStruct.new(model: sent_event)
-        ],
-        ActsAsXapian::Search.new([InfoRequestEvent], 'matches', limit: 10)
+        [comment_event, response_event, followup_sent, sent_event],
+        ['matches']
       ]
     ]
   end

--- a/spec/mailers/track_mailer_spec.rb
+++ b/spec/mailers/track_mailer_spec.rb
@@ -73,7 +73,9 @@ RSpec.describe TrackMailer do
         before do
           @track_things_sent_emails_array = []
           allow(@track_things_sent_emails_array).to receive(:where).and_return([]) # this is for the date range find (created in last 14 days)
-          @track_thing = mock_model(TrackThing, track_query: 'test query',
+          @search_results = double('search results', results: [])
+          @track_thing = mock_model(TrackThing,
+                                    matches: @search_results,
                                     track_things_sent_emails: @track_things_sent_emails_array,
                                     created_at: Time.utc(2007, 11, 9, 23, 59))
           allow(TrackThing).to receive(:where).and_return([@track_thing])
@@ -81,23 +83,14 @@ RSpec.describe TrackMailer do
                                                 :track_thing_id= => true,
                                                 :info_request_event_id= => true)
           allow(TrackThingsSentEmail).to receive(:new).and_return(@track_things_sent_email)
-          @search_results = double('search results', results: [])
           @found_event = mock_model(InfoRequestEvent, described_at: @track_thing.created_at + 1.day)
           @search_result = { model: @found_event }
-          @searcher = double('searcher', results: @search_results)
-          allow(Search).to receive(:search).and_return(@searcher)
         end
 
-        it 'should ask for the events returned by the tracking query' do
-          expect(Search).to receive(:search).with(
-            'test query',
-            models: [InfoRequestEvent],
-            sort_by: 'described_at',
-            sort_ascending: true
-          ).and_return(@searcher)
-          expect(@searcher).to receive(:results).with(
-            page: 1, per_page: 100
-          ).and_return(@search_results)
+        it 'should ask the track for the events it matches' do
+          expect(@track_thing).to receive(:matches).
+            with(sort_by: 'described_at', limit: 100).
+            and_return(@search_results)
           TrackMailer.alert_tracks
         end
 

--- a/spec/mailers/track_mailer_spec.rb
+++ b/spec/mailers/track_mailer_spec.rb
@@ -73,7 +73,8 @@ RSpec.describe TrackMailer do
         before do
           @track_things_sent_emails_array = []
           allow(@track_things_sent_emails_array).to receive(:where).and_return([]) # this is for the date range find (created in last 14 days)
-          @search_results = double('search results', results: [])
+          @search_results = double('search results', results: [],
+                                                     words_to_highlight: [])
           @track_thing = mock_model(TrackThing,
                                     matches: @search_results,
                                     track_things_sent_emails: @track_things_sent_emails_array,
@@ -123,13 +124,18 @@ RSpec.describe TrackMailer do
           TrackMailer.alert_tracks
         end
 
-        it 'should raise an error if a non-event class is returned' do
+        it 'passes the words to highlight to the digest' do
+          allow(@found_event).to receive(:described_at).
+            and_return(@track_thing.created_at + 1.day)
           allow(@search_results).to receive(:results).
-            and_return([{ model: 'string class' }])
-          expect { TrackMailer.alert_tracks }.to raise_error(
-            'need to add other types to ' \
-            'TrackMailer.alert_tracks (unalerted)'
-          )
+            and_return([@search_result])
+          allow(@search_results).to receive(:words_to_highlight).
+            and_return(%w[fancy dog])
+
+          expect(TrackMailer).to receive(:event_digest).
+            with(user, [[@track_thing, [@found_event], %w[fancy dog]]])
+
+          TrackMailer.alert_tracks
         end
 
         it 'should record sent tracking email for each included event' do

--- a/spec/models/incoming_message_spec.rb
+++ b/spec/models/incoming_message_spec.rb
@@ -34,6 +34,18 @@ RSpec.describe IncomingMessage do
   it_behaves_like 'concerns/message_prominence', :incoming_message
   it_behaves_like 'concerns/taggable', :incoming_message
 
+  describe '.is_searchable' do
+    subject { described_class.is_searchable }
+
+    let!(:searchable_message) { FactoryBot.create(:incoming_message) }
+    let!(:unsearchable_message) do
+      FactoryBot.create(:incoming_message, :hidden)
+    end
+
+    it { is_expected.to include(searchable_message) }
+    it { is_expected.not_to include(unsearchable_message) }
+  end
+
   describe '.unparsed' do
     subject { described_class.unparsed }
     before { IncomingMessage.destroy_all }

--- a/spec/models/info_request_event_spec.rb
+++ b/spec/models/info_request_event_spec.rb
@@ -19,6 +19,63 @@
 require 'spec_helper'
 
 RSpec.describe InfoRequestEvent do
+  describe '.is_searchable' do
+    subject(:searchable) { described_class.is_searchable }
+
+    let!(:visible) do
+      { sent: FactoryBot.create(:sent_event),
+        followup: FactoryBot.create(:followup_sent_event),
+        response: FactoryBot.create(:response_event),
+        comment: FactoryBot.create(:comment_event) }
+    end
+
+    let!(:hidden) do
+      { other_type: FactoryBot.create(:info_request_event, event_type: 'edit'),
+        resent: FactoryBot.create(:info_request_event, event_type: 'resent'),
+        hidden_outgoing: FactoryBot.create(
+          :sent_event,
+          outgoing_message: FactoryBot.create(:initial_request, :hidden)
+        ),
+        hidden_incoming: FactoryBot.create(
+          :response_event,
+          incoming_message_factory: [:incoming_message, :hidden]
+        ),
+        hidden_comment: FactoryBot.create(
+          :comment_event, comment: FactoryBot.create(:hidden_comment)
+        ),
+        hidden_request: FactoryBot.create(
+          :sent_event, info_request: FactoryBot.create(:info_request, :hidden)
+        ),
+        requester_only_request: FactoryBot.create(
+          :sent_event,
+          info_request: FactoryBot.create(:info_request, :requester_only)
+        ),
+        backpage_request: FactoryBot.create(
+          :sent_event,
+          info_request: FactoryBot.create(:info_request, :backpage)
+        ),
+        embargoed_request: FactoryBot.create(
+          :sent_event,
+          info_request: FactoryBot.create(:info_request, :embargoed)
+        ) }
+    end
+
+    it 'includes every event the search index would hold' do
+      expect(searchable).to include(*visible.values)
+    end
+
+    it 'excludes every event the search index would leave out' do
+      hidden.each_value { |event| expect(searchable).not_to include(event) }
+    end
+
+    it 'agrees with indexed_by_search? for all of them' do
+      events = visible.values + hidden.values
+      indexed = events.select { |event| event.send(:indexed_by_search?) }
+      expect(searchable.where(id: events).pluck(:id).sort).
+        to eq(indexed.map(&:id).sort)
+    end
+  end
+
   describe 'event_type scopes' do
     described_class::EVENT_TYPES.each do |event_type|
       it "for '#{event_type}' events" do

--- a/spec/models/track_thing_spec.rb
+++ b/spec/models/track_thing_spec.rb
@@ -163,6 +163,22 @@ RSpec.describe TrackThing, "generating track queries" do
   end
 end
 
+RSpec.describe TrackThing, "#matches" do
+  let(:track_thing) { FactoryBot.create(:search_track) }
+
+  it "searches events for the track query, newest first" do
+    expect(Search).to receive(:search).
+      with(track_thing.track_query,
+           hash_including(models: [InfoRequestEvent],
+                          sort_by: 'described_at',
+                          sort_ascending: true)).
+      and_return(double(results: :search_results))
+
+    expect(track_thing.matches(sort_by: 'described_at', limit: 100)).
+      to eq(:search_results)
+  end
+end
+
 RSpec.describe TrackThing, "destroy" do
   let(:track_thing) { FactoryBot.create(:search_track) }
 

--- a/spec/models/track_thing_spec.rb
+++ b/spec/models/track_thing_spec.rb
@@ -77,6 +77,92 @@ RSpec.describe TrackThing, "when tracking changes" do
   end
 end
 
+RSpec.describe TrackThing, "generating track queries" do
+  describe ".create_track_for_request" do
+    it "matches the request by url title" do
+      info_request = FactoryBot.create(:info_request)
+      track_thing = TrackThing.create_track_for_request(info_request)
+      expect(track_thing.track_query).
+        to eq("request:#{ info_request.url_title }")
+    end
+  end
+
+  describe ".create_track_for_all_new_requests" do
+    it "matches sent events" do
+      track_thing = TrackThing.create_track_for_all_new_requests
+      expect(track_thing.track_query).to eq('variety:sent')
+    end
+  end
+
+  describe ".create_track_for_all_successful_requests" do
+    it "matches responses to requests recorded as successful" do
+      track_thing = TrackThing.create_track_for_all_successful_requests
+      expect(track_thing.track_query).
+        to eq('variety:response ' \
+              '(status:successful OR status:partially_successful)')
+    end
+  end
+
+  describe ".create_track_for_public_body" do
+    let(:public_body) { FactoryBot.create(:public_body) }
+
+    it "matches requests to the authority" do
+      track_thing = TrackThing.create_track_for_public_body(public_body)
+      expect(track_thing.track_query).
+        to eq("requested_from:#{ public_body.url_name }")
+    end
+
+    it "appends a known event type" do
+      track_thing =
+        TrackThing.create_track_for_public_body(public_body, 'response')
+      expect(track_thing.track_query).
+        to eq("requested_from:#{ public_body.url_name } variety:response")
+    end
+
+    it "ignores an unknown event type" do
+      track_thing =
+        TrackThing.create_track_for_public_body(public_body, 'nonsense')
+      expect(track_thing.track_query).
+        to eq("requested_from:#{ public_body.url_name }")
+    end
+  end
+
+  describe ".create_track_for_user" do
+    # The space after commented_by: is a bug, not a typo here. It detaches
+    # the term from the prefix, so the clause never matches a comment.
+    it "matches requests by the user, and comments by them in name only" do
+      user = FactoryBot.create(:user)
+      track_thing = TrackThing.create_track_for_user(user)
+      expect(track_thing.track_query).
+        to eq("requested_by:#{ user.url_name }" \
+              " OR commented_by: #{ user.url_name }")
+    end
+  end
+
+  describe ".create_track_for_search_query" do
+    it "keeps the query as given" do
+      track_thing = TrackThing.create_track_for_search_query('fancy dog')
+      expect(track_thing.track_query).to eq('fancy dog')
+    end
+
+    it "appends a variety for each postfix" do
+      { 'requests' => 'fancy dog variety:sent',
+        'users' => 'fancy dog variety:user',
+        'bodies' => 'fancy dog variety:authority' }.each do |postfix, expected|
+        track_thing =
+          TrackThing.create_track_for_search_query('fancy dog', postfix)
+        expect(track_thing.track_query).to eq(expected)
+      end
+    end
+
+    it "leaves a query which already sets a variety alone" do
+      track_thing = TrackThing.
+        create_track_for_search_query('fancy dog variety:comment', 'requests')
+      expect(track_thing.track_query).to eq('fancy dog variety:comment')
+    end
+  end
+end
+
 RSpec.describe TrackThing, "destroy" do
   let(:track_thing) { FactoryBot.create(:search_track) }
 

--- a/spec/views/track_mailer/event_digest.text.erb_spec.rb
+++ b/spec/views/track_mailer/event_digest.text.erb_spec.rb
@@ -10,9 +10,6 @@ RSpec.describe "track_mailer/event_digest" do
                       title: "Request apostrophe's data")
   end
   let(:track) { FactoryBot.create(:search_track, tracking_user: user) }
-  let(:search_results) do
-    double('search results', results: [event], words_to_highlight: 'test')
-  end
 
   before do
     allow(AlaveteliConfiguration).to receive(:site_name).
@@ -27,22 +24,19 @@ RSpec.describe "track_mailer/event_digest" do
     end
 
     it "does not add HTMLEntities to the request title" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("-- Request apostrophe's data --")
     end
 
     it "does not add HTMLEntities to the public body name" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("Apostrophe's sent a response")
     end
 
     it "does not add HTMLEntities to the user name" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("sent a response to Test Us'r")
     end
@@ -51,8 +45,7 @@ RSpec.describe "track_mailer/event_digest" do
       let(:request) { FactoryBot.create(:info_request, :external) }
 
       it 'uses "An anonymous user" as the user name' do
-        result = { model: event }
-        assign(:email_about_things, [[track, [result], search_results]])
+        assign(:email_about_things, [[track, [event], ['test']]])
         render
         expect(response).to match('sent a response to An anonymous user')
       end
@@ -68,22 +61,19 @@ RSpec.describe "track_mailer/event_digest" do
     end
 
     it "does not add HTMLEntities to the request title" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("-- Request apostrophe's data --")
     end
 
     it "does not add HTMLEntities to the public body name" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("message to Apostrophe's")
     end
 
     it "does not add HTMLEntities to the user name" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("Test Us'r sent a follow up message")
     end
@@ -101,15 +91,13 @@ RSpec.describe "track_mailer/event_digest" do
     end
 
     it "does not add HTMLEntities to the request title" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("-- Request apostrophe's data --")
     end
 
     it "does not add HTMLEntities to the user name" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("Test Us'r added an annotation")
     end
@@ -125,22 +113,19 @@ RSpec.describe "track_mailer/event_digest" do
     end
 
     it "does not add HTMLEntities to the request title" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("-- Request apostrophe's data --")
     end
 
     it "does not add HTMLEntities to the public body name" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("request to Apostrophe's")
     end
 
     it "does not add HTMLEntities to the user name" do
-      result = { model: event }
-      assign(:email_about_things, [[track, [result], search_results]])
+      assign(:email_about_things, [[track, [event], ['test']]])
       render
       expect(response).to match("Test Us'r sent a request")
     end


### PR DESCRIPTION
## Relevant issue(s)

Part of #8810

## What does this do?

Five places each built their own Xapian search out of `TrackThing#track_query`: the daily digest, the user wall, the river of news, the atom and JSON feeds, and the translation task. They now all call `TrackThing#matches`.

It also moves the boundary between search and alerts from search result hashes to InfoRequestEvent records, so the views and the digest template take records rather than digging them out of `result[:model]`.

Adds an `is_searchable` scope to InfoRequestEvent and IncomingMessage although nothing calls them yet but we will.

No behaviour changes.

## Why was this needed?

Alerts run entirely via Xapian, and we are replacing Xapian with PostgreSQL search. A production audit found five of the six track types need no full text search at all as `track_query` is a pure structural filter that maps onto associations we already have.

Having a single method first means the actual move to the database is easier than it would be needed to change five searches all together.

<hr>

[skip changelog]