### PR TITLE
Allows adding extra content below sign-in form

### DIFF
--- a/app/views/user/sign.html.erb
+++ b/app/views/user/sign.html.erb
@@ -60,6 +60,7 @@
         <h2><%= _('Sign in') %></h2>
         <%= render :partial => 'signin', :locals => { :sign_in_as_existing_user => false } %>
       </div>
+       <%= render partial: 'sign_right_half_extra_content' %>
     </div>
 
     <div style="clear:both"></div>


### PR DESCRIPTION
## Relevant issue(s)
Related to this PR: https://github.com/mysociety/whatdotheyknow-theme/pull/2135

## What does this do?
Allows themes to include extra content below the sign-in bar in the `sign_in` page

## Why was this needed?

## Implementation notes

## Screenshots
<img width="346" height="314" alt="Screenshot 2026-08-26 at 09 41 15" src="https://github.com/user-attachments/assets/71cf2233-fe0c-4267-8d36-562f8a6ad86b" />

## Notes to reviewer

<hr>

[skip changelog]
