### PR TITLE
Speed up applicable_censor_rules

### DIFF
--- a/app/models/info_request.rb
+++ b/app/models/info_request.rb
@@ -1283,10 +1283,34 @@ class InfoRequest < ApplicationRecord
 
   # Get the list of censor rules that apply to this request
   def applicable_censor_rules
-    applicable_rules = [censor_rules, CensorRule.global]
-    applicable_rules << public_body.censor_rules unless public_body.blank?
-    applicable_rules << user.censor_rules if user
-    applicable_rules.flatten
+    query= <<-SQL
+    SELECT cr.* FROM censor_rules cr
+      WHERE (
+          cr.censorable_type = 'InfoRequest'
+          AND cr.censorable_id = :info_request_id
+        OR cr.censorable_id IS NULL
+          AND cr.censorable_type IS NULL
+        OR cr.censorable_type = 'PublicBody'
+          AND cr.censorable_id = :public_body_id
+        OR cr.censorable_type = 'User'
+          AND cr.censorable_id = :user_id
+      )
+    ORDER BY 
+      (CASE WHEN cr.censorable_type = 'InfoRequest' THEN 0
+         WHEN cr.censorable_type IS NULL THEN 1
+         WHEN cr.censorable_type = 'PublicBody' THEN 2
+         ELSE 3
+       END) ASC,
+      cr.created_at DESC
+    SQL
+    CensorRule.find_by_sql [
+      query,
+      {
+        info_request_id: id,
+        public_body_id: public_body_id,
+        user_id: user_id
+      }
+    ]
   end
 
   def apply_censor_rules_to_text(text)

--- a/doc/CHANGES.md
+++ b/doc/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Highlighted Features
 
+* Speed up determination of applicable censor rules and guarantee order of
+  application (Laurent Savaete)
 * Enqueue jobs once their transaction has committed, adopting the Rails 8.2
   default early (Graeme Porteous)
 * Exclude `foi_no` bodies from Batch (Gareth Rees)
@@ -206,6 +208,10 @@
   it by running:
 
     bin/rails runner "AlaveteliFeatures.backend.enable(:censor_rule_ignore_diacritics)"
+
+* **Note:** Global censor rules are now applied in descending order of creation. Prior to this release,
+  global censor rules were applied in whatever order they were returned by the database. This could lead
+  to unpredictable data leaks. The order of application of other censor rules (non-global) is not modified.
 
 * **Note:** `FACEBOOK_USERNAME` and `TWITTER_USERNAME` configuration values are
   deprecated and will be removed after this release.

--- a/spec/models/info_request_spec.rb
+++ b/spec/models/info_request_spec.rb
@@ -2987,6 +2987,60 @@ RSpec.describe InfoRequest do
     end
   end
 
+  describe '#applicable_censor_rules order' do
+    it 'returns censor rules in the expected order' do
+      global_rule_2 = FactoryBot.create(
+        :global_censor_rule,
+        created_at: '2023-01-03'
+      )
+      global_rule_1 = FactoryBot.create(
+        :global_censor_rule,
+        created_at: '2024-01-15'
+      )
+      req_rule_1 = FactoryBot.create(
+        :info_request_censor_rule,
+        text: '1',
+        created_at: '2024-01-12'
+      )
+      req_rule_2 = FactoryBot.create(
+        :info_request_censor_rule, 
+        text: '2',
+        created_at: '2024-01-11',
+        censorable: req_rule_1.censorable
+      )
+      info_request = req_rule_1.censorable
+      body_rule_2 = FactoryBot.create(
+        :public_body_censor_rule,
+        created_at: '2021-01-10'
+      )
+      body_rule_1 = FactoryBot.create(
+        :public_body_censor_rule,
+        created_at: '2025-01-10',
+        censorable: body_rule_2.censorable
+      )
+      info_request.public_body = body_rule_1.censorable
+      user_rule_1 = FactoryBot.create(
+        :user_censor_rule,
+        created_at: '2026-12-31'
+      )
+      user_rule_2 = FactoryBot.create(
+        :user_censor_rule,
+        created_at: '2023-12-31',
+        censorable: user_rule_1.censorable
+      )
+      info_request.user = user_rule_1.censorable
+
+      expected = [
+        req_rule_1.id, req_rule_2.id,
+        global_rule_1.id, global_rule_2.id,
+        body_rule_1.id, body_rule_2.id,
+        user_rule_1.id, user_rule_2.id,
+      ]
+
+      expect(info_request.applicable_censor_rules.map(&:id)).to eq(expected)
+    end
+  end
+
   describe '#apply_censor_rules_to_text' do
     it 'applies each censor rule to the text' do
       rule_1 = FactoryBot.build(:censor_rule, text: '1')

--- a/spec/models/outgoing_message_spec.rb
+++ b/spec/models/outgoing_message_spec.rb
@@ -393,7 +393,7 @@ RSpec.describe OutgoingMessage do
 
       rules = [FactoryBot.build(:censor_rule, text: 'secret'),
                FactoryBot.build(:censor_rule, text: 'sensitive')]
-      allow_any_instance_of(InfoRequest).to receive(:censor_rules).and_return(rules)
+      allow_any_instance_of(InfoRequest).to receive(:applicable_censor_rules).and_return(rules)
 
       expected = 'This [REDACTED] text contains [REDACTED] info!'
       expect(message.body).to eq(expected)


