### PR TITLE
Improve the search query to save one join

### DIFF
--- a/app/models/search_document.rb
+++ b/app/models/search_document.rb
@@ -133,15 +133,22 @@ class SearchDocument < ApplicationRecord
         LIMIT #{limit * limit_ratio}
       SQL
 
+    # when the subqueries return multiple search_documents for a single
+    # searchable, we sum their scores under the assumption that if the
+    # record matched multiple times, it is probably more relevant.
+    # Keeping min(sd_id) allows us to group on the searchable to prevent
+    # duplicates, while keeping a valid sd_id if we need to join on it
+    # in a later query, without having to go through the search_documents
+    # table one more time.
     sql = <<~SQL.squish
       SELECT
-        searches.sd_id,
         searches.searchable_type,
         searches.searchable_id,
+        min(searches.sd_id) as sd_id,
         sum(searches.rank) AS rank_sum,
         sum(rrf_score(searches.rank)) AS score
       FROM ((#{search_queries.join(") UNION ALL (")})) searches
-      GROUP BY searches.sd_id, searches.searchable_type, searches.searchable_id
+      GROUP BY searches.searchable_type, searches.searchable_id
       ORDER BY score DESC
       LIMIT #{limit}
     SQL
@@ -228,23 +235,14 @@ class SearchDocument < ApplicationRecord
       record_id = "#{relation.quoted_table_name}." \
                   "#{relation.quoted_primary_key}"
 
-      # A record can match through several translations or sections, so
-      # roll the documents up to one row per record, scored by the best
-      # of them. The relation stays chainable, countable and paginatable.
-      search_records = materialized_cte(:search_records, <<~SQL.squish)
-        SELECT searchable_type, searchable_id, max(score) AS score
-        FROM search_results
-        GROUP BY searchable_type, searchable_id
-      SQL
-
       relation.
-        with(search_results: search_results, search_records: search_records).
+        with(search_results: search_results).
         joins(
-          "JOIN search_records " \
-          "ON search_records.searchable_type = '#{model}' " \
-          "AND search_records.searchable_id = #{record_id}"
+          "JOIN search_results " \
+          "ON search_results.searchable_type = '#{model}' " \
+          "AND search_results.searchable_id = #{record_id}"
         ).
-        order(Arel.sql("search_records.score DESC, #{record_id}"))
+        order(Arel.sql("search_results.score DESC"))
     end
   end
 


### PR DESCRIPTION
## Relevant issue(s)

Adds a commit to #9515 

## What does this do?

This removes the need for an intermediate join using `search_documents` to get back `sd_id` which we already had from the previous query.

It also seems to save one sort in postgres, as the database seems smart enough to reuse the ordered materialized `search_results` and just fetch the extra columns it needs from the required model.

In terms of ranking, this version uses the sum of all scores instead of keeping the max for a given object. So if an attachment were to match on multiple pages (when we implement a `SearchDocument` for each page), we would assign it the sum of the score for each page, rather than just the highest score of any of its pages. When joining on `FoiAttachment` for example, we would end up with a single result for one attachment, pointing at the first page that matched, but a score representing the entire attachment. (this is a bit theoretical as we don't implement this yet, so difficult to test!)

Visual explain before/after show the 2 bits of work (highlighted in red) that are not needed anymore. The other parts of the query are almost exactly the same, except we return two extra columns in the CTE scan (sd_id and rank_sum).

### before
https://explain.dalibo.com/plan/a991b2adah93ef15
<img width="1236" height="1509" alt="image" src="https://github.com/user-attachments/assets/bdab872f-d25f-44eb-9d62-e5e6bda60c39" />

### after
https://explain.dalibo.com/plan/5b98ab117296cb00
<img width="962" height="1023" alt="image" src="https://github.com/user-attachments/assets/7aa1cdf9-08ca-4fe9-b428-e448ca1936ca" />


## Why was this needed?

## Implementation notes

This is a PR on top of the linked PR to make it easier to review separately.

## Screenshots

## Notes to reviewer

<hr>

Have you updated the changelog? If this is not necessary, put square brackets around this: [skip changelog]
