### PR TITLE
[#9462] Fix emails sent in the wrong locale

### DIFF
--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -1,3 +1,14 @@
+##
+# Routes inbound email to the mailbox that handles it.
+#
 class ApplicationMailbox < ActionMailbox::Base
+  around_processing :use_default_locale
+
   routing all: :request
+
+  private
+
+  def use_default_locale(&block)
+    AlaveteliLocalization.with_default_locale(&block)
+  end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -26,30 +26,27 @@ class ApplicationMailer < ActionMailer::Base
 
   # The subject: arg must be a proc, it is localized with the user's locale.
   def mail_user(user, subject:, **opts)
-    if user.is_a?(User)
-      locale = user.locale
-      opts[:to] = user.name_and_email
-    else
-      opts[:to] = user
+    locale = user.is_a?(User) ? user.locale : AlaveteliLocalization.locale
+
+    AlaveteliLocalization.with_locale(locale) do
+      opts[:to] = user.is_a?(User) ? user.name_and_email : user
+
+      if opts[:from].is_a?(User)
+        set_reply_to_headers('Reply-To' => opts[:from].name_and_email)
+        opts[:from] = MailHandler.address_from_name_and_email(
+          opts[:from].name, blackhole_email
+        )
+      else
+        set_reply_to_headers
+        opts[:from] ||= blackhole_email
+      end
+
+      set_auto_generated_headers
+
+      default_opts = { subject: subject.call }
+      default_opts.merge!(opts)
+      mail(default_opts)
     end
-
-    if opts[:from].is_a?(User)
-      set_reply_to_headers('Reply-To' => opts[:from].name_and_email)
-      opts[:from] = MailHandler.address_from_name_and_email(
-        opts[:from].name, blackhole_email
-      )
-    else
-      set_reply_to_headers
-      opts[:from] ||= blackhole_email
-    end
-
-    set_auto_generated_headers
-
-    default_opts = {
-      subject: AlaveteliLocalization.with_locale(locale) { subject.call }
-    }
-    default_opts.merge!(opts)
-    mail(default_opts)
   end
 
   def contact_for_user(user = nil)

--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -106,11 +106,7 @@ class TrackMailer < ApplicationMailer
 
       # If we have anything to send, then send everything for the user in one mail
       if !email_about_things.empty?
-        # Send the email
-
-        AlaveteliLocalization.with_locale(user.locale) do
-          TrackMailer.event_digest(user, email_about_things).deliver_now
-        end
+        TrackMailer.event_digest(user, email_about_things).deliver_now
       end
 
       # Record that we've now sent those alerts to that user

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -10,10 +10,11 @@ class UserMailer < ApplicationMailer
     @name = user.name
     @url = url
 
-    subject = reasons[:email_subject] || _(
-      'Confirm your account on {{site_name}}', site_name: site_name
-    )
-    mail_user(user, subject: -> { subject })
+    mail_user(user, subject: -> {
+      reasons[:email_subject] || _(
+        'Confirm your account on {{site_name}}', site_name: site_name
+      )
+    })
   end
 
   def already_registered(user, reasons, url)
@@ -21,10 +22,11 @@ class UserMailer < ApplicationMailer
     @name = user.name
     @url = url
 
-    subject = reasons[:email_subject] || _(
-      'Your account on {{site_name}}', site_name: site_name
-    )
-    mail_user(user, subject: -> { subject })
+    mail_user(user, subject: -> {
+      reasons[:email_subject] || _(
+        'Your account on {{site_name}}', site_name: site_name
+      )
+    })
   end
 
   def changeemail_confirm(user, new_email, url)
@@ -34,12 +36,10 @@ class UserMailer < ApplicationMailer
     @new_email = new_email
 
     # Cannot send the user to mail_user - that would send to old_email.
-    # No problem if the current locale is the user's.
-    subject = _(
-      "Confirm your new email address on {{site_name}}",
-      site_name: site_name
-    )
-    mail_user(user, subject: -> { subject })
+    mail_user(user, subject: -> {
+      _("Confirm your new email address on {{site_name}}",
+        site_name: site_name)
+    })
   end
 
   def changeemail_already_used(old_email, new_email)
@@ -48,11 +48,9 @@ class UserMailer < ApplicationMailer
     user = User.find_by_email(@old_email)
 
     # Cannot send the user to mail_user - that would send to old_email.
-    # No problem if the current locale is the user's.
-    subject = _(
-      "Unable to change email address on {{site_name}}",
-      site_name: site_name
-    )
-    mail_user(new_email, subject: -> { subject })
+    mail_user(new_email, subject: -> {
+      _("Unable to change email address on {{site_name}}",
+        site_name: site_name)
+    })
   end
 end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Highlighted Features
 
+* Fix user emails sent in the wrong locale (Graeme Porteous)
 * Exclude `foi_no` bodies from Batch (Gareth Rees)
 * Allow admins to download zips of batch requests, and only show batch download
   links to users who can use them (Ben Fairless)

--- a/spec/mailboxes/request_mailbox_spec.rb
+++ b/spec/mailboxes/request_mailbox_spec.rb
@@ -426,5 +426,23 @@ RSpec.describe RequestMailbox do
       expect(raw_email[:message_id]).to be_present
       expect(raw_email[:message_checksum]).to be_present
     end
+
+    it 'records the holding pen reason in the default locale' do
+      mail = get_fixture_mail('incoming-request-plain.eml',
+                              to: 'unknown@localhost',
+                              from: 'geraldinequango@localhost')
+
+      AlaveteliLocalization.with_locale('es') do
+        ActionMailbox::InboundEmail.create_and_extract_message_id!(
+          mail.raw_source
+        )
+      end
+
+      perform_enqueued_jobs
+
+      last_event = InfoRequest.holding_pen_request.info_request_events.last
+      expect(last_event.params[:rejected_reason]).
+        to eq('Could not identify the request from the email address')
+    end
   end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,6 +1,41 @@
 require 'spec_helper'
 
 RSpec.describe ApplicationMailer do
+  describe '#mail_user' do
+    let(:info_request) { FactoryBot.create(:info_request, user: user) }
+
+    let!(:incoming_message) do
+      FactoryBot.create(:incoming_message, info_request: info_request)
+    end
+
+    def deliver
+      RequestMailer.new_response(info_request, incoming_message).deliver_now
+      ActionMailer::Base.deliveries.last
+    end
+
+    context 'when the recipient does not use the default locale' do
+      let(:user) { FactoryBot.create(:user, locale: 'es') }
+
+      it 'renders the subject and body in the recipient locale' do
+        mail = deliver
+        expect(mail.subject).to start_with('Nueva respuesta')
+        expect(mail.body).
+          to include('Para ver la respuesta, usa el siguiente enlace.')
+      end
+    end
+
+    context 'when another locale is in use as the mail is sent' do
+      let(:user) { FactoryBot.create(:user, locale: 'en') }
+
+      it 'ignores it and uses the recipient locale' do
+        mail = AlaveteliLocalization.with_locale('es') { deliver }
+        expect(mail.subject).to start_with('New response')
+        expect(mail.body).
+          to include('To view the response, click on the link below.')
+      end
+    end
+  end
+
   context 'when using plugins' do
     def set_base_views
       ApplicationMailer.class_eval do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe UserMailer do
+  describe '#confirm_login' do
+    let(:user) { FactoryBot.create(:user, locale: 'es') }
+
+    it 'renders the subject in the recipient locale' do
+      mail = described_class.
+        confirm_login(user, { email: '' }, 'http://localhost/c/abc')
+
+      expect(mail.subject).to eq('Confirma tu cuenta en Alaveteli')
+    end
+  end
+end


### PR DESCRIPTION
## Relevant issue(s)

Fixes #9462

## What does this do?

Fix emails sent in the wrong locale

## Why was this needed?

The mail_user helper only wrapped the subject line in a locale block, so the body rendered in whatever locale the sending process held. Wrap the whole of mail_user.

UserMailer built its subjects before calling it, which could use the wrong locale, so defer those into the proc the way the other mailers already do.

