### PR TITLE
Add PG search admin stats

### DIFF
--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -277,12 +277,15 @@ class AdminPublicBodyController < AdminController
       @public_bodies =
         PublicBody.
           joins(:translations).
-            where(query).
-              merge(PublicBody::Translation.order(:name)).
-                paginate(page: @page, per_page: 100)
+            includes(:tags, :translations).
+              where(query).
+                merge(PublicBody::Translation.order(:name)).
+                  paginate(page: @page, per_page: 100)
     end
 
-    @public_bodies_by_tag = PublicBody.find_by_tag(@query)
+    @public_bodies_by_tag = PublicBody.
+      find_by_tag(@query).
+        includes(:tags, :translations)
   end
 
   def lookup_query_new

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -246,70 +246,49 @@ class AdminPublicBodyController < AdminController
       @page = params[:page]
       @page = nil if @page == ""
 
-      if legacy_search?
-        lookup_query_legacy
-      else
-        lookup_query_new
-      end
-    end
-  end
-
-  def lookup_query_legacy
-    begin # increase nested to minimise the whitespace changes in diff
-      query = if @query
-        query_str = <<-EOF.strip_heredoc
-        (lower(public_body_translations.name)
-         LIKE lower('%'||?||'%')
-         OR lower(public_body_translations.short_name)
-         LIKE lower('%'||?||'%')
-         OR lower(public_body_translations.request_email)
-         LIKE lower('%'||?||'%' ))
-         AND (public_body_translations.locale = '#{@locale}')
-        EOF
-
-        [query_str, @query, @query, @query]
-      else
-        <<-EOF.strip_heredoc
-        public_body_translations.locale = '#{@locale}'
-        EOF
-      end
-
       @public_bodies =
-        PublicBody.
-          joins(:translations).
-            includes(:tags, :translations).
-              where(query).
-                merge(PublicBody::Translation.order(:name)).
-                  paginate(page: @page, per_page: 100)
-    end
-
-    @public_bodies_by_tag = PublicBody.
-      find_by_tag(@query).
-        includes(:tags, :translations)
-  end
-
-  def lookup_query_new
-    if @query
-      @public_bodies =
-        PublicBody.
-          search_scope(@query,
-                       backend: :postgresql,
-                       admin_mode: true).
-            includes(:tags, :translations).
-              paginate(page: @page, per_page: 100)
-    else
-      @public_bodies =
-        PublicBody.
+        public_body_scope.
           includes(:tags, :translations).
-            references(:translations).
-              where(public_body_translations: { locale: @locale }).
-                merge(PublicBody::Translation.order(:name)).
-                  paginate(page: @page, per_page: 100)
-    end
+            paginate(page: @page, per_page: 100)
 
-    @public_bodies_by_tag = PublicBody.
-      find_by_tag(@query).
-        includes(:tags, :translations)
+      @public_bodies_by_tag = PublicBody.
+        find_by_tag(@query).
+          includes(:tags, :translations)
+    end
+  end
+
+  def public_body_scope
+    return locale_public_body_scope unless @query
+
+    legacy_search? ? legacy_public_body_scope : indexed_public_body_scope
+  end
+
+  def locale_public_body_scope
+    PublicBody.
+      joins(:translations).
+        where(public_body_translations: { locale: @locale }).
+          merge(PublicBody::Translation.order(:name))
+  end
+
+  def legacy_public_body_scope
+    query = <<-EOF.strip_heredoc
+    (lower(public_body_translations.name)
+     LIKE lower('%'||?||'%')
+     OR lower(public_body_translations.short_name)
+     LIKE lower('%'||?||'%')
+     OR lower(public_body_translations.request_email)
+     LIKE lower('%'||?||'%' ))
+     AND (public_body_translations.locale = '#{@locale}')
+    EOF
+
+    PublicBody.
+      joins(:translations).
+        where([query, @query, @query, @query]).
+          merge(PublicBody::Translation.order(:name))
+  end
+
+  def indexed_public_body_scope
+    PublicBody.search_scope(@query, backend: :postgresql, admin_mode: true)
   end
 
   def public_body_params

--- a/app/controllers/admin_public_body_controller.rb
+++ b/app/controllers/admin_public_body_controller.rb
@@ -246,10 +246,11 @@ class AdminPublicBodyController < AdminController
       @page = params[:page]
       @page = nil if @page == ""
 
