### PR TITLE
Improve new search performance again

### DIFF
--- a/app/controllers/admin_outgoing_message_controller.rb
+++ b/app/controllers/admin_outgoing_message_controller.rb
@@ -13,7 +13,6 @@ class AdminOutgoingMessageController < AdminController
 
     @outgoing_messages = measure_search(
       outgoing_message_scope.
-        order(created_at: :desc).
         paginate(page: params[:page], per_page: 100)
     )
   end

--- a/app/controllers/admin_request_controller.rb
+++ b/app/controllers/admin_request_controller.rb
@@ -12,7 +12,8 @@ class AdminRequestController < AdminController
     show edit update destroy move generate_upload_url hide
   ]
 
-  sortable default: :updated_at_desc, only: [:index]
+  sortable default: :updated_at_desc, relevance: :indexed_search?,
+           only: [:index]
 
   def index
     @query = params[:query]
@@ -25,10 +26,9 @@ class AdminRequestController < AdminController
     end
 
     @info_requests = measure_search(
-      info_requests.
-      includes(:embargo, :user, public_body: :translations).
-      order(sort_query).
-      paginate(page: params[:page], per_page: 100)
+      sorted(
+        info_requests.includes(:embargo, :user, public_body: :translations)
+      ).paginate(page: params[:page], per_page: 100)
     )
   end
 

--- a/app/controllers/admin_user_controller.rb
+++ b/app/controllers/admin_user_controller.rb
@@ -21,7 +21,7 @@ class AdminUserController < AdminController
                 :check_role_authorisation,
                 :check_role_requirements, only: %i[update]
 
-  sortable :name, :created_at, :updated_at,
+  sortable :name, :created_at, :updated_at, relevance: :indexed_search?,
            only: [:index, :active, :banned, :closed]
 
   sortable default: :updated_at_desc, only: [:show]
@@ -43,7 +43,7 @@ class AdminUserController < AdminController
     end
 
     @admin_users = measure_search(
-      users.order(sort_query).
+      sorted(users).
         paginate(page: params[:page], per_page: 100)
     )
 

--- a/app/controllers/concerns/admin/searchable.rb
+++ b/app/controllers/concerns/admin/searchable.rb
@@ -29,6 +29,11 @@ module Admin::Searchable
     search_engine == 'legacy'
   end
 
+  # Whether this listing is running a search that ranks what it finds.
+  def indexed_search?
+    params[:query].present? && !legacy_search?
+  end
+
   # Run +relation+, timing it so the listing can show what the search cost.
   # Returns the relation, now loaded.
   def measure_search(relation)

--- a/app/controllers/concerns/admin/sortable.rb
+++ b/app/controllers/concerns/admin/sortable.rb
@@ -20,11 +20,12 @@ module Admin::Sortable
   class_methods do
     DEFAULT_SORTABLE_ATTRS = [:created_at, :updated_at]
 
-    def sortable(*attrs, default: nil, only: nil, except: nil)
+    def sortable(*attrs, default: nil, only: nil, except: nil,
+                 relevance: nil)
       attrs = attrs.any? ? attrs : DEFAULT_SORTABLE_ATTRS
 
       before_action only: only, except: except do
-        configure_sort_options(attrs)
+        configure_sort_options(attrs, relevance: relevance)
         configure_sort_order(default: default.to_s)
       end
     end
@@ -42,13 +43,22 @@ module Admin::Sortable
     @sort_options[@sort_order]
   end
 
+  def sorted(relation)
+    sort_query ? relation.reorder(sort_query) : relation
+  end
+
   private
 
-  def configure_sort_options(attrs)
-    @sort_options = attrs.each_with_object({}) do |attr, h|
+  def configure_sort_options(attrs, relevance: nil)
+    options = attrs.each_with_object({}) do |attr, h|
       h["#{attr}_asc"]  = "#{attr} ASC"
       h["#{attr}_desc"] = "#{attr} DESC"
-    end.with_indifferent_access
+    end
+
+    offer_relevance = relevance && send(relevance)
+    options = { 'relevance': nil }.merge(options) if offer_relevance
+
+    @sort_options = options.with_indifferent_access
   end
 
   def configure_sort_order(default: nil)

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -205,29 +205,32 @@ class SearchDocument < ApplicationRecord
       SearchDocument.where("sd_id IN (SELECT s.sd_id FROM (#{sql[:query]}) s)",
 sql[:values])
     else
