### PR TITLE
Disentangle Xapian from Track Things alerts

### DIFF
--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -171,7 +171,7 @@ class TrackController < ApplicationController
 
   def atom_feed_internal
     search_results = perform_track_search(@track_thing)
-    @events = search_results.results.map { |result| result[:model] }
+    @events = search_results.events
     # We're assuming that a request to a feed url with no format suffix wants atom/xml
     # so set that as the default, regardless of content negotiation
     request.format = params[:format] || 'xml'
@@ -180,9 +180,7 @@ class TrackController < ApplicationController
         highlight = ->(t) do
           view_context.highlight_and_excerpt(
             t,
-            search_results.words_to_highlight(
-              regex: true, include_original: true
-            ),
+            search_results.highlight_words,
             150
           )
         end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -129,7 +129,7 @@ class UserController < ApplicationController
       @track_things.each do |track_thing|
         results = track_thing.matches(sort_by: 'described_at',
                                       limit: 20)
-        feed_results += results.results.map { |x| x[:model] }
+        feed_results += results.events
       end
     end
 
@@ -317,8 +317,7 @@ class UserController < ApplicationController
     else
       @user.
         track_things.
-        flat_map { |thing| perform_track_search(thing).results }.
-        map { |result| result[:model] }.
+        flat_map { |thing| perform_track_search(thing).events }.
         sort { |a, b| b.created_at <=> a.created_at }.
         first(20)
     end

--- a/app/mailers/track_mailer.rb
+++ b/app/mailers/track_mailer.rb
@@ -77,9 +77,7 @@ class TrackMailer < ApplicationMailer
                                              limit: 100)
         # Go through looking for unalerted things
         alert_events = []
-        search_results.results.each do |result|
-          event = result[:model]
-
+        search_results.events.each do |event|
           # made before the track was created
           next if track_thing.created_at >= event.described_at
 
@@ -94,7 +92,7 @@ class TrackMailer < ApplicationMailer
         end
         # If there were more alerts for this track, then store them
         unless alert_events.empty?
-          highlight_words = search_results.words_to_highlight(regex: true)
+          highlight_words = search_results.highlight_words
           email_about_things.push([track_thing, alert_events, highlight_words])
         end
       end

--- a/app/models/search/track_events.rb
+++ b/app/models/search/track_events.rb
@@ -2,8 +2,19 @@ module Search
   ##
   # The events a track matches, and the words to highlight in them.
   #
+  # One subclass per track_type, so each can move off the search index on its
+  # own. TrackEvents.for picks the right one.
+  #
   class TrackEvents
-    include EventSearch
+    def self.for(track_thing, **options)
+      strategy_for(track_thing.track_type).new(track_thing, **options)
+    end
+
+    def self.strategy_for(track_type)
+      const_get(track_type.camelize)
+    rescue NameError
+      raise ArgumentError, "no strategy for track type #{track_type.inspect}"
+    end
 
     def initialize(track_thing, sort_by:, limit:, offset: 0)
       @track_thing = track_thing
@@ -13,20 +24,15 @@ module Search
     end
 
     def events
-      @events ||= search.results.map { |result| result[:model] }
+      raise NotImplementedError
     end
 
     def highlight_words
-      search.words_to_highlight
+      []
     end
 
     private
 
-    def search
-      @search ||= search_events(@track_thing.track_query,
-                                sort_by: @sort_by,
-                                limit: @limit,
-                                offset: @offset)
-    end
+    attr_reader :track_thing, :sort_by, :limit, :offset
   end
 end

--- a/app/models/search/track_events.rb
+++ b/app/models/search/track_events.rb
@@ -6,8 +6,12 @@ module Search
   # own. TrackEvents.for picks the right one.
   #
   class TrackEvents
+    extend AlaveteliFeatures::Helpers
+
     def self.for(track_thing, **options)
-      strategy_for(track_thing.track_type).new(track_thing, **options)
+      klass = strategy_for(track_thing.track_type)
+      klass = Index unless live?(klass)
+      klass.new(track_thing, **options)
     end
 
     def self.strategy_for(track_type)
@@ -15,6 +19,15 @@ module Search
     rescue NameError
       raise ArgumentError, "no strategy for track type #{track_type.inspect}"
     end