### PR DESCRIPTION
## Relevant issue(s)

#9334 
#9347 (the breaking change here might interact with that PR)

## What does this do?

This PR replaces the existing `InfoRequest::applicable_censor_rules` method with a raw sql based one, which is both faster, and also guarantees the order of application of global censor rules.

## Why was this needed?

The change was needed to help speed up reindexing. For `OutgoingMessage`, the call to this method represents multiple hours of fetching cenor rules from the database at the scale of WDTK (about 30% of reindexing time in initial testing).
It will also positively affect `IncomingMessage` and `FoiAttachment` indexing, as they also rely on censor rules.

This will also benefit regular page views, as censor rules are loaded on various occasions.

The legacy method did not guarantee any specific order for global censor rules: postgresql does not guarantee any order unless requested, and rails does not appear to reorder records implicitly. From a quick test, it appears that global censor rules were returned in `updated_at` order, but this is most likely a side effect of how postgres stores data, and creates a risk of data leaks.

This PR introduces a potentially breaking change by forcing an ordering on global censor rules. The order of other rules is unchanged. This will be breaking under specific conditions: multiple global censor rules have overlapping application. For instance `Somename` and `Somename Somelastname` are both replaced by 2 distinct censor rules.

The change is justified because it enables future guarantees of rules applying as expected. The current code does not provide any such guarantees.

## Implementation notes

Below is a simple benchmark to show the benefits:
- first report is to preload info requests to limit caching advantage of the first run.
- `applicable_censor_rules2` is the new method in this comparison.
- doing the same benchmark with the methods swapped yields very similar results.
- the old method does 6 database queries (assuming the `InfoRequest` object is already loaded), while the new one does a single one (see sample logs below)
- the new method is roughly 4x faster in local testing, probably a bit more if running on a server with a db on a separate machine (because of network travel time).

```rb
Benchmark.bm do |x|
  x.report { a.upto(b) { |n| begin; InfoRequest.find(n); rescue; puts (n); end } }
  x.report { a.upto(b) { |n| begin; InfoRequest.find(n).applicable_censor_rules2 ; rescue; puts(n); end } }
  x.report { a.upto(b) { |n| begin; InfoRequest.find(n).applicable_censor_rules; rescue; puts(n); end } }
end
=>
       user     system      total        real
   0.215752   0.012308   0.228060 (  0.354580)
   0.522545   0.070147   0.592692 (  1.100458)
   2.832749   0.411598   3.244347 (  4.387844)
```

Sample database queries log for the old method:
```
 InfoRequest Load (0.1ms)  SELECT "info_requests".* FROM "info_requests" WHERE "info_requests"."id" = 4000 LIMIT 1 /*application='Alaveteli'*/
  PublicBody Load (0.1ms)  SELECT "public_bodies".* FROM "public_bodies" WHERE "public_bodies"."id" = 101110 LIMIT 1 /*application='Alaveteli'*/
  User Load (0.1ms)  SELECT "users".* FROM "users" WHERE "users"."id" = 686 LIMIT 1 /*application='Alaveteli'*/
  CensorRule Load (0.2ms)  SELECT "censor_rules".* FROM "censor_rules" WHERE "censor_rules"."censorable_id" = 4000 AND "censor_rules"."censorable_type" = 'InfoRequest' ORDER BY "censor_rules"."created_at" DESC /*application='Alaveteli'*/
  CensorRule Load (0.3ms)  SELECT "censor_rules".* FROM "censor_rules" WHERE "censor_rules"."censorable_id" IS NULL AND "censor_rules"."censorable_type" IS NULL /*application='Alaveteli'*/
  CensorRule Load (0.3ms)  SELECT "censor_rules".* FROM "censor_rules" WHERE "censor_rules"."censorable_id" = 101110 AND "censor_rules"."censorable_type" = 'PublicBody' ORDER BY "censor_rules"."created_at" DESC /*application='Alaveteli'*/
  CensorRule Load (0.3ms)  SELECT "censor_rules".* FROM "censor_rules" WHERE "censor_rules"."censorable_id" = 686 AND "censor_rules"."censorable_type" = 'User' ORDER BY "censor_rules"."created_at" DESC /*application='Alaveteli'*/
```
and the new one:
```
  InfoRequest Load (0.1ms)  SELECT "info_requests".* FROM "info_requests" WHERE "info_requests"."id" = 4000 LIMIT 1 /*application='Alaveteli'*/
  CensorRule Load (0.2ms)          SELECT censor_rules.*, 1 as row_ord
        FROM censor_rules
        WHERE censor_rules.censorable_id = 4000
          AND censor_rules.censorable_type = 'InfoRequest'
      UNION ALL
        SELECT censor_rules.*, 2 as row_ord
        FROM censor_rules
        WHERE censor_rules.censorable_id IS NULL
          AND censor_rules.censorable_type IS NULL
      UNION ALL
        SELECT censor_rules.*, 3 as row_ord
        FROM censor_rules
        WHERE censor_rules.censorable_id = 101110
          AND censor_rules.censorable_type = 'PublicBody'
      UNION ALL
        SELECT censor_rules.*, 4 as row_ord
        FROM censor_rules
        WHERE censor_rules.censorable_id = 686
          AND censor_rules.censorable_type = 'User'
      ORDER BY row_ord ASC, created_at DESC
 /*application='Alaveteli'*/
```

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: skip changelog
