### PR TITLE
Add legacy search engine option to admin users 

### DIFF
--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -5,6 +5,7 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AdminPublicBodyController < AdminController
+  include Admin::Searchable
   include Admin::Sortable
   include TranslatableParams
 
@@ -244,9 +245,8 @@ class AdminPublicBodyController < AdminController
       @query = nil if @query == ""
       @page = params[:page]
       @page = nil if @page == ""
-      @search_engine = params[:search_engine] || 'new'
 
-      if @search_engine == 'legacy'
+      if legacy_search?
         lookup_query_legacy
       else
         lookup_query_new

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -5,6 +5,7 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AdminRequestController < AdminController
+  include Admin::Searchable
   include Admin::Sortable
 
   before_action :set_info_request, :check_info_request, only: %i[
@@ -16,9 +17,8 @@ class AdminRequestController < AdminController
   def index
     @query = params[:query]
     @query = nil if @query == ''
-    @search_engine = params[:search_engine] || 'new'
 
-    if @search_engine == 'legacy'
+    if legacy_search?
       index_legacy
     else
       index_new

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -5,6 +5,7 @@
 # Email: hello@mysociety.org; WWW: http://www.mysociety.org/
 
 class AdminUserController < AdminController
+  include Admin::Searchable
   include Admin::Sortable
 
   layout 'admin/users'
@@ -32,19 +33,7 @@ class AdminUserController < AdminController
 
     @roles = params[:roles] || []
 
-    users = @base_scope || User
-    if @query.present?
-      # Admin search relies on the PostgreSQL-only admin index, so force
-      # that backend whatever SEARCH_BACKEND configures. Exact mode keeps
-      # fragment searches like partial email addresses working.
-      users = users.search_scope(
-        @query,
-        backend: :postgresql,
-        admin_mode: true,
-        exact_mode: true,
-        case_sensitive: false
-      )
-    end
+    users = legacy_search? ? index_legacy : index_new
 
     # with_all_roles returns an array as it takes multiple queries
     # so we need to requery in order to paginate
@@ -149,6 +138,29 @@ class AdminUserController < AdminController
   end
 
   private
+
+  def index_legacy
+    users = @base_scope || User
+    return users if @query.blank?
+
+    users.legacy_search(@query)
+  end
+
+  def index_new
+    users = @base_scope || User
+    return users if @query.blank?
+
+    # Admin search relies on the PostgreSQL-only admin index, so force
+    # that backend whatever SEARCH_BACKEND configures. Exact mode keeps
+    # fragment searches like partial email addresses working.
+    users.search_scope(
+      @query,
+      backend: :postgresql,
+      admin_mode: true,
+      exact_mode: true,
+      case_sensitive: false
+    )
+  end
 
   def user_params
     if params[:admin_user]

--- a/app/controllers/concerns/admin/searchable.rb
+++ b/app/controllers/concerns/admin/searchable.rb
@@ -1,0 +1,28 @@
+##
+# Lets an admin listing switch between the legacy database search and the
+# new search index.
+#
+# Usage:
+#   class AdminUserController < AdminController
+#     include Admin::Searchable
+#
+#     def index
+#       @admin_users = legacy_search? ? index_legacy : index_new
+#     end
+#   end
+#
+module Admin::Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :search_engine, :legacy_search?
+  end
+
+  def search_engine
+    @search_engine ||= params[:search_engine] == 'legacy' ? 'legacy' : 'new'
+  end
+
+  def legacy_search?
+    search_engine == 'legacy'
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -233,6 +233,19 @@ class User < ApplicationRecord
     "about_me": "A"
   }
 
+  def self.legacy_search(query)
+    sql = <<~SQL
+      users.name ILIKE '%'||:query||'%' OR
+      users.email ILIKE '%'||:query||'%' OR
+      users.about_me ILIKE '%'||:query||'%' OR
+      has_tag_string_tags.name ILIKE :query
+    SQL
+
+    left_outer_joins(:tags).
+      where(sql, query: query).
+      distinct
+  end
+
   def self.pro
     with_role(:pro)
   end

--- a/app/views/admin_public_body/index.html.erb
+++ b/app/views/admin_public_body/index.html.erb
@@ -28,19 +28,10 @@
       <%= submit_tag "Search", class: "btn" %>
     </div>
 
-    <div>
-      <%= radio_button_tag "search_engine", "legacy", checked: "legacy" == @search_engine %>
-      <%= label_tag "search_engine_legacy",
-      "legacy engine: substring search in names and emails; exact match of tags",
-      class: "help-inline" %>
-      <br>
-      <%= radio_button_tag "search_engine",
-      "new",
-      checked: "new" == @search_engine %>
-      <%= label_tag "search_engine_new",
-      "new engine: whole word search in names, emails and notes; please report poor search results!",
-      class: "help-inline" %>
-    </div>
+    <%= render partial: 'concerns/admin/searchable/search_engine', locals: {
+      legacy_label: 'substring search in names and emails; exact match of tags',
+      new_label: 'whole word search in names, emails and notes; please report poor search results!'
+    } %>
 
     <% if @query %>
       <%= link_to 'Show all', admin_bodies_path, class: 'btn' %>