+
+    # A strategy that has left the search index only goes live behind the
+    # flag. Types still on the index subclass Index, which ignores the flag,
+    # so it does nothing until a type has somewhere else to go.
+    def self.live?(klass)
+      klass <= Index ||
+        feature_enabled?(:database_backed_alerts)
+    end
+    private_class_method :live?
 
     def initialize(track_thing, sort_by:, limit:, offset: 0)
       @track_thing = track_thing

--- a/app/models/search/track_events.rb
+++ b/app/models/search/track_events.rb
@@ -1,0 +1,32 @@
+module Search
+  ##
+  # The events a track matches, and the words to highlight in them.
+  #
+  class TrackEvents
+    include EventSearch
+
+    def initialize(track_thing, sort_by:, limit:, offset: 0)
+      @track_thing = track_thing
+      @sort_by = sort_by
+      @limit = limit
+      @offset = offset
+    end
+
+    def events
+      @events ||= search.results.map { |result| result[:model] }
+    end
+
+    def highlight_words
+      search.words_to_highlight
+    end
+
+    private
+
+    def search
+      @search ||= search_events(@track_thing.track_query,
+                                sort_by: @sort_by,
+                                limit: @limit,
+                                offset: @offset)
+    end
+  end
+end

--- a/app/models/search/track_events/all_new_requests.rb
+++ b/app/models/search/track_events/all_new_requests.rb
@@ -1,0 +1,6 @@
+module Search
+  class TrackEvents
+    class AllNewRequests < Index
+    end
+  end
+end

--- a/app/models/search/track_events/all_new_requests.rb
+++ b/app/models/search/track_events/all_new_requests.rb
@@ -1,6 +1,15 @@
 module Search
   class TrackEvents
-    class AllNewRequests < Index
+    ##
+    # Resolves TrackThing query:
+    #   variety:sent
+    #
+    class AllNewRequests < Database
+      private
+
+      def events_scope
+        InfoRequestEvent.sent_events
+      end
     end
   end
 end

--- a/app/models/search/track_events/all_successful_requests.rb
+++ b/app/models/search/track_events/all_successful_requests.rb
@@ -1,0 +1,6 @@
+module Search
+  class TrackEvents
+    class AllSuccessfulRequests < Index
+    end
+  end
+end

--- a/app/models/search/track_events/all_successful_requests.rb
+++ b/app/models/search/track_events/all_successful_requests.rb
@@ -1,6 +1,18 @@
 module Search
   class TrackEvents
-    class AllSuccessfulRequests < Index
+    ##
+    # Resolves TrackThing query:
+    #   variety:response (status:successful OR status:partially_successful)
+    #
+    class AllSuccessfulRequests < Database
+      SUCCESSFUL_STATES = %w[successful partially_successful].freeze
+
+      private
+
+      def events_scope
+        InfoRequestEvent.response_events.
+          where(calculated_state: SUCCESSFUL_STATES)
+      end
     end
   end
 end

--- a/app/models/search/track_events/database.rb
+++ b/app/models/search/track_events/database.rb
@@ -1,0 +1,43 @@
+module Search
+  class TrackEvents
+    ##
+    # Events straight from the database, for tracks whose query is a
+    # structural filter rather than a search.
+    #
+    # Subclasses say which events the track is about; visibility, order and
+    # the pagination are handled here.
+    #
+    class Database < TrackEvents
+      def events
+        @events ||= events_scope.
+          is_searchable.
+          includes(
+            :outgoing_message,
+            :comment,
+            { info_request: [:user, :public_body, :censor_rules] }
+          ).
+          order(order).
+          limit(limit).
+          offset(offset)
+      end
+
+      private
+
+      def events_scope
+        raise NotImplementedError
+      end
+
+      # Always newest first. Xapian's sort_ascending is its reverse flag, and
+      # every alert passes true, so ascending order has never been asked for.
+      # Xapian breaks ties by docid; id is the closest we have.
+      def order
+        column = :created_at unless sort_by == 'described_at'
+        column ||= Arel.sql(
+          'COALESCE(info_request_events.last_described_at, ' \
+          'info_request_events.created_at)'
+        )
+        { column => :desc, :id => :desc }
+      end
+    end
+  end
+end

