### PR TITLE
Make OutgoingMessage searchable

### DIFF
--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -257,7 +257,7 @@ module Searchable
     # Reindex all instances of a model.
     # This would normally not be run beyond the initial indexing of a
     # pre-existing database.
-    def reindex_all(batch_size: 1000)
+    def reindex_all(start_id: nil, batch_count: nil)
       options = search_options
       return if options.nil?
 
@@ -272,7 +272,13 @@ module Searchable
 
       start = Time.zone.now
       count = 0
-      indexable.find_each(batch_size: batch_size) do |record|
+      if start_id.nil?
+        items_to_index = indexable
+      else
+        items_to_index = indexable.where(id: start_id..(start_id + batch_count))
+      end
+      items_to_index.find_each() do |record|
+        puts(record.id)
         record.reindex
         count += 1
       end

--- a/app/models/outgoing_message.rb
+++ b/app/models/outgoing_message.rb
@@ -29,6 +29,7 @@ class OutgoingMessage < ApplicationRecord
   include Rails.application.routes.url_helpers
   include LinkToHelper
   include Taggable
+  include Searchable
 
   include OutgoingMessage::DeliveryStatus
 
@@ -82,6 +83,17 @@ class OutgoingMessage < ApplicationRecord
 
   scope :followup, -> { where(message_type: 'followup') }
   scope :is_searchable, -> { where(prominence: 'normal') }
+
+  searchable(
+    index: {
+      ".get_text_for_indexing": "A",
+      ".safe_from_name": "D"
+    },
+    admin_index: {
+      from_name: "B",
+      prominence_reason: "D",
+    }
+  )
 
   def self.default_salutation(public_body)
     _("Dear {{public_body_name}},", public_body_name: public_body.name)


### PR DESCRIPTION
## Relevant issue(s)

#8814 

## What does this do?

- makes `OutgoingMessage` searchable, so that we can start indexing for testing on actual data/use cases
- adds a generic content diffing method for `searchable`s (which will be reused by other models)
- adds a `start` argument to `reindex_all` to allow running indexing in batches

## Why was this needed?

## Implementation notes

See notes in #9474 about indexing performance. There is still room for improvement in `applicable_censor_rules` but it's left out of this PR.

There is no code yet to search through outgoing messages from the UI, this will be addressed separately while indexing is happening.

## Screenshots

## Notes to reviewer

Skipping changelog as per other search related PRs, just too many small changes :)

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