-      # De-duplicate records that match through several translations or
-      # sections (the join yields one row per matching search_document),
-      # keeping the relation chainable, countable and paginatable.
+      # A record can match through several translations or sections, so
+      # group the documents to one row per record, scored by the best of
+      # them. The relation stays chainable, countable and paginatable.
       #
       # Join the ids rather than matching them with IN. A semi-join lets
       # PostgreSQL scan the whole table and re-run the search for every
       # row it looks at.
       matching_ids = SearchDocument.
-        select(:searchable_id).
+        select(:searchable_id, "max(search_results.score) AS score").
         where(searchable_type: model.to_s).
         joins(
           "JOIN search_results " \
           "ON search_results.sd_id = search_documents.sd_id"
         ).
-        distinct
+        group(:searchable_id)
+
+      record_id = "#{relation.quoted_table_name}." \
+                  "#{relation.quoted_primary_key}"
 
       relation.
         with(search_results: Arel.sql(sql[:query], **sql[:values])).
         joins(
           "JOIN (#{matching_ids.to_sql}) search_matches " \
-          "ON search_matches.searchable_id = " \
-          "#{relation.quoted_table_name}.#{relation.quoted_primary_key}"
-        )
+          "ON search_matches.searchable_id = #{record_id}"
+        ).
+        order(Arel.sql("search_matches.score DESC, #{record_id}"))
     end
   end
 end

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -206,21 +206,28 @@ class SearchDocument < ApplicationRecord
 sql[:values])
     else
       # De-duplicate records that match through several translations or
-      # sections (the join yields one row per matching search_document).
-      # Matching on the ids keeps the relation chainable, countable and
-      # paginatable, and leaves PostgreSQL free to fetch just the rows
-      # that matched.
+      # sections (the join yields one row per matching search_document),
+      # keeping the relation chainable, countable and paginatable.
+      #
+      # Join the ids rather than matching them with IN. A semi-join lets
+      # PostgreSQL scan the whole table and re-run the search for every
+      # row it looks at.
       matching_ids = SearchDocument.
         select(:searchable_id).
         where(searchable_type: model.to_s).
         joins(
           "JOIN search_results " \
           "ON search_results.sd_id = search_documents.sd_id"
-        )
+        ).
+        distinct
 
       relation.
         with(search_results: Arel.sql(sql[:query], **sql[:values])).
-        where(id: matching_ids)
+        joins(
+          "JOIN (#{matching_ids.to_sql}) search_matches " \
+          "ON search_matches.searchable_id = " \
+          "#{relation.quoted_table_name}.#{relation.quoted_primary_key}"
+        )
     end
   end
 end

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -75,6 +75,8 @@ class SearchDocument < ApplicationRecord
       search_queries << <<~SQL.chomp
           SELECT
               sd_id,