-      @public_bodies =
+      @public_bodies = measure_search(
         public_body_scope.
           includes(:tags, :translations).
             paginate(page: @page, per_page: 100)
+      )
 
       @public_bodies_by_tag = PublicBody.
         find_by_tag(@query).

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -24,11 +24,12 @@ class AdminRequestController < AdminController
       info_requests = info_requests.not_embargoed
     end
 
-    @info_requests =
+    @info_requests = measure_search(
       info_requests.
       includes(:embargo, :user, public_body: :translations).
       order(sort_query).
       paginate(page: params[:page], per_page: 100)
+    )
   end
 
   def show

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -223,6 +223,7 @@ class AdminRequestController < AdminController
 
     @info_requests =
       info_requests.
+      includes(:embargo, :user, public_body: :translations).
       order(sort_query).
       paginate(page: params[:page], per_page: 100)
   end

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -18,11 +18,17 @@ class AdminRequestController < AdminController
     @query = params[:query]
     @query = nil if @query == ''
 
-    if legacy_search?
-      index_legacy
-    else
-      index_new
+    info_requests = info_request_scope
+
+    if cannot? :admin, AlaveteliPro::Embargo
+      info_requests = info_requests.not_embargoed
     end
+
+    @info_requests =
+      info_requests.
+      includes(:embargo, :user, public_body: :translations).
+      order(sort_query).
+      paginate(page: params[:page], per_page: 100)
   end
 
   def show
@@ -210,43 +216,20 @@ class AdminRequestController < AdminController
 
   private
 
-  def index_legacy
-    if @query
-      info_requests = InfoRequest.where(["lower(title) like lower('%'||?||'%')", @query])
-    else
-      info_requests = InfoRequest
-    end
+  def info_request_scope
+    return InfoRequest unless @query
 
-    if cannot? :admin, AlaveteliPro::Embargo
-      info_requests = info_requests.not_embargoed
-    end
-
-    @info_requests =
-      info_requests.
-      includes(:embargo, :user, public_body: :translations).
-      order(sort_query).
-      paginate(page: params[:page], per_page: 100)
+    legacy_search? ? legacy_info_request_scope : indexed_info_request_scope
   end
 
-  def index_new
-    info_requests =
-      if @query
-        InfoRequest.search_scope(@query,
-                                 backend: :postgresql,
-                                 admin_mode: true)
-      else
-        InfoRequest
-      end
+  def legacy_info_request_scope
+    InfoRequest.where(
+      ["lower(title) like lower('%'||?||'%')", @query]
+    )
+  end
 
-    if cannot? :admin, AlaveteliPro::Embargo
-      info_requests = info_requests.not_embargoed
-    end
-
-    @info_requests =
-      info_requests.
-      includes(:embargo, :user, public_body: :translations).
-      order(sort_query).
-      paginate(page: params[:page], per_page: 100)
+  def indexed_info_request_scope
+    InfoRequest.search_scope(@query, backend: :postgresql, admin_mode: true)
   end
 
   def info_request_params

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -33,7 +33,7 @@ class AdminUserController < AdminController
 
     @roles = params[:roles] || []
 
-    users = legacy_search? ? index_legacy : index_new
+    users = user_scope
 
     # with_all_roles returns an array as it takes multiple queries
     # so we need to requery in order to paginate
@@ -139,21 +139,25 @@ class AdminUserController < AdminController
 
   private
 
-  def index_legacy
-    users = @base_scope || User
-    return users if @query.blank?
+  def user_scope
+    return base_scope if @query.blank?
 
-    users.legacy_search(@query)
+    legacy_search? ? legacy_user_scope : indexed_user_scope
   end
 
-  def index_new
-    users = @base_scope || User
-    return users if @query.blank?
+  def base_scope
+    @base_scope || User
+  end
 
+  def legacy_user_scope
+    base_scope.legacy_search(@query)
+  end
+
+  def indexed_user_scope
     # Admin search relies on the PostgreSQL-only admin index, so force
     # that backend whatever SEARCH_BACKEND configures. Exact mode keeps
     # fragment searches like partial email addresses working.
