### PR TITLE
Speed up search query

### DIFF
--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -75,6 +75,8 @@ class SearchDocument < ApplicationRecord
       search_queries << <<~SQL.chomp
           SELECT
               sd_id,
+              searchable_type,
+              searchable_id,
               rank() OVER (
                 ORDER BY ts_rank_cd(admin_content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
               ) AS rank
@@ -101,6 +103,8 @@ class SearchDocument < ApplicationRecord
       search_queries << <<~SQL.chomp
         SELECT
           sd_id,
+          searchable_type,
+          searchable_id,
           rank() OVER (ORDER BY sd_id DESC) AS rank
         FROM search_documents
         WHERE
@@ -115,6 +119,8 @@ class SearchDocument < ApplicationRecord
     search_queries << <<~SQL.chomp
         SELECT
             sd_id,
+            searchable_type,
+            searchable_id,
             rank() OVER (
               ORDER BY ts_rank_cd(content_tsv, websearch_to_tsquery(:language, unaccent(:query))) DESC
             ) AS rank
@@ -127,13 +133,18 @@ class SearchDocument < ApplicationRecord
         LIMIT #{limit * limit_ratio}
       SQL
 
+    # we use the min(sd_id) here to allow grouping by searchable_(type+id)
+    # while still returning a sd_id that allows joining with SearchDocument
+    # when searching for multiple models.
     sql = <<~SQL.chomp.squeeze(' ')
       SELECT
-        searches.sd_id,
+        searches.searchable_type,
+        searches.searchable_id,
+        min(searches.sd_id) as sd_id,
         sum(searches.rank) AS rank_sum,
         sum(rrf_score(searches.rank)) AS score
       FROM ((#{search_queries.join(") UNION ALL (")})) searches
-      GROUP BY searches.sd_id
+      GROUP BY searches.searchable_type, searches.searchable_id
       ORDER BY score DESC
       LIMIT #{limit}
     SQL
@@ -200,27 +211,35 @@ class SearchDocument < ApplicationRecord
       case_sensitive: case_sensitive,
       limit_ratio: limit_ratio
     )
+    # prevent postgresql from trying to optimise the CTE by inlining in the
+    # main query. `materialized` makes sure that the actual search query is
+    # only executed once.
+    # This uses the rails patch in config/initializers/materialized_cte.rb
+    search_results_cte = 
+      Arel::Nodes::Cte.new(
+        :search_results,
+        Arel.sql("(#{sql[:query]})", **sql[:values]),
+        materialized: true
+      )
 
     if model.nil?
-      SearchDocument.where("sd_id IN (SELECT s.sd_id FROM (#{sql[:query]}) s)",
-sql[:values])
-    else
-      # De-duplicate records that match through several translations or
-      # sections (the join yields one row per matching search_document).
-      # Matching on the ids keeps the relation chainable, countable and
-      # paginatable, and leaves PostgreSQL free to fetch just the rows
-      # that matched.
-      matching_ids = SearchDocument.
-        select(:searchable_id).
-        where(searchable_type: model.to_s).
+      SearchDocument.
+        with(search_results_cte).
         joins(
           "JOIN search_results " \
-          "ON search_results.sd_id = search_documents.sd_id"
-        )
-
+          "ON search_documents.sd_id = search_results.sd_id"
+        ).
+        order(Arel.sql("search_results.score DESC"))
+    else
       relation.
-        with(search_results: Arel.sql(sql[:query], **sql[:values])).
-        where(id: matching_ids)
+        with(search_results_cte).
+        joins(
+          "JOIN search_results " \
+          "ON search_results.searchable_type = '#{relation.name}' " \
+          "AND search_results.searchable_id = " \
+          "#{relation.quoted_table_name}.#{relation.quoted_primary_key}"
+        ).
+        order(Arel.sql("search_results.score DESC"))
     end
   end
 end

--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -152,6 +152,8 @@ class SearchDocument < ApplicationRecord
     { query: sql, values: query_values }
   end
 
+  private_class_method :hybrid_search_internal
+
   # Run the hybrid full-text search and return a chainable relation.
   #
   # +relation+ an optional base ActiveRecord::Relation to search within;

--- a/config/initializers/materialized_cte.rb
+++ b/config/initializers/materialized_cte.rb
@@ -1,0 +1,50 @@
+# Taken from https://github.com/rails/rails/pull/54322
+# to allow ActiveRecord::QueryMethods.with to accept a CTE as well
+# as a Hash. This allows creating materialized CTEs, which makes
+# search a lot faster by putting an "optimisation fence" up, so
+# postgres does not try to inline the search query.
+ActiveRecord::QueryMethods.module_eval do
+
+    private
+      def build_with(arel)
+        return if with_values.empty?
+
+        with_statements = with_values.map do |with_value|
+          case with_value
+          when Arel::Nodes::Cte then with_value
+          when Hash then build_with_value_from_hash(with_value)
+          else
+            raise ArgumentError,
+              "Unsupported argument type: #{with_value} #{with_value.class}"
+          end
+        end
+
+        @with_is_recursive ?
+          arel.with(:recursive, with_statements) :
+          arel.with(with_statements)
+      end
+
+      def build_with_value_from_hash(hash)
+        hash.map do |name, value|
+          Arel::Nodes::TableAlias.new(
+            build_with_expression_from_value(value),
+            name
+          )
+          Arel::Nodes::Cte.new(
+            name,
+            build_with_expression_from_value(value)
+          )
+        end
+      end
+
+      def process_with_args(args)
+        args.flat_map do |arg|
+          case arg
+          when Hash then arg.map { |k, v| { k => v } }
+          when Arel::Nodes::Cte then arg
+          else raise ArgumentError,
+            "Unsupported argument type: #{arg} #{arg.class}"
+          end
+        end
+      end
+end


### PR DESCRIPTION
## Relevant issue(s)
https://github.com/mysociety/alaveteli/issues/9304#issuecomment-5506792378
(I now see that @gbp proposed a fix for the same issue yesterday :disappointed: So this does more or less the same work as #9515 but in a different way.)

I will try to compare both approaches in more detail to see what is faster

## What does this do?

The change relies mainly on patching 2 internal rails methods based on an open PR so that we can `MATERIALIZE` the search CTE. This in turn prevents postgres from trying to optimise the query, which led to the search subquery being run several thousand times for a single search,
causing the slow search speeds observed.

This also removes one of the 2 joins we were using (by fetching some extra columns in the subqueries), which helps save a bit more execution time.

Ordering of results is also fixed.

On some local testing:
- searching for `cardiff` in public bodies was taking over a minute, now 12-15ms
- even searching for "mairie" in my dataset (which should return > 35k results) completes in ~600ms

This also works with other models, and even across multiple models (which will be handy for searching through requests and their children elements).

## Why was this needed?

#9489 fixed one slowness problem by adding a different one. This PR hopefully fixes both :crossed_fingers: 

## Implementation notes

This takes some of the code in https://github.com/rails/rails/pull/54322 which means fiddling a bit with rails' internals. I've gone with it under the assumption that the code is good (as several people seem to have reviewed it or even deployed it to prod, and I think I understand what it does :wink:), and the PR would eventually be merged upstream so we could drop the change locally.

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
