### PR TITLE
Drop random rotation on pro marketing highlight

### DIFF
--- a/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
+++ b/app/assets/stylesheets/responsive/alaveteli_pro/_pro_marketing.scss
@@ -132,7 +132,7 @@
       bottom: 0;
       left: 0;
       background-color: #faf785;
-      transform: rotate(random(2) - 2 + deg);
+      transform: rotate(-1deg);
       z-index: -1;
   }
 }


### PR DESCRIPTION
The rotation is worked out when assets are precompiled. Each build picks -1deg or 0deg, so the asset digest hash changes and the user's browser cache gets thrown away.

<hr>

[skip changelog]