--- a/app/models/search/track_events/index.rb
+++ b/app/models/search/track_events/index.rb
@@ -1,0 +1,31 @@
+module Search
+  class TrackEvents
+    ##
+    # Runs the track's own query string through the search index, whichever
+    # backend SEARCH_BACKEND names.
+    #
+    # The fallback every track type starts on, and the only way to answer a
+    # saved search that carries free text.
+    #
+    class Index < TrackEvents
+      include EventSearch
+
+      def events
+        @events ||= search.results.map { |result| result[:model] }
+      end
+
+      def highlight_words
+        search.words_to_highlight
+      end
+
+      private
+
+      def search
+        @search ||= search_events(track_thing.track_query,
+                                  sort_by: sort_by,
+                                  limit: limit,
+                                  offset: offset)
+      end
+    end
+  end
+end

--- a/app/models/search/track_events/public_body_updates.rb
+++ b/app/models/search/track_events/public_body_updates.rb
@@ -1,6 +1,24 @@
 module Search
   class TrackEvents
-    class PublicBodyUpdates < Index
+    ##
+    # Resolves TrackThink query:
+    #   requested_from: Every request made to one authority.
+    #   variety: Events of a given type
+    #
+    class PublicBodyUpdates < Database
+      private
+
+      def events_scope
+        scope = InfoRequestEvent.
+          where(info_requests: { public_body_id: track_thing.public_body_id })
+
+        event_type = variety_from_track_query
+        event_type ? scope.where(event_type: event_type) : scope
+      end
+
+      def variety_from_track_query
+        track_thing.track_query[/\bvariety:(\w+)/, 1]
+      end
     end
   end
 end

--- a/app/models/search/track_events/public_body_updates.rb
+++ b/app/models/search/track_events/public_body_updates.rb
@@ -1,0 +1,6 @@
+module Search
+  class TrackEvents
+    class PublicBodyUpdates < Index
+    end
+  end
+end

--- a/app/models/search/track_events/request_updates.rb
+++ b/app/models/search/track_events/request_updates.rb
@@ -1,6 +1,15 @@
 module Search
   class TrackEvents
-    class RequestUpdates < Index
+    ##
+    # Resolved TrackThing query:
+    #   request:info_request.url_title
+    #
+    class RequestUpdates < Database
+      private
+
+      def events_scope
+        InfoRequestEvent.where(info_request: track_thing.info_request)
+      end
     end
   end
 end

--- a/app/models/search/track_events/request_updates.rb
+++ b/app/models/search/track_events/request_updates.rb
@@ -1,0 +1,6 @@
+module Search
+  class TrackEvents
+    class RequestUpdates < Index
+    end
+  end
+end

--- a/app/models/search/track_events/search_query.rb
+++ b/app/models/search/track_events/search_query.rb
@@ -1,0 +1,6 @@
+module Search
+  class TrackEvents
+    class SearchQuery < Index
+    end
+  end
+end

--- a/app/models/search/track_events/user_updates.rb
+++ b/app/models/search/track_events/user_updates.rb
@@ -1,6 +1,19 @@
 module Search
   class TrackEvents
-    class UserUpdates < Index
+    ##
+    # Resolves TrackThing query:
+    #   requested_by:user.url_name OR commented_by: user.url_name
+    #
+    # Note: the space after the `commented_by:` so form of the query never
+    # worked. We don't fix that here yet.
+    #
+    class UserUpdates < Database
+      private
+
+      def events_scope
+        InfoRequestEvent.
+          where(info_requests: { user_id: track_thing.tracked_user_id })
+      end
     end
   end
 end

--- a/app/models/search/track_events/user_updates.rb
+++ b/app/models/search/track_events/user_updates.rb
@@ -1,0 +1,6 @@
+module Search
+  class TrackEvents
+    class UserUpdates < Index
+    end
+  end
+end

--- a/app/models/track_thing.rb
+++ b/app/models/track_thing.rb
@@ -128,7 +128,7 @@ class TrackThing < ApplicationRecord
   # Newest first, from the sort_ascending default in search_events, which
   # the backend reads as a reverse flag rather than as an ascending one.
   def matches(sort_by:, limit:, offset: 0)
