### PR TITLE
Extract `InfoRequest::Guessable` and `InfoRequest::MagicEmail` 

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -56,6 +56,7 @@ class InfoRequest < ApplicationRecord
   include InfoRequest::BatchPagination
   include InfoRequest::Guessable
   include InfoRequest::HoldingPen
+  include InfoRequest::MagicEmail
   include InfoRequest::PublicToken
   include InfoRequest::Sluggable
   include InfoRequest::TitleValidation
@@ -206,7 +207,6 @@ class InfoRequest < ApplicationRecord
 
   after_initialize :set_defaults
   before_create :set_use_notifications
-  before_validation :compute_idhash
   before_validation :set_law_used, on: :create
   after_create :notify_associations
   after_save :update_counter_cache
@@ -224,33 +224,6 @@ class InfoRequest < ApplicationRecord
                "prominence_reason": "D"
              }
 
-  # Return info request corresponding to an incoming email address, or nil if
-  # none found. Checks the hash to ensure the email came from the public body -
-  # only they are sent the email address with the has in it. (We don't check
-  # the prefix and domain, as sometimes those change, or might be elided by
-  # copying an email, and that doesn't matter)
-  def self.find_by_incoming_email(incoming_email)
-    id, hash = InfoRequest._extract_id_hash_from_email(incoming_email)
-    if hash_from_id(id) == hash
-      # Not using find(id) because we don't exception raised if nothing found
-      find_by_id(id)
-    end
-  end
-
-  # Public: Find by a list of incoming email addresses.
-  # TODO: It would be better to make this return a chainable
-  # ActiveRecord::Relation
-  #
-  # Examples:
-  #
-  #   InfoRequest.matching_incoming_email('request-1-ae63fb73@localhost')
-  #   InfoRequest.matching_incoming_email(@array_of_email_addresses)
-  #
-  # Returns an Array
-  def self.matching_incoming_email(emails)
-    Array(emails).map { |email| find_by_incoming_email(email) }.compact
-  end
-
   # Subset of states accepted via the API
   def self.allowed_incoming_states
     %w[
@@ -263,42 +236,6 @@ class InfoRequest < ApplicationRecord
 
   def self.custom_states_loaded
     @@custom_states_loaded
-  end
-
-  # Internal function - attempts to convert a guessed id String from incoming
-  # email addresses to an Integer. Returns nil if it fails to avoid accidentally
-  # stripping trailing letters e.g. '123ab' should not match 123
-  #
-  # Returns an Integer
-  def self._id_string_to_i(id_string)
-    Integer(id_string) if id_string
-  rescue ArgumentError
-    nil
-  end
-
-  # Internal function used to clean the id_hash from incoming email addresses.
-  # Converts l to 1, and o to 0. FOI officers quite often retype the email
-  # address and make this kind of error.
-  def self._clean_idhash(hash)
-    return unless hash
-
-    hash.gsub(/l/, "1").gsub(/o/, "0")
-  end
-
-  # Internal function used by find_by_incoming_email and guess_by_incoming_email
-  def self._extract_id_hash_from_email(incoming_email)
-    # Match case insensitively, FOI officers often write Request with capital R.
-    incoming_email = incoming_email.downcase
-
-    # The optional bounce- dates from when we used to have separate emails for the envelope from.
-    # (that was abandoned because councils would send hand written responses to them, not just
-    # bounce messages)
-    incoming_email =~ /request-(?:bounce-)?([a-z0-9]+)-([a-z0-9]+)/
-
-    id = _id_string_to_i($1)
-    hash = _clean_idhash($2)
-
-    [id, hash]
   end
 
   # When constructing a new request, use this to check user hasn't double submitted.
@@ -353,14 +290,6 @@ class InfoRequest < ApplicationRecord
     end
   end
 
-  def self.magic_email_for_id(prefix_part, id)
-    magic_email = AlaveteliConfiguration.incoming_email_prefix
-    magic_email += prefix_part + id.to_s
-    magic_email += "-" + InfoRequest.hash_from_id(id)
-    magic_email += "@" + AlaveteliConfiguration.incoming_email_domain
-    magic_email
-  end
-
   def self.build_from_attributes(info_request_atts, outgoing_message_atts, user=nil)
     info_request = new(info_request_atts)
     default_message_params = {
@@ -398,10 +327,6 @@ class InfoRequest < ApplicationRecord
       )
     end
     info_request
-  end
-
-  def self.hash_from_id(id)
-    Digest::SHA1.hexdigest(id.to_s + AlaveteliConfiguration.incoming_email_secret)[0,8]
   end
 
   # Used to find when event last changed
@@ -744,13 +669,6 @@ class InfoRequest < ApplicationRecord
     _title = read_attribute(:title)
     _title.strip! if _title
     _title
-  end
-
-  # Email which public body should use to respond to request. This is in
-  # the format PREFIXrequest-ID-HASH@DOMAIN. Here ID is the id of the
-  # FOI request, and HASH is a signature for that id.
-  def incoming_email
-    magic_email("request-")
   end
 
   def incoming_name_and_email
@@ -1229,18 +1147,6 @@ class InfoRequest < ApplicationRecord
 
   def display_status(cached_value_ok=false)
     InfoRequest.get_status_description(calculate_status(cached_value_ok))
-  end
-
-  # Called by incoming_email - and used to be called to generate separate
-  # envelope from address until we abandoned it.
-  def magic_email(prefix_part)
-    raise "id required to create a magic email" unless id
-
-    InfoRequest.magic_email_for_id(prefix_part, id)
-  end
-
-  def compute_idhash
-    self.idhash = InfoRequest.hash_from_id(id)
   end
 
   def foi_fragment_cache_directories

--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -54,6 +54,7 @@ class InfoRequest < ApplicationRecord
   include AlaveteliFeatures::Helpers
 
   include InfoRequest::BatchPagination
+  include InfoRequest::Guessable
   include InfoRequest::HoldingPen
   include InfoRequest::PublicToken
   include InfoRequest::Sluggable
@@ -264,47 +265,6 @@ class InfoRequest < ApplicationRecord
     @@custom_states_loaded
   end
 
-  # Public: Attempt to find InfoRequests by matching against extracted `id` and
-  # `idhash` elements of an `incoming_email`.
-  #
-  # emails - A String email address or an Array of String email addresses.
-  #
-  # Returns an Array
-  def self.guess_by_incoming_email(*emails)
-    guesses = emails.flatten.reduce([]) do |memo, email|
-      id, idhash = _extract_id_hash_from_email(email)
-      id, idhash = _guess_idhash_from_email(email) if idhash.nil? || id.nil?
-
-      memo << Guess.new(
-        find_by_id(id), email: email, id: id, idhash: idhash
-      )
-      memo << Guess.new(
-        find_by_idhash(idhash), email: email, id: id, idhash: idhash
-      )
-    end
-
-    # Unique Guesses where we've found an `InfoRequest`
-    guesses.select(&:info_request).uniq(&:info_request)
-  end
-
-  # Internal function used by guess_by_incoming_email
-  def self._guess_idhash_from_email(incoming_email)
-    incoming_email = incoming_email.downcase
-    incoming_email =~ /request\-?(\w+)-?(\w{8})@/
-
-    id = _id_string_to_i(_clean_idhash($1))
-    id_hash = $2
-
-    if id_hash.nil? && incoming_email.include?('@')
-      # try to grab the last 8 chars of the local part of the address instead
-      local_part = incoming_email[0..incoming_email.index('@')-1]
-      id_hash =
-        (_clean_idhash(local_part[-8..-1]) if local_part.length >= 8)
-    end
-
-    [id, id_hash]
-  end
-
   # Internal function - attempts to convert a guessed id String from incoming
   # email addresses to an Integer. Returns nil if it fails to avoid accidentally
   # stripping trailing letters e.g. '123ab' should not match 123
@@ -325,39 +285,7 @@ class InfoRequest < ApplicationRecord
     hash.gsub(/l/, "1").gsub(/o/, "0")
   end
 
-  # Public: Attempt to find InfoRequests by matching against extracted `subject`
-  # element of an `incoming_email`.
-  #
-  # subject_line - A String an email subject line
-  # Returns an Array
-  def self.guess_by_incoming_subject(subject_line)
-    return [] unless subject_line
-
-    # try to find a match on InfoRequest#title
-    reply_format = InfoRequest.new(title: '').email_subject_followup
-    requests_by_title = InfoRequest.left_joins(:incoming_messages).
-      where(title: subject_line.gsub(/#{reply_format}/i, '').strip)
-
-    # try to find a match on IncomingMessage#subject
-    requests_by_subject = InfoRequest.left_joins(:incoming_messages).
-      where(incoming_messages: {
-              subject: [subject_line.gsub(/^Re: /i, ''), subject_line].uniq
-            })
-
-    requests = requests_by_title.or(requests_by_subject).
-      distinct.
-      where.not(url_title: 'holding_pen').
-      limit(25)
-
-    guesses = requests.each.reduce([]) do |memo, request|
-      memo << Guess.new(request, subject: subject_line)
-    end
-
-    # Unique Guesses where we've found an `InfoRequest`
-    guesses.select(&:info_request).uniq(&:info_request)
-  end
-
-  # Internal function used by find_by_magic_email and guess_by_incoming_email
+  # Internal function used by find_by_incoming_email and guess_by_incoming_email
   def self._extract_id_hash_from_email(incoming_email)
     # Match case insensitively, FOI officers often write Request with capital R.
     incoming_email = incoming_email.downcase

--- a/app/models/info_request/guessable.rb
+++ b/app/models/info_request/guessable.rb
@@ -1,0 +1,79 @@
+# Find the most likely InfoRequest when we don't have the exact id/idhash
+module InfoRequest::Guessable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    # Public: Attempt to find InfoRequests by matching against extracted `id`
+    # and `idhash` elements of an `incoming_email`.
+    #
+    # emails - A String email address or an Array of String email addresses.
+    #
+    # Returns an Array
+    def guess_by_incoming_email(*emails)
+      guesses = emails.flatten.reduce([]) do |memo, email|
+        id, idhash = _extract_id_hash_from_email(email)
+        id, idhash = _guess_idhash_from_email(email) if idhash.nil? || id.nil?
+
+        memo << Guess.new(
+          find_by_id(id), email: email, id: id, idhash: idhash
+        )
+        memo << Guess.new(
+          find_by_idhash(idhash), email: email, id: id, idhash: idhash
+        )
+      end
+
+      # Unique Guesses where we've found an `InfoRequest`
+      guesses.select(&:info_request).uniq(&:info_request)
+    end
+
+    # Public: Attempt to find InfoRequests by matching against extracted `subject`
+    # element of an `incoming_email`.
+    #
+    # subject_line - A String an email subject line
+    # Returns an Array
+    def guess_by_incoming_subject(subject_line)
+      return [] unless subject_line
+
+      # try to find a match on InfoRequest#title
+      reply_format = InfoRequest.new(title: '').email_subject_followup
+      requests_by_title = InfoRequest.left_joins(:incoming_messages).
+        where(title: subject_line.gsub(/#{reply_format}/i, '').strip)
+
+      # try to find a match on IncomingMessage#subject
+      requests_by_subject = InfoRequest.left_joins(:incoming_messages).
+        where(incoming_messages: {
+                subject: [subject_line.gsub(/^Re: /i, ''), subject_line].uniq
+              })
+
+      requests = requests_by_title.or(requests_by_subject).
+        distinct.
+        where.not(url_title: 'holding_pen').
+        limit(25)
+
+      guesses = requests.each.reduce([]) do |memo, request|
+        memo << Guess.new(request, subject: subject_line)
+      end
+
+      # Unique Guesses where we've found an `InfoRequest`
+      guesses.select(&:info_request).uniq(&:info_request)
+    end
+
+    # Internal function used by guess_by_incoming_email
+    def _guess_idhash_from_email(incoming_email)
+      incoming_email = incoming_email.downcase
+      incoming_email =~ /request\-?(\w+)-?(\w{8})@/
+
+      id = _id_string_to_i(_clean_idhash($1))
+      id_hash = $2
+
+      if id_hash.nil? && incoming_email.include?('@')
+        # try to grab the last 8 chars of the local part of the address instead
+        local_part = incoming_email[0..incoming_email.index('@') - 1]
+        id_hash =
+          (_clean_idhash(local_part[-8..-1]) if local_part.length >= 8)
+      end
+
+      [id, id_hash]
+    end
+  end
+end

--- a/app/models/info_request/magic_email.rb
+++ b/app/models/info_request/magic_email.rb
@@ -1,0 +1,108 @@
+# Generate magic email and find an InfoRequest by the magic email
+module InfoRequest::MagicEmail
+  extend ActiveSupport::Concern
+
+  included do
+    before_validation :compute_idhash
+  end
+
+  class_methods do
+    def magic_email_for_id(prefix_part, id)
+      magic_email = AlaveteliConfiguration.incoming_email_prefix
+      magic_email += prefix_part + id.to_s
+      magic_email += "-" + InfoRequest.hash_from_id(id)
+      magic_email += "@" + AlaveteliConfiguration.incoming_email_domain
+      magic_email
+    end
+
+    def hash_from_id(id)
+      Digest::SHA1.hexdigest(
+        id.to_s + AlaveteliConfiguration.incoming_email_secret
+      )[0, 8]
+    end
+
+    # Return info request corresponding to an incoming email address, or nil if
+    # none found. Checks the hash to ensure the email came from the public
+    # body - only they are sent the email address with the hash in it. (We don't
+    # check the prefix and domain, as sometimes those change, or might be elided
+    # by copying an email, and that doesn't matter)
+    def find_by_incoming_email(incoming_email)
+      id, hash = InfoRequest._extract_id_hash_from_email(incoming_email)
+      if hash_from_id(id) == hash
+        # Not using find(id) because we don't exception raised if nothing found
+        find_by_id(id)
+      end
+    end
+
+    # Public: Find by a list of incoming email addresses.
+    # TODO: It would be better to make this return a chainable
+    # ActiveRecord::Relation
+    #
+    # Examples:
+    #
+    #   InfoRequest.matching_incoming_email('request-1-ae63fb73@localhost')
+    #   InfoRequest.matching_incoming_email(@array_of_email_addresses)
+    #
+    # Returns an Array
+    def matching_incoming_email(emails)
+      Array(emails).map { |email| find_by_incoming_email(email) }.compact
+    end
+
+    # Internal function used by find_by_incoming_email and
+    # guess_by_incoming_email
+    def _extract_id_hash_from_email(incoming_email)
+      # Match case insensitively, FOI officers often write Request with a
+      # capital R.
+      incoming_email = incoming_email.downcase
+
+      # The optional bounce- dates from when we used to have separate emails for
+      # the envelope from.  (that was abandoned because councils would send hand
+      # written responses to them, not just bounce messages)
+      incoming_email =~ /request-(?:bounce-)?([a-z0-9]+)-([a-z0-9]+)/
+
+      id = _id_string_to_i($1)
+      hash = _clean_idhash($2)
+
+      [id, hash]
+    end
+
+    # Internal function - attempts to convert a guessed id String from incoming
+    # email addresses to an Integer. Returns nil if it fails to avoid
+    # accidentally stripping trailing letters e.g. '123ab' should not match 123
+    #
+    # Returns an Integer
+    def _id_string_to_i(id_string)
+      Integer(id_string) if id_string
+    rescue ArgumentError
+      nil
+    end
+
+    # Internal function used to clean the id_hash from incoming email addresses.
+    # Converts l to 1, and o to 0. FOI officers quite often retype the email
+    # address and make this kind of error.
+    def _clean_idhash(hash)
+      return unless hash
+
+      hash.gsub(/l/, "1").gsub(/o/, "0")
+    end
+  end
+
+  # Email which public body should use to respond to request. This is in
+  # the format PREFIXrequest-ID-HASH@DOMAIN. Here ID is the id of the
+  # FOI request, and HASH is a signature for that id.
+  def incoming_email
+    magic_email("request-")
+  end
+
+  # Called by incoming_email - and used to be called to generate separate
+  # envelope from address until we abandoned it.
+  def magic_email(prefix_part)
+    raise "id required to create a magic email" unless id
+
+    InfoRequest.magic_email_for_id(prefix_part, id)
+  end
+
+  def compute_idhash
+    self.idhash = InfoRequest.hash_from_id(id)
+  end
+end


### PR DESCRIPTION
Extract the guess-related methods and magic email related methods to concerns to reduce complexity of the main class definition.

[skip changelog]
