### PR TITLE
Drop support for Bullseye and Focal

### DIFF
--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -87,6 +87,7 @@
 * Improve raw email testing fixtures (Graeme Porteous)
 * Add support for Debian 13 "Trixie" (Graeme Porteous)
 * Add support for Ubuntu 24.04 LTS "Nobel Numbat" (Graeme Porteous)
+* Drop support for Debian 11 "Bullseye" (Graeme Porteous)
 * Add new script to reconcile theme (Graeme Porteous)
 * Dropped support for generating PDF of request correspondence (Graeme Porteous)
 * Drop support for Ruby 3.3 (Graeme Porteous)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -88,6 +88,7 @@
 * Add support for Debian 13 "Trixie" (Graeme Porteous)
 * Add support for Ubuntu 24.04 LTS "Nobel Numbat" (Graeme Porteous)
 * Drop support for Debian 11 "Bullseye" (Graeme Porteous)
+* Drop support for Ubuntu 20.04 LTS "Focal Fossa" (Graeme Porteous)
 * Add new script to reconcile theme (Graeme Porteous)
 * Dropped support for generating PDF of request correspondence (Graeme Porteous)
 * Drop support for Ruby 3.3 (Graeme Porteous)


### PR DESCRIPTION
Add changelog entries to show we now don't support these OSs