-    Search::TrackEvents.new(self, sort_by: sort_by, limit: limit,
+    Search::TrackEvents.for(self, sort_by: sort_by, limit: limit,
                                   offset: offset)
   end
 

--- a/app/models/track_thing.rb
+++ b/app/models/track_thing.rb
@@ -25,8 +25,6 @@ require 'set'
 # TODO: TrackThing looks like a good candidate for single table inheritance
 
 class TrackThing < ApplicationRecord
-  include Search::EventSearch
-
   TRACK_MEDIUMS = %w(email_daily feed)
 
   belongs_to :info_request,
@@ -130,8 +128,8 @@ class TrackThing < ApplicationRecord
   # Newest first, from the sort_ascending default in search_events, which
   # the backend reads as a reverse flag rather than as an ascending one.
   def matches(sort_by:, limit:, offset: 0)
-    search_events(track_query,
-                  sort_by: sort_by, limit: limit, offset: offset)
+    Search::TrackEvents.new(self, sort_by: sort_by, limit: limit,
+                                  offset: offset)
   end
 
   def track_query_description

--- a/config/initializers/alaveteli_features.rb
+++ b/config/initializers/alaveteli_features.rb
@@ -49,6 +49,10 @@ Rails.configuration.after_initialize do
     :pro_batch_category_add_all,
     label: 'Batch category "add all" button'
   )
+  AlaveteliFeatures.features.add(
+    :database_backed_alerts,
+    label: 'Generate alerts from the database instead of the search index'
+  )
 
   next unless ActiveRecord::Base.connection.data_source_exists?(:roles)
 

--- a/lib/tasks/translation.rake
+++ b/lib/tasks/translation.rake
@@ -142,8 +142,8 @@ namespace :translation do
 
     # track mailer
     search_results = track_thing.matches(sort_by: 'described_at', limit: 100)
-    highlight_words = search_results.words_to_highlight(regex: true)
-    alert_events = search_results.results.map { |result| result[:model] }
+    highlight_words = search_results.highlight_words
+    alert_events = search_results.events
     event_digest_email = TrackMailer.event_digest(
       info_request.user, [[track_thing, alert_events, highlight_words]]
     )

--- a/spec/factories/track_things.rb
+++ b/spec/factories/track_things.rb
@@ -33,9 +33,15 @@ FactoryBot.define do
     factory :public_body_track do
       association :public_body, factory: :public_body
       track_type { 'public_body_updates' }
-      after(:create) do |track_thing, _evaluator|
+      transient do
+        variety { nil }
+      end
+      after(:create) do |track_thing, evaluator|
         track_thing.track_query = "requested_from:" \
                                   "#{ track_thing.public_body.url_name }"
+        if evaluator.variety
+          track_thing.track_query += " variety:#{ evaluator.variety }"
+        end
         track_thing.save!
       end
     end

--- a/spec/factories/track_things.rb
+++ b/spec/factories/track_things.rb
@@ -25,8 +25,9 @@ FactoryBot.define do
       association :tracked_user, factory: :user
       track_type { 'user_updates' }
       after(:create) do |track_thing, _evaluator|
-        track_thing.track_query = "requested_by:#{ user.url_name }" \
-                                  " OR commented_by: #{ user.url_name }"
+        url_name = track_thing.tracked_user.url_name
+        track_thing.track_query = "requested_by:#{ url_name }" \
+                                  " OR commented_by: #{ url_name }"
         track_thing.save!
       end
     end

--- a/spec/integration/track_alerts_spec.rb
+++ b/spec/integration/track_alerts_spec.rb
@@ -56,6 +56,34 @@ RSpec.describe "When sending track alerts" do
     expect(deliveries.size).to eq(0)
   end
 
+  # No search stub: the whole point is that nothing consults the index.
+  it "sends alerts from the database", feature: :database_backed_alerts do
+    info_request = FactoryBot.create(:info_request)
+    user = FactoryBot.create(:user, last_daily_track_email: 3.days.ago)
+    user_session = login(user)
+    using_session(user_session) do
+      visit "request/#{info_request.url_title}/track"
+    end
+
+    other_user = FactoryBot.create(:user)
+    other_user_session = login(other_user)
+    using_session(other_user_session) do
+      visit "annotate/request/#{info_request.url_title}"
+      fill_in "comment[body]", with: 'database comment'
+      click_button 'Preview your annotation'
+      click_button 'Post annotation'
+    end
+
+    expect(Search).not_to receive(:search)
+
+    TrackMailer.alert_tracks
+
+    mail = ActionMailer::Base.deliveries.last
+    expect(mail.to_addrs.first.to_s).to include(user.email)
+    expect(mail.body).to include('added an annotation')
+    expect(mail.body).to match(/database comment/)
+  end
+
   it "should send localised alerts" do
     info_request = FactoryBot.create(:info_request)
     user = FactoryBot.create(:user, last_daily_track_email: 3.days.ago)

