### PR TITLE
Removes `background:#fff` from `.comment_content .event_actions`

### DIFF
--- a/app/assets/stylesheets/responsive/_request_style.scss
+++ b/app/assets/stylesheets/responsive/_request_style.scss
@@ -246,6 +246,10 @@ div.comment_in_request {
 
   .comment_content {
     padding: 1.2em 1.2em 0 1.2em;
+
+    .event_actions {
+      background-color: inherit;
+    }
   }
 }
 


### PR DESCRIPTION
## Relevant issue(s)

Fixes: https://github.com/mysociety/alaveteli/issues/9480

## What does this do?

Removes white background from `.comment_content .event_actions`, instead it will inherit the same background colour as its parent.

## Why was this needed?

## Implementation notes

## Screenshots
### WDTK
<img width="1351" height="557" alt="Screenshot 2026-08-24 at 08 03 24" src="https://github.com/user-attachments/assets/f77ff3e4-c995-455a-a80b-cbceac2ee0e4" />

### None them
<img width="1351" height="668" alt="Screenshot 2026-08-24 at 08 05 30" src="https://github.com/user-attachments/assets/7b150c95-6310-41dc-82e6-4add8b396b4d" />

## Notes to reviewer

<hr>

[skip changelog]