@@ -58,11 +49,11 @@
   <% if @query.nil? %>
     <h2>All authorities</h2>
   <% else %>
-    <% if @search_engine == "new" %>
-      <h2>Search engine matches (<%= @public_bodies.total_entries %>
+    <% if legacy_search? %>
+      <h2>Substring search matches (<%= @public_bodies.total_entries %>
         total)</h2>
     <% else %>
-      <h2>Substring search matches (<%= @public_bodies.total_entries %>
+      <h2>Search engine matches (<%= @public_bodies.total_entries %>
         total)</h2>
     <% end %>
   <% end %>

--- a/app/views/admin_request/index.html.erb
+++ b/app/views/admin_request/index.html.erb
@@ -14,19 +14,10 @@
     <%= submit_tag 'Search', class: 'btn' %>
   </div>
 
-  <div>
-    <%= radio_button_tag "search_engine", "legacy", checked: "legacy" == @search_engine %>
-    <%= label_tag "search_engine_legacy",
-    "legacy engine: substring search in titles only",
-    class: "help-inline" %>
-    <br>
-    <%= radio_button_tag "search_engine",
-    "new",
-    checked: "new" == @search_engine %>
-    <%= label_tag "search_engine_new",
-    "new engine: whole word search in titles; please report poor search results!",
-    class: "help-inline" %>
-  </div>
+  <%= render partial: 'concerns/admin/searchable/search_engine', locals: {
+    legacy_label: 'substring search in titles only',
+    new_label: 'whole word search in titles; please report poor search results!'
+  } %>
 <% end %>
 
 <%= render partial: 'some_requests', locals: { info_requests: @info_requests } %>

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -8,9 +8,10 @@
       <%= submit_tag 'Search', class: 'btn' %>
     </div>
 
-    <span class="help-inline">
-      (substring search, names, emails and about me; exact match of tags)
-    </span>
+    <%= render partial: 'concerns/admin/searchable/search_engine', locals: {
+      legacy_label: 'substring search in names, emails and about me; exact match of tags',
+      new_label: 'whole word and substring search in names, emails and about me; please report poor search results!'
+    } %>
 
     <div class="input-group role-filter">
       <span class="help-inline">Filter by role:</span>

--- a/app/views/concerns/admin/searchable/_search_engine.html.erb
+++ b/app/views/concerns/admin/searchable/_search_engine.html.erb
@@ -1,0 +1,11 @@
+<div class="search-engine-options">
+  <%= radio_button_tag 'search_engine', 'legacy', legacy_search? %>
+  <%= label_tag 'search_engine_legacy',
+                "legacy engine: #{legacy_label}",
+                class: 'help-inline' %>
+  <br>
+  <%= radio_button_tag 'search_engine', 'new', !legacy_search? %>
+  <%= label_tag 'search_engine_new',
+                "new engine: #{new_label}",
+                class: 'help-inline' %>
+</div>

--- a/spec/controllers/concerns/admin/searchable_spec.rb
+++ b/spec/controllers/concerns/admin/searchable_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe Admin::Searchable do
+  let(:controller_class) do
+    Class.new(ActionController::Base) do
+      include Admin::Searchable
+    end
+  end
+
+  let(:controller) { controller_class.new }
+
+  before do
+    allow(controller).to receive(:params).and_return(
+      ActionController::Parameters.new(search_engine: search_engine)
+    )
+  end
+
+  describe '#search_engine' do
+    subject { controller.search_engine }
+
+    context 'when the legacy engine is requested' do
+      let(:search_engine) { 'legacy' }
+      it { is_expected.to eq('legacy') }
+    end
+
+    context 'when nothing is requested' do
+      let(:search_engine) { nil }
+      it { is_expected.to eq('new') }
+    end
+
+    context 'when an unknown engine is requested' do
+      let(:search_engine) { 'quantum' }
+      it { is_expected.to eq('new') }
+    end
+  end
+
+  describe '#legacy_search?' do
+    subject { controller.legacy_search? }
+
+    context 'when the legacy engine is requested' do
+      let(:search_engine) { 'legacy' }
+      it { is_expected.to be(true) }
+    end
+
+    context 'when nothing is requested' do
+      let(:search_engine) { nil }
+      it { is_expected.to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
Refactor admin search toggle into a concern and add search toggle to the admin user search so all three info request, public body and user admin searching all work the same way.

[skip changelog]