--- a/spec/mailers/track_mailer_spec.rb
+++ b/spec/mailers/track_mailer_spec.rb
@@ -73,10 +73,10 @@ RSpec.describe TrackMailer do
         before do
           @track_things_sent_emails_array = []
           allow(@track_things_sent_emails_array).to receive(:where).and_return([]) # this is for the date range find (created in last 14 days)
-          @search_results = double('search results', results: [],
-                                                     words_to_highlight: [])
+          @matches = double('matching events', events: [],
+                                               highlight_words: [])
           @track_thing = mock_model(TrackThing,
-                                    matches: @search_results,
+                                    matches: @matches,
                                     track_things_sent_emails: @track_things_sent_emails_array,
                                     created_at: Time.utc(2007, 11, 9, 23, 59))
           allow(TrackThing).to receive(:where).and_return([@track_thing])
@@ -85,13 +85,12 @@ RSpec.describe TrackMailer do
                                                 :info_request_event_id= => true)
           allow(TrackThingsSentEmail).to receive(:new).and_return(@track_things_sent_email)
           @found_event = mock_model(InfoRequestEvent, described_at: @track_thing.created_at + 1.day)
-          @search_result = { model: @found_event }
         end
 
         it 'should ask the track for the events it matches' do
           expect(@track_thing).to receive(:matches).
             with(sort_by: 'described_at', limit: 100).
-            and_return(@search_results)
+            and_return(@matches)
           TrackMailer.alert_tracks
         end
 
@@ -100,8 +99,7 @@ RSpec.describe TrackMailer do
           # this is for the date range find (created in last 14 days)
           allow(@track_things_sent_emails_array).
             to receive(:where).and_return([sent_email])
-          allow(@search_results).to receive(:results).
-            and_return([@search_result])
+          allow(@matches).to receive(:events).and_return([@found_event])
           expect(TrackMailer).not_to receive(:event_digest)
           TrackMailer.alert_tracks
         end
@@ -109,8 +107,7 @@ RSpec.describe TrackMailer do
         it 'should not include events described before the track was set up' do
           allow(@found_event).to receive(:described_at).
             and_return(@track_thing.created_at - 1.day)
-          allow(@search_results).to receive(:results).
-            and_return([@search_result])
+          allow(@matches).to receive(:events).and_return([@found_event])
           expect(TrackMailer).not_to receive(:event_digest)
           TrackMailer.alert_tracks
         end
@@ -118,8 +115,7 @@ RSpec.describe TrackMailer do
         it 'should include new events described since the track was set up' do
           allow(@found_event).to receive(:described_at).
             and_return(@track_thing.created_at + 1.day)
-          allow(@search_results).to receive(:results).
-            and_return([@search_result])
+          allow(@matches).to receive(:events).and_return([@found_event])
           expect(TrackMailer).to receive(:event_digest)
           TrackMailer.alert_tracks
         end
@@ -127,9 +123,8 @@ RSpec.describe TrackMailer do
         it 'passes the words to highlight to the digest' do
           allow(@found_event).to receive(:described_at).
             and_return(@track_thing.created_at + 1.day)
-          allow(@search_results).to receive(:results).
-            and_return([@search_result])
-          allow(@search_results).to receive(:words_to_highlight).
+          allow(@matches).to receive(:events).and_return([@found_event])
+          allow(@matches).to receive(:highlight_words).
             and_return(%w[fancy dog])
 
           expect(TrackMailer).to receive(:event_digest).
@@ -139,8 +134,7 @@ RSpec.describe TrackMailer do
         end
 
         it 'should record sent tracking email for each included event' do
-          allow(@search_results).to receive(:results).
-            and_return([@search_result])
+          allow(@matches).to receive(:events).and_return([@found_event])
           sent_email = mock_model(TrackThingsSentEmail)
           expect(TrackThingsSentEmail).to receive(:new).and_return(sent_email)
           expect(sent_email).to receive(:track_thing_id=).with(@track_thing.id)