+              searchable_type,
+              searchable_id,
               rank() OVER (
                 ORDER BY ts_rank_cd(admin_content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
               ) AS rank
@@ -101,6 +103,8 @@ class SearchDocument < ApplicationRecord
       search_queries << <<~SQL.chomp
         SELECT
           sd_id,
+          searchable_type,
+          searchable_id,
           rank() OVER (ORDER BY sd_id DESC) AS rank
         FROM search_documents
         WHERE
@@ -115,6 +119,8 @@ class SearchDocument < ApplicationRecord
     search_queries << <<~SQL.chomp
         SELECT
             sd_id,
+            searchable_type,
+            searchable_id,
             rank() OVER (
               ORDER BY ts_rank_cd(content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
             ) AS rank
@@ -130,10 +136,12 @@ class SearchDocument < ApplicationRecord
     sql = <<~SQL.chomp.squeeze(' ')
       SELECT
         searches.sd_id,
+        searches.searchable_type,
+        searches.searchable_id,
         sum(searches.rank) AS rank_sum,
         sum(rrf_score(searches.rank)) AS score
       FROM ((#{search_queries.join(") UNION ALL (")})) searches
-      GROUP BY searches.sd_id
+      GROUP BY searches.sd_id, searches.searchable_type, searches.searchable_id
       ORDER BY score DESC
       LIMIT #{limit}
     SQL
@@ -205,39 +213,38 @@ class SearchDocument < ApplicationRecord
       SearchDocument.where("sd_id IN (SELECT s.sd_id FROM (#{sql[:query]}) s)",
 sql[:values])
     else
-      # A record can match through several translations or sections, so
-      # group the documents to one row per record, scored by the best of
-      # them. The relation stays chainable, countable and paginatable.
-      #
-      # Join the ids rather than matching them with IN. A semi-join lets
-      # PostgreSQL scan the whole table and re-run the search for every
-      # row it looks at.
-      matching_ids = SearchDocument.
-        select(:searchable_id, "max(search_results.score) AS score").
-        where(searchable_type: model.to_s).
-        joins(
-          "JOIN search_results " \
-          "ON search_results.sd_id = search_documents.sd_id"
-        ).
-        group(:searchable_id)
-
       record_id = "#{relation.quoted_table_name}." \
                   "#{relation.quoted_primary_key}"
 
-      # Requires: lib/core_ext/active_record_materialized_cte.rb
-      search_results = Arel::Nodes::Cte.new(
-        :search_results,
-        Arel.sql("(#{sql[:query]})", **sql[:values]),
-        materialized: true
+      search_results = materialized_cte(
+        :search_results, sql[:query], sql[:values]
       )
 
+      # A record can match through several translations or sections, so
+      # roll the documents up to one row per record, scored by the best
+      # of them. The relation stays chainable, countable and paginatable.
+      search_records = materialized_cte(:search_records, <<~SQL.squish)
+        SELECT searchable_type, searchable_id, max(score) AS score
+        FROM search_results
+        GROUP BY searchable_type, searchable_id
+      SQL
+
       relation.
-        with(search_results: search_results).
+        with(search_results: search_results, search_records: search_records).
         joins(
-          "JOIN (#{matching_ids.to_sql}) search_matches " \
-          "ON search_matches.searchable_id = #{record_id}"
+          "JOIN search_records " \
+          "ON search_records.searchable_type = '#{model}' " \
+          "AND search_records.searchable_id = #{record_id}"
         ).
-        order(Arel.sql("search_matches.score DESC, #{record_id}"))
+        order(Arel.sql("search_records.score DESC, #{record_id}"))
     end
   end
+
+  # Requires: lib/core_ext/active_record_materialized_cte.rb
+  def self.materialized_cte(name, query, values = {})
+    Arel::Nodes::Cte.new(
+      name, Arel.sql("(#{query})", **values), materialized: true
+    )
+  end
+  private_class_method :materialized_cte
 end

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -224,8 +224,15 @@ sql[:values])
       record_id = "#{relation.quoted_table_name}." \
                   "#{relation.quoted_primary_key}"
 
+      # Requires: lib/core_ext/active_record_materialized_cte.rb
+      search_results = Arel::Nodes::Cte.new(
+        :search_results,
+        Arel.sql("(#{sql[:query]})", **sql[:values]),
+        materialized: true
+      )
+
       relation.
-        with(search_results: Arel.sql(sql[:query], **sql[:values])).
+        with(search_results: search_results).
         joins(
           "JOIN (#{matching_ids.to_sql}) search_matches " \
           "ON search_matches.searchable_id = #{record_id}"

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -148,6 +148,7 @@ class SearchDocument < ApplicationRecord
 
     { query: sql, values: query_values }
   end
+  private_class_method :hybrid_search_internal
 
   # Run the hybrid full-text search and return a chainable relation.
   #

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -209,16 +209,23 @@ class SearchDocument < ApplicationRecord
       limit_ratio: limit_ratio
     )
 
+    search_results = materialized_cte(
+      :search_results, sql[:query], sql[:values]
+    )
+
     if model.nil?
-      SearchDocument.where("sd_id IN (SELECT s.sd_id FROM (#{sql[:query]}) s)",
-sql[:values])
+      # A document is one row per section and language already, so the
+      # search results map to them one for one.
+      SearchDocument.
+        with(search_results: search_results).
+        joins(
+          "JOIN search_results " \
+          "ON search_results.sd_id = search_documents.sd_id"
+        ).
+        order(Arel.sql("search_results.score DESC, search_documents.sd_id"))
     else
       record_id = "#{relation.quoted_table_name}." \
                   "#{relation.quoted_primary_key}"
-
-      search_results = materialized_cte(
-        :search_results, sql[:query], sql[:values]
-      )
 
       # A record can match through several translations or sections, so
       # roll the documents up to one row per record, scored by the best

--- a/app/views/admin_request/index.html.erb
+++ b/app/views/admin_request/index.html.erb
@@ -11,6 +11,7 @@
 <%= form_tag({}, method: 'get', class: 'form form-search') do %>
   <div class="input-append">
     <%= text_field_tag 'query', params[:query], size: 30, class: 'input-large search-query' %>
+    <%= hidden_field_tag 'sort_order', @sort_order %>
     <%= submit_tag 'Search', class: 'btn' %>
   </div>
 

--- a/app/views/concerns/admin/sortable/_sort_options.html.erb
+++ b/app/views/concerns/admin/sortable/_sort_options.html.erb
@@ -2,7 +2,7 @@
   <div class="btn-group sort-options">
     <% sort_options.keys.each do |sort_option| %>
       <%=
-        link_to_unless(sort_order == sort_option, sort_order_humanized(sort_option), url_for(sort_order: sort_option, query: @query), class: 'btn') do
+        link_to_unless(sort_order == sort_option, sort_order_humanized(sort_option), url_for(sort_order: sort_option, query: @query, search_engine: params[:search_engine]), class: 'btn') do
           link_to sort_order_humanized(sort_option), '#', class: 'btn disabled'
         end
        %>

--- a/config/initializers/alaveteli.rb
+++ b/config/initializers/alaveteli.rb
@@ -31,6 +31,7 @@ ActionMailer::Base.default_url_options[:host] = AlaveteliConfiguration.domain
 # Load monkey patches and other things from lib/
 require 'core_ext/warning'
 require 'core_ext/active_storage_ensure_attached'
+require 'core_ext/active_record_materialized_cte'
 
 require 'use_spans_for_errors.rb'
 require 'world_foi_websites.rb'

--- a/lib/core_ext/active_record_materialized_cte.rb
+++ b/lib/core_ext/active_record_materialized_cte.rb
@@ -1,0 +1,22 @@
+##
+# Rails builds every CTE as an Arel::Nodes::TableAlias, which has no way
+# to say MATERIALIZED. Let the value passed to `with` be an
+# Arel::Nodes::Cte instead, which does.
+#
+# Based on https://github.com/rails/rails/pull/54322. Drop this once the
+# Rails PR lands.
+#
+module ActiveRecord::MaterializedCte
+  private
+
+  def build_with_value_from_hash(hash)
+    hash.flat_map do |name, value|
+      next super({ name => value }) unless value.is_a?(Arel::Nodes::Cte)
+
+      Arel::Nodes::Cte.new(name, value.relation,
+                           materialized: value.materialized)
+    end
+  end
+end
+
+ActiveRecord::Relation.prepend(ActiveRecord::MaterializedCte)

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe AdminOutgoingMessageController do
 
     it 'finds outgoing messages matching a query' do
       outgoing.update!(body: 'A Very Distinctive Phrase')
-      outgoing.reindex
       get :index, params: { query: 'distinctive' }
       expect(assigns[:outgoing_messages]).to match_array([outgoing])
     end

--- a/spec/controllers/admin_outgoing_message_controller_spec.rb
+++ b/spec/controllers/admin_outgoing_message_controller_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe AdminOutgoingMessageController do
       expect(assigns[:outgoing_messages]).to match_array([outgoing])
     end
 
+    it "lists the best match first", :postgresql do
+      weak = FactoryBot.create(:initial_request, body: 'Need more data!')
+      strong = FactoryBot.create(:initial_request, body: 'Data Data Data')
+      get :index, params: { query: 'data' }
+      expect(assigns[:outgoing_messages].first).to eq(strong)
+    end
+
     context 'when a request is embargoed' do
       before { info_request.create_embargo }
 

--- a/spec/controllers/admin_public_body_controller_spec.rb
+++ b/spec/controllers/admin_public_body_controller_spec.rb
@@ -40,6 +40,13 @@ RSpec.describe AdminPublicBodyController do
       expect(names).to eq(names.sort_by(&:downcase))
     end
 
+    it "lists the best match first with the new search", :postgresql do
+      weak = FactoryBot.create(:public_body, name: 'Otter Watch')
+      strong = FactoryBot.create(:public_body, name: 'Otter Otter Otter Watch')
+      get :index, params: { query: 'otter', search_engine: 'new' }
+      expect(assigns[:public_bodies].first).to eq(strong)
+    end
+
     it "searches for a request email with the new search", :postgresql do
       get :index, params: { query: "humpadink-requests@localhost",
                             search_engine: "new" }

--- a/spec/controllers/admin_request_controller_spec.rb
+++ b/spec/controllers/admin_request_controller_spec.rb
@@ -130,6 +130,25 @@ RSpec.describe AdminRequestController, "when administering requests" do
         get :index, params: { query: 'cat' }
         expect(assigns[:info_requests]).not_to include(cat_request)
       end
+
+      it 'sorts by the chosen column rather than search relevance' do
+        best_match = FactoryBot.create(:info_request,
+                                       title: 'A cat cat cat request')
+        best_match.update_columns(updated_at: 2.days.ago)
+
+        get :index, params: { query: 'cat', sort_order: 'updated_at_desc' }
+        expect(assigns[:info_requests].first).to eq(cat_request)
+      end
+
+      it 'offers relevance as a sort option' do
+        get :index, params: { query: 'cat' }
+        expect(controller.sort_options.keys.first).to eq('relevance')
+      end
+
+      it 'does not offer relevance without a search' do
+        get :index
+        expect(controller.sort_options.keys).not_to include('relevance')
+      end
     end
   end
 

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -128,6 +128,22 @@ RSpec.describe AdminUserController do
       expect(assigns[:admin_users]).to eq([u2, u1])
     end
 
+    it 'sorts by relevance until another order is chosen' do
+      User.destroy_all
+      alice = FactoryBot.create(:user, name: 'Alice Smith')
+      bob = FactoryBot.create(:user, name: 'Bob Smith Smith Smith')
+      get :index, params: { query: 'smith' }
+      expect(assigns[:admin_users]).to eq([bob, alice])
+    end
+
+    it 'sorts by the chosen column rather than search relevance' do
+      User.destroy_all
+      alice = FactoryBot.create(:user, name: 'Alice Smith')
+      bob = FactoryBot.create(:user, name: 'Bob Smith Smith Smith')
+      get :index, params: { query: 'smith', sort_order: 'name_asc' }
+      expect(assigns[:admin_users]).to eq([alice, bob])
+    end
+
     it 'filters the records by role' do
       User.destroy_all
       admin_user = FactoryBot.create(:admin_user)

--- a/spec/controllers/admin_user_controller_spec.rb
+++ b/spec/controllers/admin_user_controller_spec.rb
@@ -90,21 +90,18 @@ RSpec.describe AdminUserController do
 
     it "assigns users matching a case-insensitive query to the view" do
       user = FactoryBot.create(:user, name: 'Bob Smith')
-      user.reindex
       get :index, params: { query: 'bob' }
       expect(assigns[:admin_users].include?(user)).to be true
     end
 
     it 'strips the string when searching' do
       user = FactoryBot.create(:user, email: 'julie@example.com')
-      user.reindex
       get :index, params: { query: ' julie@example.com ' }
       expect(assigns[:admin_users]).to include(user)
     end
 
     it 'finds users by a partial email fragment' do
       user = FactoryBot.create(:user, email: 'julie@example.com')
-      user.reindex
       get :index, params: { query: '@example.com' }
       expect(assigns[:admin_users]).to include(user)
     end
@@ -113,7 +110,6 @@ RSpec.describe AdminUserController do
       # PostgreSQL tokenises a URL by host, so the about me link is found by
       # its domain rather than an arbitrary substring.
       user = FactoryBot.create(:user, about_me: 'http://example.com')
-      user.reindex
       get :index, params: { query: 'example.com' }
       expect(assigns[:admin_users]).to include(user)
     end
@@ -123,7 +119,6 @@ RSpec.describe AdminUserController do
       u1 = FactoryBot.create(:user, name: 'Alice Smith')
       u2 = FactoryBot.create(:user, name: 'Bob Smith')
       u3 = FactoryBot.create(:user, name: 'John Doe')
-      [u1, u2, u3].each(&:reindex)
       get :index, params: { query: 'smith', sort_order: 'name_desc' }
       expect(assigns[:admin_users]).to eq([u2, u1])
     end

--- a/spec/controllers/concerns/admin/searchable_spec.rb
+++ b/spec/controllers/concerns/admin/searchable_spec.rb
@@ -34,6 +34,35 @@ RSpec.describe Admin::Searchable do
     end
   end
 
+  describe '#indexed_search?' do
+    subject { controller.indexed_search? }
+
+    before do
+      allow(controller).to receive(:params).and_return(
+        ActionController::Parameters.new(search_engine: search_engine,
+                                         query: query)
+      )
+    end
+
+    context 'when the new engine is searching' do
+      let(:search_engine) { nil }
+      let(:query) { 'bob' }
+      it { is_expected.to be(true) }
+    end
+
+    context 'when nothing is being searched for' do
+      let(:search_engine) { nil }
+      let(:query) { '' }
+      it { is_expected.to be(false) }
+    end
+
+    context 'when the legacy engine is searching' do
+      let(:search_engine) { 'legacy' }
+      let(:query) { 'bob' }
+      it { is_expected.to be(false) }
+    end
+  end
+
   describe '#measure_search' do
     let(:search_engine) { nil }
     let(:relation) { User.all.paginate(page: 1, per_page: 100) }

--- a/spec/models/public_body_spec.rb
+++ b/spec/models/public_body_spec.rb
@@ -2122,7 +2122,6 @@ RSpec.describe PublicBody, "when indexing for postgres search" do
             name: "Northern England NHS fictitious center"
           )
         ]
-        bodies.each(&:reindex)
         expect(PublicBody.newsearch("NHS England").first).to eq(nhs)
       end
     end
@@ -2134,7 +2133,6 @@ RSpec.describe PublicBody, "when indexing for postgres search" do
             :public_body,
             name: "Ministère de l'Intérieur"
           )
-          body.reindex
           expect(PublicBody.newsearch(
                    "ministere intérieur",
             language: 'french'
@@ -2153,8 +2151,7 @@ RSpec.describe PublicBody, "when indexing for postgres search" do
       # from https://github.com/mysociety/alaveteli/issues/1179#issuecomment-304157132
       with_default_locale(:en) do
         ag = FactoryBot.create(:public_body,
-name: "WA Department of the Attorney General")
-        ag.reindex
+                               name: "WA Department of the Attorney General")
         expect(PublicBody.newsearch("WA Attorney General")).to match_array([ag])
         expect(PublicBody.newsearch("Attorney General")).to match_array([ag])
       end

--- a/spec/models/search_document_spec.rb
+++ b/spec/models/search_document_spec.rb
@@ -107,6 +107,17 @@ RSpec.describe SearchDocument do
     end
   end
 
+  context 'ordering' do
+    it 'returns the best match first' do
+      weak = FactoryBot.create(:user, name: 'Otter Watcher')
+      strong = FactoryBot.create(:user, name: 'Otter Otter Otter')
+
+      results = User.newsearch('Otter', admin_mode: true)
+
+      expect(results.to_a).to eq([strong, weak])
+    end
+  end
+
   context 'exact mode case sensitivity' do
     # A partial token ("ASE" inside "Charlotte Case") can only match through
     # exact mode's substring search, never through the tsvector matching.

--- a/spec/models/search_document_spec.rb
+++ b/spec/models/search_document_spec.rb
@@ -107,6 +107,15 @@ RSpec.describe SearchDocument do
     end
   end
 
+  context 'materialized CTE' do
+    it 'fences the search off so PostgreSQL runs it once' do
+      results = SearchDocument.hybrid_search('Florence', model: User,
+                                                         admin_mode: true)
+
+      expect(results.to_sql).to include('WITH "search_results" AS MATERIALIZED')
+    end
+  end
+
   context 'ordering' do
     it 'returns the best match first' do
       weak = FactoryBot.create(:user, name: 'Otter Watcher')

--- a/spec/models/search_document_spec.rb
+++ b/spec/models/search_document_spec.rb
@@ -127,6 +127,17 @@ RSpec.describe SearchDocument do
     end
   end
 
+  context 'searching every model at once' do
+    it 'returns the documents best match first' do
+      FactoryBot.create(:user, name: 'Ferret Watcher')
+      strong = FactoryBot.create(:user, name: 'Ferret Ferret Ferret')
+
+      results = SearchDocument.hybrid_search('Ferret', admin_mode: true)
+
+      expect(results.first.searchable).to eq(strong)
+    end
+  end
+
   context 'exact mode case sensitivity' do
     # A partial token ("ASE" inside "Charlotte Case") can only match through
     # exact mode's substring search, never through the tsvector matching.


### PR DESCRIPTION
## Relevant issue(s)

#9304. Follows on from #9489. Part of #8813.

## What does this do?

Makes the new admin search fast again, and orders results by how well they match rather than by nothing at all.

Listings with sort buttons offer "Relevance" as one of the choices while the new engine is searching. The ones without buttons come back best first.

## Why was this needed?

#9489 swapped `DISTINCT` for matching on the IDs, which gave PostgreSQL a semi-join. With the page `LIMIT` on top it answered that by scanning the whole table and running the search again for every row it looked at. The bodies listing took about 30 seconds for "cardiff" on production.

The same change removed an ordering we didn't know we had. `DISTINCT` over every column sorts by every column, starting with `id`, so results came back oldest first and looked ranked. Nothing replaced it, so the score the search works out was thrown away and rows came back in whatever order the plan produced. Paging wasn't stable either, as a record could turn up on two pages or on none.

<hr>

[skip changelog]