-    users.search_scope(
+    base_scope.search_scope(
       @query,
       backend: :postgresql,
       admin_mode: true,

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -42,9 +42,10 @@ class AdminUserController < AdminController
       users = User.where(id: users.map(&:id))
     end
 
-    @admin_users =
+    @admin_users = measure_search(
       users.order(sort_query).
         paginate(page: params[:page], per_page: 100)
+    )
 
     render action: :index
   end

--- a/app/controllers/concerns/admin/searchable.rb
+++ b/app/controllers/concerns/admin/searchable.rb
@@ -1,6 +1,6 @@
 ##
 # Lets an admin listing switch between the legacy database search and the
-# new search index.
+# new search index, and reports what the search it ran cost.
 #
 # Usage:
 #   class AdminUserController < AdminController
@@ -8,7 +8,7 @@
 #
 #     def index
 #       users = legacy_search? ? legacy_user_scope : indexed_user_scope
-#       @admin_users = users.paginate(page: params[:page])
+#       @admin_users = measure_search(users.paginate(page: params[:page]))
 #     end
 #   end
 #
@@ -16,8 +16,10 @@ module Admin::Searchable
   extend ActiveSupport::Concern
 
   included do
-    helper_method :search_engine, :legacy_search?
+    helper_method :search_engine, :legacy_search?, :search_stats
   end
+
+  attr_reader :search_stats
 
   def search_engine
     @search_engine ||= params[:search_engine] == 'legacy' ? 'legacy' : 'new'
@@ -25,5 +27,12 @@ module Admin::Searchable
 
   def legacy_search?
     search_engine == 'legacy'
+  end
+
+  # Run +relation+, timing it so the listing can show what the search cost.
+  # Returns the relation, now loaded.
+  def measure_search(relation)
+    @search_stats = Search::Stats.measure(relation)
+    relation
   end
 end

--- a/app/controllers/concerns/admin/searchable.rb
+++ b/app/controllers/concerns/admin/searchable.rb
@@ -7,7 +7,8 @@
 #     include Admin::Searchable
 #
 #     def index
-#       @admin_users = legacy_search? ? index_legacy : index_new
+#       users = legacy_search? ? legacy_user_scope : indexed_user_scope
+#       @admin_users = users.paginate(page: params[:page])
 #     end
 #   end
 #

--- a/app/helpers/admin/search_helper.rb
+++ b/app/helpers/admin/search_helper.rb
@@ -1,0 +1,16 @@
+# Helpers for showing search stats in the admin interface
+module Admin::SearchHelper
+  def search_duration(seconds)
+    ms = number_with_precision(seconds * 1000, precision: 1, delimiter: ',')
+    "#{ms}ms"
+  end
+
+  def explain_search?
+    params[:explain] == '1'
+  end
+
+  # The current listing, with the query plan switched on or off.
+  def explain_search_url(explain)
+    url_for(request.query_parameters.merge(explain: explain ? '1' : '0'))
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -5,6 +5,7 @@ module AdminHelper
   include Admin::ClassificationsHelper
   include Admin::LinkHelper
   include Admin::ProminenceHelper
+  include Admin::SearchHelper
 
   def icon(name)
     content_tag(:i, "", class: "icon-#{name}")

--- a/app/models/search/stats.rb
+++ b/app/models/search/stats.rb
@@ -1,0 +1,58 @@
+module Search
+  ##
+  # Times a search query and keeps hold of the SQL behind it, so admin
+  # listings can show what a search cost. Counting the matches and loading
+  # the page are timed apart, as counting is often the slower of the two.
+  #
+  # Takes the paginated relation a listing renders, so +count+ is every
+  # match rather than the page.
+  #
+  #   relation = PublicBody.search_scope('foi').paginate(page: 1)
+  #   stats = Search::Stats.measure(relation)
+  #   stats.count     # => 42
+  #   stats.duration  # => 0.031
+  #
+  class Stats
+    attr_reader :relation, :count, :count_duration, :load_duration
+
+    def self.measure(relation)
+      new(relation).measure
+    end
+
+    def initialize(relation)
+      @relation = relation
+    end
+
+    def measure
+      @count_duration = timed { @count = relation.total_entries }
+      @load_duration = timed { relation.load }
+      self
+    end
+
+    def duration
+      count_duration + load_duration
+    end
+
+    def sql
+      @sql ||= relation.to_sql
+    end
+
+    # Ask PostgreSQL what it actually did with the query. This runs the
+    # query again, so only do it when someone asks to see it. The query
+    # cache has to be off or EXPLAIN sees a cached result and reports
+    # nothing.
+    def explain
+      @explain ||= relation.klass.uncached do
+        relation.explain(:analyze, :buffers).inspect
+      end
+    end
+
+    private
+
+    def timed
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+      Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+    end
+  end
+end

--- a/app/views/admin_public_body/index.html.erb
+++ b/app/views/admin_public_body/index.html.erb
@@ -28,10 +28,13 @@
       <%= submit_tag "Search", class: "btn" %>
     </div>
 
-    <%= render partial: 'concerns/admin/searchable/search_engine', locals: {
-      legacy_label: 'substring search in names and emails; exact match of tags',
-      new_label: 'whole word search in names, emails and notes; please report poor search results!'
-    } %>
+    <%= render partial: 'concerns/admin/searchable/search_engine',
+               locals: {
+                 legacy_label: 'substring search in names and emails; ' \
+                               'exact match of tags',
+                 new_label: 'whole word search in names, emails and ' \
+                            'notes; please report poor search results!'
+               } %>
 
     <% if @query %>
       <%= link_to 'Show all', admin_bodies_path, class: 'btn' %>
@@ -61,3 +64,5 @@
 <% end %>
 
 <%= will_paginate(@public_bodies) %>
+
+<%= render 'concerns/admin/searchable/search_stats' %>

--- a/app/views/admin_request/index.html.erb
+++ b/app/views/admin_request/index.html.erb
@@ -14,10 +14,14 @@
     <%= submit_tag 'Search', class: 'btn' %>
   </div>
 
-  <%= render partial: 'concerns/admin/searchable/search_engine', locals: {
-    legacy_label: 'substring search in titles only',
-    new_label: 'whole word search in titles; please report poor search results!'
-  } %>
+  <%= render partial: 'concerns/admin/searchable/search_engine',
+             locals: {
+               legacy_label: 'substring search in titles only',
+               new_label: 'whole word search in titles; please report ' \
+                          'poor search results!'
+             } %>
 <% end %>
 
 <%= render partial: 'some_requests', locals: { info_requests: @info_requests } %>
+
+<%= render 'concerns/admin/searchable/search_stats' %>

--- a/app/views/admin_user/index.html.erb
+++ b/app/views/admin_user/index.html.erb
@@ -8,10 +8,14 @@
       <%= submit_tag 'Search', class: 'btn' %>
     </div>
 
-    <%= render partial: 'concerns/admin/searchable/search_engine', locals: {
-      legacy_label: 'substring search in names, emails and about me; exact match of tags',
-      new_label: 'whole word and substring search in names, emails and about me; please report poor search results!'
-    } %>
+    <%= render partial: 'concerns/admin/searchable/search_engine',
+               locals: {
+                 legacy_label: 'substring search in names, emails and ' \
+                               'about me; exact match of tags',
+                 new_label: 'whole word and substring search in names, ' \
+                            'emails and about me; please report poor ' \
+                            'search results!'
+               } %>
 
     <div class="input-group role-filter">
       <span class="help-inline">Filter by role:</span>
@@ -35,5 +39,11 @@
 <div class="row">
   <div class="span12">
     <%= render :partial => 'user_table', :locals => { :users => @admin_users } %>
+  </div>
+</div>
+
+<div class="row">
+  <div class="span12">
+    <%= render 'concerns/admin/searchable/search_stats' %>
   </div>
 </div>

--- a/app/views/concerns/admin/searchable/_search_stats.html.erb
+++ b/app/views/concerns/admin/searchable/_search_stats.html.erb
@@ -1,0 +1,27 @@
+<% if search_stats %>
+  <details class="search-stats">
+    <summary>
+      <%= search_engine %> engine:
+      <%= pluralize(number_with_delimiter(search_stats.count), 'match') %>
+      in <%= search_duration(search_stats.duration) %>
+    </summary>
+
+    <dl class="dl-horizontal">
+      <dt>Counting matches</dt>
+      <dd><%= search_duration(search_stats.count_duration) %></dd>
+      <dt>Loading this page</dt>
+      <dd><%= search_duration(search_stats.load_duration) %></dd>
+    </dl>
+
+    <pre class="pre-scrollable"><%= search_stats.sql %></pre>
+
+    <% if explain_search? %>
+      <pre class="pre-scrollable"><%= search_stats.explain %></pre>
+      <%= link_to 'Hide the query plan', explain_search_url(false),
+                  class: 'btn btn-small' %>
+    <% else %>
+      <%= link_to 'Explain this query', explain_search_url(true),
+                  class: 'btn btn-small' %>
+    <% end %>
+  </details>
+<% end %>

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -20,6 +20,20 @@ RSpec.describe AdminPublicBodyController do
         to eq([public_bodies(:humpadink_public_body)])
     end
 
+    it "eager loads associations for the legacy search" do
+      get :index, params: { query: "humpa", search_engine: "legacy" }
+      body = assigns[:public_bodies].first
+      expect(body.association(:tags)).to be_loaded
+      expect(body.association(:translations)).to be_loaded
+    end
+
+    it "eager loads associations for the tag search" do
+      get :index, params: { query: "useless_agency", search_engine: "legacy" }
+      body = assigns[:public_bodies_by_tag].first
+      expect(body.association(:tags)).to be_loaded
+      expect(body.association(:translations)).to be_loaded
+    end
+
     it "lists all authorities in name order" do
       get :index
       names = assigns[:public_bodies].map(&:name)

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe AdminRequestController, "when administering requests" do
         expect(assigns[:info_requests].include?(cat_request)).to be false
       end
 
+      it 'eager loads the associations the listing renders' do
+        get :index, params: { query: 'cat', search_engine: 'legacy' }
+        request = assigns[:info_requests].first
+        expect(request.association(:embargo)).to be_loaded
+        expect(request.association(:user)).to be_loaded
+        expect(request.association(:public_body)).to be_loaded
+      end
+
       context 'when pro is enabled' do
         it 'does not include embargoed requests if the current user is an
             admin user' do

--- a/spec/controllers/concerns/admin/searchable_spec.rb
+++ b/spec/controllers/concerns/admin/searchable_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe Admin::Searchable do
     end
   end
 
+  describe '#measure_search' do
+    let(:search_engine) { nil }
+    let(:relation) { User.all.paginate(page: 1, per_page: 100) }
+
+    it 'gathers stats for the relation' do
+      controller.measure_search(relation)
+      expect(controller.search_stats.count).to eq(User.count)
+    end
+
+    it 'returns the relation' do
+      expect(controller.measure_search(relation)).to eq(relation)
+    end
+  end
+
   describe '#legacy_search?' do
     subject { controller.legacy_search? }
 

--- a/spec/helpers/admin/search_helper_spec.rb
+++ b/spec/helpers/admin/search_helper_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+RSpec.describe Admin::SearchHelper do
+  describe '#search_duration' do
+    subject { helper.search_duration(seconds) }
+
+    context 'given a fraction of a second' do
+      let(:seconds) { 0.0312 }
+      it { is_expected.to eq('31.2ms') }
+    end
+
+    context 'given several seconds' do
+      let(:seconds) { 2.5 }
+      it { is_expected.to eq('2,500.0ms') }
+    end
+  end
+
+  describe '#explain_search?' do
+    subject { helper.explain_search? }
+
+    before { allow(helper).to receive(:params).and_return(explain: explain) }
+
+    context 'when the explain param is on' do
+      let(:explain) { '1' }
+      it { is_expected.to be(true) }
+    end
+
+    context 'when the explain param is off' do
+      let(:explain) { '0' }
+      it { is_expected.to be(false) }
+    end
+  end
+
+  describe '#explain_search_url' do
+    subject { helper.explain_search_url(explain) }
+
+    before do
+      controller.request.path_parameters =
+        { controller: 'admin_user', action: 'index' }
+      controller.request.query_parameters[:query] = 'bob'
+    end
+
+    context 'switching the query plan on' do
+      let(:explain) { true }
+      it { is_expected.to eq('/admin/users?explain=1&query=bob') }
+    end
+
+    context 'switching the query plan off' do
+      let(:explain) { false }
+      it { is_expected.to eq('/admin/users?explain=0&query=bob') }
+    end
+  end
+end

--- a/spec/models/search/stats_spec.rb
+++ b/spec/models/search/stats_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+RSpec.describe Search::Stats do
+  let(:relation) do
+    User.where(name: 'Alice Smith').paginate(page: 1, per_page: 1)
+  end
+
+  let!(:user) { FactoryBot.create(:user, name: 'Alice Smith') }
+
+  describe '.measure' do
+    subject(:stats) { described_class.measure(relation) }
+
+    it 'loads the relation' do
+      expect(stats.relation).to be_loaded
+    end
+
+    it 'counts every match rather than the current page' do
+      FactoryBot.create(:user, name: 'Alice Smith')
+      expect(stats.count).to eq(2)
+    end
+  end
+
+  describe '#explain' do
+    subject { described_class.measure(relation).explain }
+
+    it { is_expected.to include('Execution Time') }
+
+    it 'reports a plan when the query cache is on' do
+      User.cache { is_expected.to include('Execution Time') }
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

https://github.com/mysociety/alaveteli/issues/9304

## What does this do?

Add PG search admin stats allow us to measure and explain PG queries from the Alaveteli admin where we've introduced the new search.

<hr>

[skip changelog]