--- a/spec/models/search/track_events/all_new_requests_spec.rb
+++ b/spec/models/search/track_events/all_new_requests_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+RSpec.describe Search::TrackEvents::AllNewRequests do
+  let(:track_thing) { FactoryBot.create(:new_request_track) }
+
+  subject(:events) do
+    described_class.new(track_thing, sort_by: 'created_at', limit: 100).events
+  end
+
+  it { is_expected.to include(FactoryBot.create(:sent_event)) }
+  it { is_expected.not_to include(FactoryBot.create(:response_event)) }
+  it { is_expected.not_to include(FactoryBot.create(:followup_sent_event)) }
+end

--- a/spec/models/search/track_events/all_successful_requests_spec.rb
+++ b/spec/models/search/track_events/all_successful_requests_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Search::TrackEvents::AllSuccessfulRequests do
+  let(:track_thing) { FactoryBot.create(:successful_request_track) }
+
+  subject(:events) do
+    described_class.new(track_thing, sort_by: 'described_at', limit: 100).events
+  end
+
+  def response(calculated_state)
+    FactoryBot.create(:response_event, calculated_state: calculated_state)
+  end
+
+  it { is_expected.to include(response('successful')) }
+  it { is_expected.to include(response('partially_successful')) }
+  it { is_expected.not_to include(response('rejected')) }
+
+  it 'ignores a successful state on another event type' do
+    event = FactoryBot.create(:sent_event, calculated_state: 'successful')
+    is_expected.not_to include(event)
+  end
+end

--- a/spec/models/search/track_events/public_body_updates_spec.rb
+++ b/spec/models/search/track_events/public_body_updates_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe Search::TrackEvents::PublicBodyUpdates do
+  let(:public_body) { FactoryBot.create(:public_body) }
+  let(:track_thing) do
+    FactoryBot.create(:public_body_track, public_body: public_body)
+  end
+
+  def track_events(track = track_thing)
+    described_class.new(track, sort_by: 'described_at', limit: 100)
+  end
+
+  def event_on(body, factory = :sent_event, **options)
+    FactoryBot.create(
+      factory,
+      info_request: FactoryBot.create(:info_request, public_body: body,
+                                                     **options)
+    )
+  end
+
+  it 'finds events on requests to the authority' do
+    event = event_on(public_body)
+    expect(track_events.events).to include(event)
+  end
+
+  it 'ignores requests to another authority' do
+    event = event_on(FactoryBot.create(:public_body))
+    expect(track_events.events).not_to include(event)
+  end
+
+  it 'ignores events on a hidden request' do
+    event = event_on(public_body, prominence: 'hidden')
+    expect(track_events.events).not_to include(event)
+  end
+
+  it 'orders newest described first' do
+    older = event_on(public_body)
+    newer = event_on(public_body)
+    older.update!(last_described_at: 2.days.ago)
+    newer.update!(last_described_at: 1.hour.ago)
+
+    ids = track_events.events.map(&:id)
+    expect(ids.index(newer.id)).to be < ids.index(older.id)
+  end
+
+  it 'applies the cap' do
+    2.times { event_on(public_body) }
+    capped = described_class.new(track_thing, sort_by: 'described_at', limit: 1)
+
+    expect(capped.events.count).to eq(1)
+  end
+
+  it 'has no words to highlight' do
+    expect(track_events.highlight_words).to eq([])
+  end
+
+  it 'loads the associations the digest walks' do
+    event_on(public_body)
+    expect(track_events.events.first.association(:info_request)).to be_loaded
+  end
+
+  context 'when the track names an event type' do
+    let(:track_thing) do
+      FactoryBot.create(
+        :public_body_track, public_body: public_body, variety: 'comment'
+      )
+    end
+
+    it 'finds only that type' do
+      comment = FactoryBot.create(
+        :comment_event,
+        info_request: FactoryBot.create(:info_request, public_body: public_body)
+      )
+      sent = event_on(public_body)
+
+      expect(track_events.events).to include(comment)
+      expect(track_events.events).not_to include(sent)
+    end
+  end
+end

--- a/spec/models/search/track_events/request_updates_spec.rb
+++ b/spec/models/search/track_events/request_updates_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Search::TrackEvents::RequestUpdates do
+  let(:info_request) { FactoryBot.create(:info_request) }
+  let(:track_thing) do
+    FactoryBot.create(:request_update_track, info_request: info_request)
+  end
+
+  subject(:events) do
+    described_class.new(track_thing, sort_by: 'created_at', limit: 100).events
+  end
+
+  it 'finds events on the tracked request' do
+    is_expected.to include(
+      FactoryBot.create(:response_event, info_request: info_request)
+    )
+  end
+
+  it 'ignores events on any other request' do
+    is_expected.not_to include(FactoryBot.create(:response_event))
+  end
+end

