### PR TITLE
Exclude `foi_no` bodies from batch

### DIFF
--- a/app/models/public_body.rb
+++ b/app/models/public_body.rb
@@ -58,7 +58,7 @@ class PublicBody < ApplicationRecord
   # batch authority search results or batch category UI
   cattr_accessor :batch_excluded_tags,
                  instance_accessor: false,
-                 default: %w[not_apply defunct]
+                 default: %w[defunct foi_no not_apply]
 
   has_many :info_requests,
            -> { order(created_at: :desc) },

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Exclude `foi_no` bodies from Batch (Gareth Rees)
 * Allow admins to download zips of batch requests, and only show batch download
   links to users who can use them (Ben Fairless)
 * Allow admins to hide a request without notifying the user (Laurent Savaete)


### PR DESCRIPTION
These authorities are listed because we think they ought to be subject to FOI, which is a reasonable campaigning stance.

We limit the use of batch to certain groups of authorities for various reasons.

We already exclude `not_apply`, and so it feels reasonable to exclude `foi_no`. Requests to these authorities should have a higher quality bar so excluding them from batch prevents any unintentionally misdirected requests.

