### PR TITLE
[#9499] Fix erased files not being deleted from storage

### DIFF
--- a/config/initializers/active_job.rb
+++ b/config/initializers/active_job.rb
@@ -1,0 +1,6 @@
+ActiveSupport.on_load(:active_job) do
+  # Rails 8.2 default, adopted early. Enqueuing during a transaction races
+  # Sidekiq, which picks the job up on another connection and can't see
+  # anything the transaction hasn't committed.
+  self.enqueue_after_transaction_commit = true
+end

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Enqueue jobs once their transaction has committed, adopting the Rails 8.2
+  default early (Graeme Porteous)
 * Exclude `foi_no` bodies from Batch (Gareth Rees)
 * Allow admins to download zips of batch requests, and only show batch download
   links to users who can use them (Ben Fairless)

--- a/spec/models/foi_attachment_spec.rb
+++ b/spec/models/foi_attachment_spec.rb
@@ -2065,6 +2065,42 @@ RSpec.describe FoiAttachment do
       expect(foi_attachment.reload.file).not_to be_attached
     end
 
+    it 'deletes the file from storage' do
+      blob = foi_attachment.file.blob
+
+      perform_enqueued_jobs { subject }
+
+      expect(blob.service.exist?(blob.key)).to eq(false)
+    end
+
+    context 'when the purge runs in another process' do
+      self.use_transactional_tests = false
+
+      after do
+        [info_request, info_request.user, info_request.public_body,
+         editor].each(&:destroy)
+      end
+
+      it 'deletes the file from storage' do
+        blob = foi_attachment.file.blob
+
+        # Purge from another connection part way through the erase, once the
+        # file has been detached but before anything has been saved
+        allow(foi_attachment).to receive(:expire) do
+          Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              perform_enqueued_jobs(only: ActiveStorage::PurgeJob)
+            end
+          end.join
+        end
+
+        subject
+        perform_enqueued_jobs(only: ActiveStorage::PurgeJob)
+
+        expect(blob.service.exist?(blob.key)).to eq(false)
+      end
+    end
+
     it 'touches erased_at' do
       expect { subject }.to change(foi_attachment, :erased_at).from(nil)
       expect(foi_attachment.erased_at).to be_a(Time)
@@ -2156,6 +2192,14 @@ RSpec.describe FoiAttachment do
       it 'does not erase the file' do
         subject
         expect(foi_attachment.reload).not_to be_erased
+      end
+
+      it 'does not delete the file from storage' do
+        blob = foi_attachment.file.blob
+
+        perform_enqueued_jobs { subject }
+
+        expect(blob.service.exist?(blob.key)).to eq(true)
       end
 
       it { is_expected.to eq(false) }

--- a/spec/models/raw_email_spec.rb
+++ b/spec/models/raw_email_spec.rb
@@ -397,6 +397,42 @@ RSpec.describe RawEmail do
       expect(raw_email.reload.file).not_to be_attached
     end
 
+    it 'deletes the file from storage' do
+      blob = raw_email.file.blob
+
+      perform_enqueued_jobs { subject }
+
+      expect(blob.service.exist?(blob.key)).to eq(false)
+    end
+
+    context 'when the purge runs in another process' do
+      self.use_transactional_tests = false
+
+      after do
+        [raw_email.info_request, raw_email.info_request.user,
+         raw_email.info_request.public_body].each(&:destroy)
+      end
+
+      it 'deletes the file from storage' do
+        blob = raw_email.file.blob
+
+        # Purge from another connection part way through the erase, once the
+        # file has been detached but before anything has been saved
+        allow(raw_email).to receive(:expire) do
+          Thread.new do
+            ActiveRecord::Base.connection_pool.with_connection do
+              perform_enqueued_jobs(only: ActiveStorage::PurgeJob)
+            end
+          end.join
+        end
+
+        subject
+        perform_enqueued_jobs(only: ActiveStorage::PurgeJob)
+
+        expect(blob.service.exist?(blob.key)).to eq(false)
+      end
+    end
+
     it 'touches erased_at' do
       expect { subject }.to change(raw_email, :erased_at).from(nil)
       expect(raw_email.erased_at).to be_a(Time)
@@ -519,6 +555,14 @@ RSpec.describe RawEmail do
       it 'does not erase the file' do
         subject
         expect(raw_email.reload).not_to be_erased
+      end
+
+      it 'does not delete the file from storage' do
+        blob = raw_email.file.blob
+
+        perform_enqueued_jobs { subject }
+
+        expect(blob.service.exist?(blob.key)).to eq(true)
       end
 
       it { is_expected.to eq(false) }


### PR DESCRIPTION
## Relevant issue(s)

Fixes #9499

## What does this do?

Fix erased files not being deleted from storage

## Why was this needed?

Erasing a RawEmail or a FoiAttachment purges the file inside its own transaction, so the job reaches Sidekiq before the attachment row is committed. Sidekiq runs it on another connection, still sees the blob as attached, and `ActiveStorage::Blob#purge` swallows the resulting InvalidForeignKey. Nothing is deleted, and nothing is logged.

Enqueue every job once its transaction has committed, which is the Rails 8.2 default. Other jobs are queued mid transaction too, such as `FoiAttachment::MaskJob` from before_save, so set it app-wide rather than on the purge job alone.