--- a/spec/models/search/track_events/user_updates_spec.rb
+++ b/spec/models/search/track_events/user_updates_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+RSpec.describe Search::TrackEvents::UserUpdates do
+  let(:tracked_user) { FactoryBot.create(:user) }
+  let(:track_thing) do
+    FactoryBot.create(:user_track, tracked_user: tracked_user)
+  end
+  let(:their_request) do
+    FactoryBot.create(:info_request, user: tracked_user)
+  end
+
+  subject(:events) do
+    described_class.new(track_thing, sort_by: 'created_at', limit: 100).events
+  end
+
+  it 'finds requests the user sent' do
+    is_expected.to include(
+      FactoryBot.create(:sent_event, info_request: their_request)
+    )
+  end
+
+  it 'finds responses to the user' do
+    is_expected.to include(
+      FactoryBot.create(:response_event, info_request: their_request)
+    )
+  end
+
+  # requested_by: is indexed from the request owner, so it catches comments
+  # left on their requests by anyone.
+  it 'finds other people annotating their requests' do
+    comment = FactoryBot.create(
+      :comment_event,
+      info_request: their_request,
+      comment: FactoryBot.create(:visible_comment, info_request: their_request)
+    )
+    is_expected.to include(comment)
+  end
+
+  # The other half of the query, commented_by:, has a stray space that stops
+  # it matching anything. Following it here would add alerts, not port them.
+  it 'ignores them annotating somebody else request' do
+    comment = FactoryBot.create(
+      :comment_event, comment: FactoryBot.create(:visible_comment,
+                                                 user: tracked_user)
+    )
+    is_expected.not_to include(comment)
+  end
+
+  it 'ignores requests by anybody else' do
+    is_expected.not_to include(FactoryBot.create(:sent_event))
+  end
+end

--- a/spec/models/search/track_events_spec.rb
+++ b/spec/models/search/track_events_spec.rb
@@ -12,6 +12,29 @@ RSpec.describe Search::TrackEvents do
       end
     end
 
+    context 'when a type has a database finder' do
+      before do
+        stub_const('Search::TrackEvents::SearchQuery', database_finder)
+      end
+
+      let(:database_finder) { Class.new(Search::TrackEvents) }
+      let(:track_thing) { FactoryBot.build(:search_track) }
+
+      subject do
+        described_class.for(track_thing, sort_by: 'created_at', limit: 25)
+      end
+
+      it 'uses the search index while the feature is off' do
+        is_expected.to be_a(Search::TrackEvents::Index)
+      end
+
+      it 'uses the database once the feature is on' do
+        with_feature_enabled(:database_backed_alerts) do
+          is_expected.to be_a(database_finder)
+        end
+      end
+    end
+
     it 'raises for a track type with no strategy' do
       track_thing = FactoryBot.build(:track_thing)
       allow(track_thing).to receive(:track_type).and_return('nonsense')

--- a/spec/models/search/track_events_spec.rb
+++ b/spec/models/search/track_events_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+RSpec.describe Search::TrackEvents do
+  describe '.for' do
+    TrackThing::TranslatedConstants.track_types.each_key do |track_type|
+      it "returns the #{track_type} strategy" do
+        track_thing = FactoryBot.build(:track_thing, track_type: track_type)
+
+        expect(described_class.for(track_thing, sort_by: 'created_at',
+                                                limit: 25)).
+          to be_a(described_class.strategy_for(track_type))
+      end
+    end
+
+    it 'raises for a track type with no strategy' do
+      track_thing = FactoryBot.build(:track_thing)
+      allow(track_thing).to receive(:track_type).and_return('nonsense')
+
+      expect {
+        described_class.for(track_thing, sort_by: 'created_at', limit: 25)
+      }.to raise_error(ArgumentError, /nonsense/)
+    end
+  end
+
+  describe '#events' do
+    it 'is not implemented on the base class' do
+      track_events = described_class.new(FactoryBot.build(:track_thing),
+                                         sort_by: 'created_at', limit: 25)
+
+      expect { track_events.events }.to raise_error(NotImplementedError)
+    end
+  end
+end

