### PR TITLE
Document sitemaps and crawler behaviour

### DIFF
--- a/docs/customising/config.md
+++ b/docs/customising/config.md
@@ -135,6 +135,7 @@ indentation correct. If in doubt, look at the examples already in the file, and 
 <br> <code><a href="#enable_annotations">ENABLE_ANNOTATIONS</a></code>
 <br> <code><a href="#enable_public_annotations">ENABLE_PUBLIC_ANNOTATIONS</a></code>
 <br> <code><a href="#enable_user_to_user_messaging">ENABLE_USER_TO_USER_MESSAGING</a></code>
+<br> <code><a href="#enable_sitemap">ENABLE_SITEMAP</a></code>
 <br> <code><a href="#survey_url">SURVEY_URL</a></code>
 <br> <code><a href="#user_sign_in_activity_retention_days">USER_SIGN_IN_ACTIVITY_RETENTION_DAYS</a></code>
 
@@ -1848,6 +1849,40 @@ SHARED_DIRECTORIES:
       <ul class="examples">
         <li>
             <code>ENABLE_USER_TO_USER_MESSAGING: true</code>
+        </li>
+      </ul>
+    </div>
+  </dd>
+
+  <dt>
+    <a name="enable_sitemap"><code>ENABLE_SITEMAP</code></a>
+  </dt>
+  <dd>
+    Publishes an <a href="https://www.sitemaps.org/">XML sitemap</a> at
+    <code>/sitemap.xml</code>, listing every request and authority that search
+    engines should index. Without one, search engines can only reach the
+    requests linked from the first page of a listing, because Alaveteli marks
+    later pages <code>noindex</code>.
+
+    <p>
+      The sitemap lists only requests Alaveteli already considers searchable, so
+      requests which are hidden, requester-only, embargoed, or set to the
+      <a href="{{ page.baseurl }}/docs/running/hiding_information/">backpage
+      prominence</a> are left out of it.
+    </p>
+
+    <p>
+      The files are built by a cron job rather than when they are requested, so
+      you also need the <code>sitemap:generate</code> entry from
+      <code>config/crontab-example</code>. See
+      <a href="{{ page.baseurl }}/docs/running/server/#search-engines-and-crawling">search
+      engines and crawling</a>.
+    </p>
+    <div class="more-info">
+      <p>Example:</p>
+      <ul class="examples">
+        <li>
+            <code>ENABLE_SITEMAP: true</code>
         </li>
       </ul>
     </div>