--- a/spec/models/search/track_events_spec.rb
+++ b/spec/models/search/track_events_spec.rb
@@ -1,36 +1,18 @@
 require 'spec_helper'
 
 RSpec.describe Search::TrackEvents do
+  def track_events_for(track_thing)
+    described_class.for(track_thing, sort_by: 'created_at', limit: 25)
+  end
+
   describe '.for' do
     TrackThing::TranslatedConstants.track_types.each_key do |track_type|
       it "returns the #{track_type} strategy" do
         track_thing = FactoryBot.build(:track_thing, track_type: track_type)
 
-        expect(described_class.for(track_thing, sort_by: 'created_at',
-                                                limit: 25)).
-          to be_a(described_class.strategy_for(track_type))
-      end
-    end
-
-    context 'when a type has a database finder' do
-      before do
-        stub_const('Search::TrackEvents::SearchQuery', database_finder)
-      end
-
-      let(:database_finder) { Class.new(Search::TrackEvents) }
-      let(:track_thing) { FactoryBot.build(:search_track) }
-
-      subject do
-        described_class.for(track_thing, sort_by: 'created_at', limit: 25)
-      end
-
-      it 'uses the search index while the feature is off' do
-        is_expected.to be_a(Search::TrackEvents::Index)
-      end
-
-      it 'uses the database once the feature is on' do
         with_feature_enabled(:database_backed_alerts) do
-          is_expected.to be_a(database_finder)
+          expect(track_events_for(track_thing)).
+            to be_a(described_class.strategy_for(track_type))
         end
       end
     end
@@ -39,9 +21,35 @@ RSpec.describe Search::TrackEvents do
       track_thing = FactoryBot.build(:track_thing)
       allow(track_thing).to receive(:track_type).and_return('nonsense')
 
-      expect {
-        described_class.for(track_thing, sort_by: 'created_at', limit: 25)
-      }.to raise_error(ArgumentError, /nonsense/)
+      expect { track_events_for(track_thing) }.
+        to raise_error(ArgumentError, /nonsense/)
+    end
+
+    context 'for a type that has left the search index' do
+      let(:track_thing) { FactoryBot.build(:public_body_track) }
+
+      it 'falls back to the index while the feature is off' do
+        expect(track_events_for(track_thing)).
+          to be_a(Search::TrackEvents::Index)
+      end
+
+      it 'uses the database once the feature is on' do
+        with_feature_enabled(:database_backed_alerts) do
+          expect(track_events_for(track_thing)).
+            to be_a(Search::TrackEvents::PublicBodyUpdates)
+        end
+      end
+    end
+
+    context 'for a type still on the search index' do
+      let(:track_thing) { FactoryBot.build(:search_track) }
+
+      it 'uses the index whatever the feature says' do
+        with_feature_enabled(:database_backed_alerts) do
+          expect(track_events_for(track_thing)).
+            to be_a(Search::TrackEvents::Index)
+        end
+      end
     end
   end
 

--- a/spec/models/track_thing_spec.rb
+++ b/spec/models/track_thing_spec.rb
@@ -172,10 +172,9 @@ RSpec.describe TrackThing, "#matches" do
            hash_including(models: [InfoRequestEvent],
                           sort_by: 'described_at',
                           sort_ascending: true)).
-      and_return(double(results: :search_results))
+      and_return(double(results: build_search_results(items: [])))
 
-    expect(track_thing.matches(sort_by: 'described_at', limit: 100)).
-      to eq(:search_results)
+    track_thing.matches(sort_by: 'described_at', limit: 100).events
   end
 end
 


### PR DESCRIPTION
## Relevant issue(s)

Most of #8810

## What does this do?

Adds a strategy per track type, so five of the six can find their events in the database instead of Xapian.

Alerts, feeds, the wall and the river all go through `TrackThing#matches`, which returns events and the words to highlight.

## Why was this needed?

Alerts blocks the Postgres search work. They have to keep working whichever backend is in place, so they need to stop depending on one.

Saved searches are the exception. They carry free text, so they still need a search index and keep using it.

## Implementation notes

The new `database_backed_alerts` flag picks the database strategies. It is a runtime flag, off by default, so it can be turned on and off from a console while the alert daemon is running.

<hr>

[skip changelog]