--- a/docs/running/server.md
+++ b/docs/running/server.md
@@ -49,6 +49,68 @@ If your hosting company supports [IPv6](https://en.wikipedia.org/wiki/IPv6)
 make sure that you've enabled this and configured [an AAAA record](https://en.wikipedia.org/wiki/List_of_DNS_record_types#AAAA)
 in your domain's DNS zone for capable clients.
 
+## Search engines and crawling
+
+Most of what an Alaveteli site holds is only worth publishing if people can
+find it, and for most sites that means search engines.
+
+### What Alaveteli keeps out of search results
+
+Alaveteli ships a `robots.txt` which keeps crawlers away from pages that are
+expensive to generate or not worth indexing, such as search results, feeds and
+the forms for making a request. It is rendered from
+`app/views/robots/show.text.erb`, so you can
+[override it in your theme]({{ page.baseurl }}/docs/customising/themes/) like
+any other template rather than editing Alaveteli's copy.
+
+Two other rules apply automatically:
+
+* every page of a listing after the first is served with an
+  `X-Robots-Tag: noindex, nofollow` header, because later pages are expensive
+  and their contents appear elsewhere
+* requests set to the `backpage`
+  [prominence]({{ page.baseurl }}/docs/running/hiding_information/) are served
+  with the same header, which is what that prominence is for
+
+### Publishing a sitemap
+
+Because listings are capped and only their first page is indexable, a crawler
+which just follows links will reach very few of your requests. A
+[sitemap](https://www.sitemaps.org/) is what makes the rest of the archive
+discoverable, so it is enabled by default. Set
+<code><a href="{{ page.baseurl }}/docs/customising/config/#enable_sitemap">ENABLE_SITEMAP</a></code>
+to `false` if you would rather your site was not indexed.
+
+The sitemap covers the requests Alaveteli already treats as searchable, every
+visible authority, and the site's main static pages. Requests which are hidden,
+requester-only, embargoed or on the backpage are not listed.
+
+It is built ahead of time rather than when it is requested, by a nightly cron
+job:
+
+    bin/rails sitemap:generate
+
+Install the `sitemap:generate` entry from `config/crontab-example` along with
+the rest of your cron jobs. Until it has run for the first time, `/sitemap.xml`
+will return a 404.
+
+The generated files are written to the `cache/` directory, which should be one
+of your `SHARED_DIRECTORIES` so that they survive a deploy. A large site
+produces a sitemap index plus one gzipped file per 50,000 URLs.
+
+### Telling search engines about it
+
+`robots.txt` advertises the sitemap automatically, which is all most crawlers
+need. You can also submit it directly through
+[Google Search Console](https://search.google.com/search-console) or
+[Bing Webmaster Tools](https://www.bing.com/webmasters), which additionally
+report any problems found in it.
+
+There is no need to notify search engines when the sitemap changes. The old
+"ping" endpoints for doing so have been withdrawn by both
+[Google](https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping)
+and Bing, which is why Alaveteli does not call them.
+
 ## Security
 
 You _must_ change all key-related [config settings]({{ page.baseurl }}/docs/customising/config/)


### PR DESCRIPTION
## Relevant issue(s)

Documents behaviour introduced by mysociety/alaveteli#9519, and the template move in mysociety/alaveteli#9518.

## What does this do?

Documents sitemaps and crawler behaviour on alaveteli.org:

- `docs/customising/config.md`: adds `ENABLE_SITEMAP` to the behaviour settings topic index and the settings reference.
- `docs/running/server.md`: adds a "Search engines and crawling" section covering what `robots.txt` keeps out of search results, the two `noindex` rules Alaveteli applies automatically, publishing a sitemap and the cron job which builds it, and how to submit it to a search console.

## Why was this needed?

mysociety/alaveteli#9519 adds an XML sitemap and the `ENABLE_SITEMAP` setting, neither of which is documented.

Beyond the new setting, `docs/running/server.md` has never said anything about `robots.txt`, crawling or indexing, and there is no page anywhere that documents `robots.txt` or how a deployment should customise it. That gap matters more now that mysociety/alaveteli#9518 makes the file a template a theme can override, and it is the natural place to explain why deep listing pages are `noindex` and what a sitemap is for.

The two `noindex` behaviours are documented here for the first time. `backpage` prominence is described in `docs/running/hiding_information.md` and `docs/running/requests.md`, but the sitewide rule that every listing page after the first is `noindex` was not written down anywhere, and it is the reason a sitemap is needed rather than optional.

## Implementation notes

English docs only; nothing under `es/` was touched.

No new pages, so the sidebar in `_layouts/page.html` is unchanged. Cross-links use `{{ page.baseurl }}` and point at the existing themes, hiding information and configuration pages.

Deliberately out of scope: `docs/customising/config.md` documents 75 settings while `lib/configuration.rb` has 119, so 55 are missing, including `SEARCH_BACKEND`, `ENABLE_PROJECTS` and all the `BLOCK_SPAM_*` settings. Worth closing, but it would swamp this diff.

## Screenshots

## Notes to reviewer

Do not merge until mysociety/alaveteli#9519 lands — this documents behaviour introduced there, and the `ENABLE_SITEMAP` entry would otherwise describe a setting that does not exist.

The sitemap section states that Google's and Bing's sitemap ping endpoints have been withdrawn, which is why Alaveteli does not call them. That is sourced from [Google's own announcement](https://developers.google.com/search/blog/2023/06/sitemaps-lastmod-ping) rather than second-hand.

---

Prepared with AI assistance (Claude Code, claude-opus-5).

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
